### PR TITLE
enhancement: Create Vue analytics dashboard components

### DIFF
--- a/resources/js/vue/AnalyticsDashboard.vue
+++ b/resources/js/vue/AnalyticsDashboard.vue
@@ -1,0 +1,143 @@
+<!--
+  AnalyticsDashboard Vue component.
+
+  Main dashboard layout composing all analytics widgets with date range
+  selection and tab navigation using @artisanpack-ui/vue Card, Tabs,
+  Select, and Grid. Designed for use with Inertia.js page props.
+  Mirrors the Livewire AnalyticsDashboard component.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Card, Tabs, Select, Grid } from '@artisanpack-ui/vue';
+
+import type { TabItem } from '@artisanpack-ui/vue';
+import type { TopPageItem, TrafficSourceItem, StatsComparison } from '../types';
+
+import StatsCards from './widgets/StatsCards.vue';
+import TopPages from './widgets/TopPages.vue';
+import TrafficSources from './widgets/TrafficSources.vue';
+import VisitorsChart from './widgets/VisitorsChart.vue';
+
+import type { ChartDataPoint } from './widgets/VisitorsChart.vue';
+
+interface Stats {
+    pageviews: number;
+    visitors: number;
+    sessions: number;
+    bounce_rate: number;
+    avg_session_duration: number;
+    pages_per_session?: number;
+    realtime_visitors?: number;
+    comparison?: StatsComparison | null;
+}
+
+const props = withDefaults( defineProps<{
+    /** Statistics data for the StatsCards widget. */
+    stats: Stats;
+    /** Time-series chart data points. */
+    chartData: ChartDataPoint[];
+    /** Top pages data. */
+    topPages: TopPageItem[];
+    /** Traffic sources data. */
+    trafficSources: TrafficSourceItem[];
+    /** Active date range preset value. */
+    dateRangePreset?: string;
+    /** Available date range presets. */
+    dateRangePresets?: Record<string, string>;
+}>(), {
+    dateRangePreset: '30d',
+    dateRangePresets: () => ( {
+        today: 'Today',
+        yesterday: 'Yesterday',
+        '7d': 'Last 7 days',
+        '30d': 'Last 30 days',
+        '90d': 'Last 90 days',
+        this_week: 'This week',
+        last_week: 'Last week',
+        this_month: 'This month',
+        last_month: 'Last month',
+        this_year: 'This year',
+    } ),
+} );
+
+const emit = defineEmits<{
+    dateRangeChange: [preset: string];
+}>();
+
+const activeTab = ref( 'overview' );
+
+const presetOptions = computed( () => {
+    return Object.entries( props.dateRangePresets ).map( ( [ id, name ] ) => ( {
+        id,
+        name,
+    } ) );
+} );
+
+function handlePresetChange( event: Event ): void {
+    emit( 'dateRangeChange', ( event.target as HTMLSelectElement ).value );
+}
+
+const tabs: TabItem[] = [
+    { name: 'overview', label: 'Overview' },
+    { name: 'pages', label: 'Pages' },
+    { name: 'traffic', label: 'Traffic' },
+    { name: 'audience', label: 'Audience' },
+];
+</script>
+
+<template>
+    <div class="space-y-6">
+        <!-- Header with date range selector -->
+        <Card>
+            <div class="flex items-center justify-between">
+                <h2 class="text-2xl font-bold">Analytics Dashboard</h2>
+                <div class="w-48">
+                    <Select
+                        :options="presetOptions"
+                        :model-value="props.dateRangePreset"
+                        @change="handlePresetChange"
+                    />
+                </div>
+            </div>
+        </Card>
+
+        <!-- Tabbed content -->
+        <Tabs
+            :tabs="tabs"
+            v-model:active-tab="activeTab"
+            variant="bordered"
+        >
+            <template #overview>
+                <div class="space-y-6 pt-4">
+                    <StatsCards :stats="props.stats" />
+                    <VisitorsChart :chart-data="props.chartData" />
+                    <Grid :cols="1" :cols-lg="2" :gap="6">
+                        <TopPages :top-pages="props.topPages" :limit="5" />
+                        <TrafficSources :traffic-sources="props.trafficSources" :limit="5" />
+                    </Grid>
+                </div>
+            </template>
+
+            <template #pages>
+                <div class="space-y-6 pt-4">
+                    <VisitorsChart :chart-data="props.chartData" />
+                    <TopPages :top-pages="props.topPages" />
+                </div>
+            </template>
+
+            <template #traffic>
+                <div class="space-y-6 pt-4">
+                    <TrafficSources :traffic-sources="props.trafficSources" />
+                </div>
+            </template>
+
+            <template #audience>
+                <div class="space-y-6 pt-4">
+                    <StatsCards :stats="props.stats" />
+                </div>
+            </template>
+        </Tabs>
+    </div>
+</template>

--- a/resources/js/vue/MultiTenantDashboard.vue
+++ b/resources/js/vue/MultiTenantDashboard.vue
@@ -1,0 +1,94 @@
+<!--
+  MultiTenantDashboard Vue component.
+
+  Wraps the AnalyticsDashboard with site selection functionality for
+  multi-tenant environments using @artisanpack-ui/vue Card.
+  Mirrors the Livewire MultiTenantDashboard component.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { Card } from '@artisanpack-ui/vue';
+
+import type { Site, TopPageItem, TrafficSourceItem, StatsComparison } from '../types';
+import type { ChartDataPoint } from './widgets/VisitorsChart.vue';
+
+import AnalyticsDashboard from './AnalyticsDashboard.vue';
+import SiteSelector from './SiteSelector.vue';
+
+interface Stats {
+    pageviews: number;
+    visitors: number;
+    sessions: number;
+    bounce_rate: number;
+    avg_session_duration: number;
+    pages_per_session?: number;
+    realtime_visitors?: number;
+    comparison?: StatsComparison | null;
+}
+
+const props = withDefaults( defineProps<{
+    /** Array of available sites for selection. */
+    sites: Site[];
+    /** The initially selected site ID. */
+    initialSiteId?: number | null;
+    /** Whether multi-tenant mode is enabled. */
+    multiTenantEnabled?: boolean;
+    /** Statistics data for the StatsCards widget. */
+    stats: Stats;
+    /** Time-series chart data points. */
+    chartData: ChartDataPoint[];
+    /** Top pages data. */
+    topPages: TopPageItem[];
+    /** Traffic sources data. */
+    trafficSources: TrafficSourceItem[];
+    /** Active date range preset value. */
+    dateRangePreset?: string;
+    /** Available date range presets. */
+    dateRangePresets?: Record<string, string>;
+}>(), {
+    initialSiteId: null,
+    multiTenantEnabled: true,
+    dateRangePreset: '30d',
+    dateRangePresets: undefined,
+} );
+
+const emit = defineEmits<{
+    siteChange: [siteId: number];
+    dateRangeChange: [preset: string];
+}>();
+
+const selectedSiteId = ref<number | null>( props.initialSiteId );
+
+watch( () => props.initialSiteId, ( newVal ) => {
+    selectedSiteId.value = newVal;
+} );
+
+function handleSiteChange( siteId: number ): void {
+    selectedSiteId.value = siteId;
+    emit( 'siteChange', siteId );
+}
+</script>
+
+<template>
+    <div class="space-y-6">
+        <Card v-if="multiTenantEnabled && sites.length > 1">
+            <SiteSelector
+                :sites="props.sites"
+                :selected-site-id="selectedSiteId"
+                @site-change="handleSiteChange"
+            />
+        </Card>
+
+        <AnalyticsDashboard
+            :stats="props.stats"
+            :chart-data="props.chartData"
+            :top-pages="props.topPages"
+            :traffic-sources="props.trafficSources"
+            :date-range-preset="props.dateRangePreset"
+            :date-range-presets="props.dateRangePresets"
+            @date-range-change="( preset ) => emit( 'dateRangeChange', preset )"
+        />
+    </div>
+</template>

--- a/resources/js/vue/PageAnalytics.vue
+++ b/resources/js/vue/PageAnalytics.vue
@@ -1,0 +1,98 @@
+<!--
+  PageAnalytics Vue component.
+
+  Displays analytics for a specific page including pageviews, visitors,
+  bounce rate, and a sparkline chart using @artisanpack-ui/vue
+  Card, Stat, Badge, and Sparkline. Mirrors the Livewire PageAnalytics
+  component.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Card, Stat, Badge, Sparkline } from '@artisanpack-ui/vue';
+
+import type { PageAnalyticsData, PageViewOverTimeItem } from '../types';
+
+const props = withDefaults( defineProps<{
+    /** The page path being analyzed. */
+    path: string;
+    /** Analytics data for the page. */
+    analytics: PageAnalyticsData;
+    /** Time-series data for the sparkline chart. */
+    viewsOverTime?: PageViewOverTimeItem[];
+    /** Whether to show the inline chart. Defaults to true. */
+    showChart?: boolean;
+    /** Whether to use compact layout. Defaults to false. */
+    compact?: boolean;
+}>(), {
+    viewsOverTime: () => [],
+    showChart: true,
+    compact: false,
+} );
+
+const chartData = computed( () =>
+    props.viewsOverTime.length > 0
+        ? props.viewsOverTime
+        : props.analytics.over_time ?? [],
+);
+
+const sparklineData = computed( () =>
+    chartData.value.map( ( d ) => d.pageviews ),
+);
+
+const bounceRateDisplay = computed( () =>
+    props.analytics.bounce_rate != null
+        ? `${props.analytics.bounce_rate.toFixed( 1 )}%`
+        : '\u2014',
+);
+</script>
+
+<template>
+    <Card v-if="compact" compact>
+        <div class="flex items-center justify-between gap-4">
+            <div class="flex items-center gap-3">
+                <Badge :value="props.path" ghost size="sm" />
+                <span class="text-sm">
+                    {{ new Intl.NumberFormat().format( props.analytics.pageviews ) }} views
+                </span>
+                <span class="text-sm text-base-content/50">
+                    {{ new Intl.NumberFormat().format( props.analytics.visitors ) }} visitors
+                </span>
+            </div>
+            <Sparkline
+                v-if="showChart && sparklineData.length >= 2"
+                :data="sparklineData"
+                type="area"
+                :height="30"
+                :width="120"
+                color="primary"
+            />
+        </div>
+    </Card>
+
+    <Card v-else :title="props.path">
+        <div class="stats stats-vertical lg:stats-horizontal shadow w-full">
+            <Stat
+                title="Pageviews"
+                :value="new Intl.NumberFormat().format( props.analytics.pageviews )"
+            />
+            <Stat
+                title="Visitors"
+                :value="new Intl.NumberFormat().format( props.analytics.visitors )"
+            />
+            <Stat
+                title="Bounce Rate"
+                :value="bounceRateDisplay"
+            />
+        </div>
+        <div v-if="showChart && sparklineData.length >= 2" class="mt-4">
+            <Sparkline
+                :data="sparklineData"
+                type="area"
+                :height="60"
+                color="primary"
+            />
+        </div>
+    </Card>
+</template>

--- a/resources/js/vue/SiteSelector.vue
+++ b/resources/js/vue/SiteSelector.vue
@@ -21,7 +21,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-    siteChange: [siteId: number];
+    siteChange: [siteId: number | null];
 }>();
 
 const options = computed( () => {
@@ -42,6 +42,8 @@ function handleChange( event: Event ): void {
 
     if ( value ) {
         emit( 'siteChange', parseInt( value, 10 ) );
+    } else {
+        emit( 'siteChange', null );
     }
 }
 </script>

--- a/resources/js/vue/SiteSelector.vue
+++ b/resources/js/vue/SiteSelector.vue
@@ -1,0 +1,57 @@
+<!--
+  SiteSelector Vue component.
+
+  Provides a dropdown for selecting between multiple sites in
+  multi-tenant environments using @artisanpack-ui/vue Select.
+  Mirrors the Livewire SiteSelector widget.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Select } from '@artisanpack-ui/vue';
+
+import type { Site } from '../types';
+
+const props = defineProps<{
+    /** Array of available sites. */
+    sites: Site[];
+    /** The currently selected site ID. */
+    selectedSiteId?: number | null;
+}>();
+
+const emit = defineEmits<{
+    siteChange: [siteId: number];
+}>();
+
+const options = computed( () => {
+    return props.sites.map( ( site ) => ( {
+        id: String( site.id ),
+        name: `${site.name} (${site.domain})`,
+    } ) );
+} );
+
+const selectedValue = computed( () =>
+    props.selectedSiteId !== null && props.selectedSiteId !== undefined
+        ? String( props.selectedSiteId )
+        : '',
+);
+
+function handleChange( event: Event ): void {
+    const value = ( event.target as HTMLSelectElement ).value;
+
+    if ( value ) {
+        emit( 'siteChange', parseInt( value, 10 ) );
+    }
+}
+</script>
+
+<template>
+    <Select
+        label="Site"
+        placeholder="Select a site"
+        :options="options"
+        :model-value="selectedValue"
+        @change="handleChange"
+    />
+</template>

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -1,0 +1,26 @@
+/**
+ * ArtisanPack Analytics — Vue dashboard components.
+ *
+ * Barrel file re-exporting all Vue dashboard components so consumers
+ * can import from a single entry point:
+ *
+ *   import { AnalyticsDashboard, StatsCards } from '@artisanpack-ui/analytics/vue';
+ *
+ * @since 1.1.0
+ */
+
+// Widgets
+export { default as StatsCards } from './widgets/StatsCards.vue';
+export { default as VisitorsChart } from './widgets/VisitorsChart.vue';
+export { default as TopPages } from './widgets/TopPages.vue';
+export { default as TrafficSources } from './widgets/TrafficSources.vue';
+export { default as RealtimeVisitors } from './widgets/RealtimeVisitors.vue';
+
+// Dashboard components
+export { default as AnalyticsDashboard } from './AnalyticsDashboard.vue';
+export { default as PageAnalytics } from './PageAnalytics.vue';
+export { default as SiteSelector } from './SiteSelector.vue';
+export { default as MultiTenantDashboard } from './MultiTenantDashboard.vue';
+
+// Composables
+export { useAnalyticsApi } from './useAnalyticsApi';

--- a/resources/js/vue/useAnalyticsApi.ts
+++ b/resources/js/vue/useAnalyticsApi.ts
@@ -1,0 +1,112 @@
+/**
+ * Vue composable for fetching data from the analytics API endpoints.
+ *
+ * Provides a generic fetch wrapper that handles loading states, error
+ * handling, request cancellation, and optional polling for realtime data.
+ *
+ * @since 1.1.0
+ */
+
+import { onUnmounted, ref, watch, type Ref } from 'vue';
+
+import type { AnalyticsQueryParams, RealtimeQueryParams } from '../types';
+
+interface UseAnalyticsApiOptions {
+    /** The API endpoint path relative to the analytics route prefix. */
+    endpoint: string;
+    /** Query parameters to include in the request. */
+    params?: AnalyticsQueryParams | RealtimeQueryParams;
+    /** Polling interval in milliseconds. Set to 0 to disable. */
+    pollInterval?: number;
+    /** Whether to fetch on mount. Defaults to true. */
+    fetchOnMount?: boolean;
+}
+
+/**
+ * Build a query string from an object of parameters.
+ */
+function buildQueryString( params: Record<string, unknown> ): string {
+    const parts: string[] = [];
+
+    for ( const [ key, value ] of Object.entries( params ) ) {
+        if ( value !== undefined && value !== null && value !== '' ) {
+            parts.push( `${encodeURIComponent( key )}=${encodeURIComponent( String( value ) )}` );
+        }
+    }
+
+    return parts.length > 0 ? `?${parts.join( '&' )}` : '';
+}
+
+/**
+ * Composable for fetching analytics API data with optional polling.
+ */
+export function useAnalyticsApi<T>( options: UseAnalyticsApiOptions ) {
+    const {
+        endpoint,
+        params = {},
+        pollInterval = 0,
+        fetchOnMount = true,
+    } = options;
+
+    const data = ref<T | undefined>() as Ref<T | undefined>;
+    const loading = ref( fetchOnMount );
+    const error = ref<string | null>( null );
+
+    let abortController: AbortController | null = null;
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    async function fetchData(): Promise<void> {
+        const controller = new AbortController();
+        abortController = controller;
+
+        loading.value = true;
+        error.value = null;
+
+        try {
+            const queryString = buildQueryString( params as Record<string, unknown> );
+            const response = await fetch( `/api/analytics/${endpoint}${queryString}`, {
+                headers: {
+                    Accept: 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                credentials: 'same-origin',
+                signal: controller.signal,
+            } );
+
+            if ( ! response.ok ) {
+                throw new Error( `HTTP ${response.status}: ${response.statusText}` );
+            }
+
+            const json = await response.json();
+            data.value = json.data ?? json;
+        } catch ( err ) {
+            if ( err instanceof DOMException && err.name === 'AbortError' ) {
+                return;
+            }
+
+            error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
+        } finally {
+            if ( ! controller.signal.aborted ) {
+                loading.value = false;
+            }
+        }
+    }
+
+    if ( fetchOnMount ) {
+        fetchData();
+    }
+
+    if ( pollInterval > 0 ) {
+        intervalId = setInterval( fetchData, pollInterval );
+    }
+
+    onUnmounted( () => {
+        abortController?.abort();
+
+        if ( intervalId ) {
+            clearInterval( intervalId );
+        }
+    } );
+
+    return { data, loading, error, refresh: fetchData };
+}

--- a/resources/js/vue/useAnalyticsApi.ts
+++ b/resources/js/vue/useAnalyticsApi.ts
@@ -54,11 +54,20 @@ export function useAnalyticsApi<T>( options: UseAnalyticsApiOptions ) {
 
     let abortController: AbortController | null = null;
     let intervalId: ReturnType<typeof setInterval> | null = null;
+    let inFlight = false;
 
-    async function fetchData(): Promise<void> {
-        abortController?.abort();
+    async function fetchData( force = false ): Promise<void> {
+        if ( inFlight && ! force ) {
+            return;
+        }
+
+        if ( force ) {
+            abortController?.abort();
+        }
+
         const controller = new AbortController();
         abortController = controller;
+        inFlight = true;
 
         loading.value = true;
         error.value = null;
@@ -87,10 +96,16 @@ export function useAnalyticsApi<T>( options: UseAnalyticsApiOptions ) {
 
             error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
         } finally {
+            inFlight = false;
+
             if ( ! controller.signal.aborted ) {
                 loading.value = false;
             }
         }
+    }
+
+    function refresh(): Promise<void> {
+        return fetchData( true );
     }
 
     if ( fetchOnMount ) {
@@ -109,5 +124,5 @@ export function useAnalyticsApi<T>( options: UseAnalyticsApiOptions ) {
         }
     } );
 
-    return { data, loading, error, refresh: fetchData };
+    return { data, loading, error, refresh };
 }

--- a/resources/js/vue/useAnalyticsApi.ts
+++ b/resources/js/vue/useAnalyticsApi.ts
@@ -56,6 +56,7 @@ export function useAnalyticsApi<T>( options: UseAnalyticsApiOptions ) {
     let intervalId: ReturnType<typeof setInterval> | null = null;
 
     async function fetchData(): Promise<void> {
+        abortController?.abort();
         const controller = new AbortController();
         abortController = controller;
 

--- a/resources/js/vue/useAnalyticsApi.ts
+++ b/resources/js/vue/useAnalyticsApi.ts
@@ -96,7 +96,9 @@ export function useAnalyticsApi<T>( options: UseAnalyticsApiOptions ) {
 
             error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
         } finally {
-            inFlight = false;
+            if ( abortController === controller ) {
+                inFlight = false;
+            }
 
             if ( ! controller.signal.aborted ) {
                 loading.value = false;

--- a/resources/js/vue/widgets/RealtimeVisitors.vue
+++ b/resources/js/vue/widgets/RealtimeVisitors.vue
@@ -1,0 +1,177 @@
+<!--
+  RealtimeVisitors Vue component.
+
+  Displays the current number of active visitors with optional polling
+  for live updates using @artisanpack-ui/vue Stat, Card, Badge, and
+  Loading. Mirrors the Livewire RealtimeVisitors widget.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed, onUnmounted, ref, watchEffect } from 'vue';
+import { Card, Stat, Badge, Loading } from '@artisanpack-ui/vue';
+
+import type { RealtimeData } from '../../types';
+
+const props = withDefaults( defineProps<{
+    /** Initial realtime data (e.g. from Inertia page props). */
+    initialData?: RealtimeData;
+    /** Polling interval in milliseconds. Defaults to 10000 (10s). Set to 0 to disable. */
+    pollInterval?: number;
+    /** Number of minutes of activity to consider. Defaults to 5. */
+    minutes?: number;
+}>(), {
+    initialData: undefined,
+    pollInterval: 10000,
+    minutes: 5,
+} );
+
+/**
+ * Normalize a raw API payload into a safe RealtimeData shape.
+ */
+function normalizeRealtimeData( payload: unknown ): RealtimeData {
+    if ( payload && typeof payload === 'object' ) {
+        const obj = payload as Record<string, unknown>;
+
+        return {
+            active_visitors: typeof obj.active_visitors === 'number' ? obj.active_visitors : 0,
+            recent_pageviews: Array.isArray( obj.recent_pageviews )
+                ? obj.recent_pageviews.map( ( pv: Record<string, unknown> ) => ( {
+                    path: typeof pv?.path === 'string' ? pv.path : '',
+                    timestamp: typeof pv?.timestamp === 'string' ? pv.timestamp : '',
+                } ) )
+                : [],
+        };
+    }
+
+    return { active_visitors: 0, recent_pageviews: [] };
+}
+
+const data = ref<RealtimeData | null>( props.initialData ?? null );
+const previousCount = ref<number | null>( props.initialData?.active_visitors ?? null );
+const loading = ref( ! props.initialData );
+const error = ref<string | null>( null );
+
+async function fetchRealtime(): Promise<void> {
+    try {
+        const response = await fetch(
+            `/api/analytics/realtime?minutes=${props.minutes}`,
+            {
+                headers: {
+                    Accept: 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                },
+                credentials: 'same-origin',
+            },
+        );
+
+        if ( ! response.ok ) {
+            throw new Error( `HTTP ${response.status}` );
+        }
+
+        const json = await response.json();
+        const realtimeData = normalizeRealtimeData( json.data ?? json );
+
+        if ( data.value ) {
+            previousCount.value = data.value.active_visitors;
+        }
+
+        data.value = realtimeData;
+        error.value = null;
+    } catch ( err ) {
+        error.value = err instanceof Error ? err.message : 'Failed to fetch realtime data';
+    } finally {
+        loading.value = false;
+    }
+}
+
+if ( ! props.initialData ) {
+    fetchRealtime();
+}
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+if ( props.pollInterval > 0 ) {
+    intervalId = setInterval( fetchRealtime, props.pollInterval );
+}
+
+onUnmounted( () => {
+    if ( intervalId ) {
+        clearInterval( intervalId );
+    }
+} );
+
+const activeVisitors = computed( () => data.value?.active_visitors ?? 0 );
+const trend = computed( () =>
+    previousCount.value !== null ? activeVisitors.value - previousCount.value : 0,
+);
+const hasTrend = computed( () => previousCount.value !== null && trend.value !== 0 );
+const isActive = computed( () => activeVisitors.value > 0 );
+
+const changeDisplay = computed( () => {
+    if ( ! hasTrend.value ) {
+        return undefined;
+    }
+
+    const pct = ( trend.value / Math.max( previousCount.value!, 1 ) ) * 100;
+    const sign = pct >= 0 ? '+' : '';
+
+    return `${sign}${pct.toFixed( 1 )}%`;
+} );
+
+const changeDir = computed<'up' | 'down' | 'neutral'>( () => {
+    if ( ! hasTrend.value ) {
+        return 'neutral';
+    }
+
+    return trend.value > 0 ? 'up' : 'down';
+} );
+</script>
+
+<template>
+    <Card title="Realtime Visitors">
+        <template #menu>
+            <Badge
+                :color="isActive ? 'success' : 'neutral'"
+                :value="isActive ? 'Live' : 'Idle'"
+                size="sm"
+            />
+        </template>
+
+        <div v-if="loading" class="flex justify-center py-8">
+            <Loading size="lg" />
+        </div>
+        <p v-else-if="error" class="text-error text-center py-4">
+            {{ error }}
+        </p>
+        <div v-else class="space-y-4">
+            <Stat
+                title="Active Now"
+                :value="new Intl.NumberFormat().format( activeVisitors )"
+                :change="changeDisplay"
+                :change-direction="changeDir"
+                description="from last poll"
+            />
+
+            <div v-if="data?.recent_pageviews && data.recent_pageviews.length > 0">
+                <h4 class="text-sm font-semibold mb-2">Recent Activity</h4>
+                <div class="space-y-1">
+                    <div
+                        v-for="( pv, index ) in data.recent_pageviews.slice( 0, 5 )"
+                        :key="`${pv.path}-${pv.timestamp}-${index}`"
+                        class="flex items-center justify-between text-sm"
+                    >
+                        <span class="font-mono text-base-content/70 truncate">
+                            {{ pv.path }}
+                        </span>
+                        <Badge
+                            :value="new Date( pv.timestamp ).toLocaleTimeString()"
+                            size="xs"
+                            ghost
+                        />
+                    </div>
+                </div>
+            </div>
+        </div>
+    </Card>
+</template>

--- a/resources/js/vue/widgets/RealtimeVisitors.vue
+++ b/resources/js/vue/widgets/RealtimeVisitors.vue
@@ -51,8 +51,13 @@ const data = ref<RealtimeData | null>( props.initialData ?? null );
 const previousCount = ref<number | null>( props.initialData?.active_visitors ?? null );
 const loading = ref( ! props.initialData );
 const error = ref<string | null>( null );
+let abortController: AbortController | null = null;
 
 async function fetchRealtime(): Promise<void> {
+    abortController?.abort();
+    const controller = new AbortController();
+    abortController = controller;
+
     try {
         const response = await fetch(
             `/api/analytics/realtime?minutes=${props.minutes}`,
@@ -62,6 +67,7 @@ async function fetchRealtime(): Promise<void> {
                     'X-Requested-With': 'XMLHttpRequest',
                 },
                 credentials: 'same-origin',
+                signal: controller.signal,
             },
         );
 
@@ -79,9 +85,15 @@ async function fetchRealtime(): Promise<void> {
         data.value = realtimeData;
         error.value = null;
     } catch ( err ) {
+        if ( err instanceof DOMException && err.name === 'AbortError' ) {
+            return;
+        }
+
         error.value = err instanceof Error ? err.message : 'Failed to fetch realtime data';
     } finally {
-        loading.value = false;
+        if ( ! controller.signal.aborted ) {
+            loading.value = false;
+        }
     }
 }
 
@@ -96,6 +108,8 @@ if ( props.pollInterval > 0 ) {
 }
 
 onUnmounted( () => {
+    abortController?.abort();
+
     if ( intervalId ) {
         clearInterval( intervalId );
     }

--- a/resources/js/vue/widgets/StatsCards.vue
+++ b/resources/js/vue/widgets/StatsCards.vue
@@ -1,0 +1,102 @@
+<!--
+  StatsCards Vue component.
+
+  Displays key analytics metrics using @artisanpack-ui/vue Stat
+  components with comparison indicators. Mirrors the Livewire
+  StatsCards widget.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Stat } from '@artisanpack-ui/vue';
+
+import type { StatsComparison } from '../../types';
+
+interface Stats {
+    pageviews: number;
+    visitors: number;
+    sessions: number;
+    bounce_rate: number;
+    avg_session_duration: number;
+    pages_per_session?: number;
+    realtime_visitors?: number;
+    comparison?: StatsComparison | null;
+}
+
+const props = defineProps<{
+    /** Core statistics object from the API. */
+    stats: Stats;
+}>();
+
+function formatDuration( seconds: number ): string {
+    const totalSeconds = Math.round( seconds );
+
+    if ( totalSeconds < 60 ) {
+        return `${totalSeconds}s`;
+    }
+
+    const minutes = Math.floor( totalSeconds / 60 );
+    const remainingSeconds = totalSeconds % 60;
+
+    return `${minutes}m ${remainingSeconds}s`;
+}
+
+function formatChange( value?: { change: number } ): string | undefined {
+    if ( ! value ) {
+        return undefined;
+    }
+
+    const sign = value.change >= 0 ? '+' : '';
+
+    return `${sign}${value.change.toFixed( 1 )}%`;
+}
+
+function changeDirection( value?: { change: number } ): 'up' | 'down' | 'neutral' {
+    if ( ! value || value.change === 0 ) {
+        return 'neutral';
+    }
+
+    return value.change > 0 ? 'up' : 'down';
+}
+</script>
+
+<template>
+    <div class="stats stats-vertical lg:stats-horizontal shadow w-full">
+        <Stat
+            title="Pageviews"
+            :value="new Intl.NumberFormat().format( props.stats.pageviews )"
+            :change="formatChange( props.stats.comparison?.pageviews )"
+            :change-direction="changeDirection( props.stats.comparison?.pageviews )"
+            :description="props.stats.comparison ? 'vs previous period' : undefined"
+        />
+        <Stat
+            title="Visitors"
+            :value="new Intl.NumberFormat().format( props.stats.visitors )"
+            :change="formatChange( props.stats.comparison?.visitors )"
+            :change-direction="changeDirection( props.stats.comparison?.visitors )"
+            :description="props.stats.comparison ? 'vs previous period' : undefined"
+        />
+        <Stat
+            title="Sessions"
+            :value="new Intl.NumberFormat().format( props.stats.sessions )"
+            :change="formatChange( props.stats.comparison?.sessions )"
+            :change-direction="changeDirection( props.stats.comparison?.sessions )"
+            :description="props.stats.comparison ? 'vs previous period' : undefined"
+        />
+        <Stat
+            title="Bounce Rate"
+            :value="`${props.stats.bounce_rate.toFixed( 1 )}%`"
+            :change="formatChange( props.stats.comparison?.bounce_rate )"
+            :change-direction="changeDirection( props.stats.comparison?.bounce_rate )"
+            :description="props.stats.comparison ? 'vs previous period' : undefined"
+        />
+        <Stat
+            title="Avg. Session Duration"
+            :value="formatDuration( props.stats.avg_session_duration )"
+            :change="formatChange( props.stats.comparison?.avg_session_duration )"
+            :change-direction="changeDirection( props.stats.comparison?.avg_session_duration )"
+            :description="props.stats.comparison ? 'vs previous period' : undefined"
+        />
+    </div>
+</template>

--- a/resources/js/vue/widgets/TopPages.vue
+++ b/resources/js/vue/widgets/TopPages.vue
@@ -30,7 +30,8 @@ const columns: TableColumn[] = [
 ];
 
 const displayData = computed( () => {
-    const clampedLimit = Math.max( 0, Math.floor( props.limit ) );
+    const raw = Number( props.limit );
+    const clampedLimit = Number.isFinite( raw ) ? Math.max( 0, Math.floor( raw ) ) : 0;
 
     return props.topPages.slice( 0, clampedLimit );
 } );

--- a/resources/js/vue/widgets/TopPages.vue
+++ b/resources/js/vue/widgets/TopPages.vue
@@ -1,0 +1,48 @@
+<!--
+  TopPages Vue component.
+
+  Displays a sortable table of the most visited pages using
+  @artisanpack-ui/vue Table component. Mirrors the Livewire
+  TopPages widget.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Card, Table } from '@artisanpack-ui/vue';
+
+import type { TableColumn } from '@artisanpack-ui/vue';
+import type { TopPageItem } from '../../types';
+
+const props = withDefaults( defineProps<{
+    /** Array of top page data from the API. */
+    topPages: TopPageItem[];
+    /** Maximum number of pages to display. */
+    limit?: number;
+}>(), {
+    limit: 10,
+} );
+
+const columns: TableColumn[] = [
+    { key: 'path', label: 'Page', sortable: true },
+    { key: 'views', label: 'Views', sortable: true },
+    { key: 'unique_views', label: 'Unique Views', sortable: true },
+];
+
+const displayData = computed( () => {
+    const clampedLimit = Math.max( 0, Math.floor( props.limit ) );
+
+    return props.topPages.slice( 0, clampedLimit );
+} );
+</script>
+
+<template>
+    <Card title="Top Pages">
+        <Table
+            :columns="columns"
+            :rows="displayData"
+            striped
+            :empty-message="'No page data available for this period.'"
+        />
+    </Card>
+</template>

--- a/resources/js/vue/widgets/TrafficSources.vue
+++ b/resources/js/vue/widgets/TrafficSources.vue
@@ -1,0 +1,59 @@
+<!--
+  TrafficSources Vue component.
+
+  Displays a table of traffic sources with session and visitor counts
+  using @artisanpack-ui/vue Table. Mirrors the Livewire TrafficSources
+  widget.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Card, Table } from '@artisanpack-ui/vue';
+
+import type { TableColumn } from '@artisanpack-ui/vue';
+import type { TrafficSourceItem } from '../../types';
+
+const props = withDefaults( defineProps<{
+    /** Array of traffic source data from the API. */
+    trafficSources: TrafficSourceItem[];
+    /** Maximum number of sources to display. */
+    limit?: number;
+}>(), {
+    limit: 10,
+} );
+
+const columns: TableColumn[] = [
+    { key: 'source', label: 'Source', sortable: true },
+    { key: 'medium', label: 'Medium', sortable: true },
+    { key: 'sessions', label: 'Sessions', sortable: true },
+    { key: 'visitors', label: 'Visitors', sortable: true },
+    { key: 'percentage', label: '%' },
+];
+
+const totalSessions = computed(
+    () => props.trafficSources.reduce( ( sum, s ) => sum + s.sessions, 0 ),
+);
+
+const displayData = computed( () => {
+    return props.trafficSources.slice( 0, props.limit ).map( ( source ) => ( {
+        ...source,
+        source: source.source || '(direct)',
+        medium: source.medium || '(none)',
+        percentage: totalSessions.value > 0
+            ? `${( ( source.sessions / totalSessions.value ) * 100 ).toFixed( 1 )}%`
+            : '0.0%',
+    } ) );
+} );
+</script>
+
+<template>
+    <Card title="Traffic Sources">
+        <Table
+            :columns="columns"
+            :rows="displayData"
+            striped
+            :empty-message="'No traffic source data available for this period.'"
+        />
+    </Card>
+</template>

--- a/resources/js/vue/widgets/TrafficSources.vue
+++ b/resources/js/vue/widgets/TrafficSources.vue
@@ -36,7 +36,9 @@ const totalSessions = computed(
 );
 
 const displayData = computed( () => {
-    return props.trafficSources.slice( 0, props.limit ).map( ( source ) => ( {
+    const clampedLimit = Math.max( 0, Math.floor( props.limit ) );
+
+    return props.trafficSources.slice( 0, clampedLimit ).map( ( source ) => ( {
         ...source,
         source: source.source || '(direct)',
         medium: source.medium || '(none)',

--- a/resources/js/vue/widgets/VisitorsChart.vue
+++ b/resources/js/vue/widgets/VisitorsChart.vue
@@ -1,0 +1,97 @@
+<!--
+  VisitorsChart Vue component.
+
+  Renders a time-series area chart of page views and visitors using
+  @artisanpack-ui/vue Chart (ApexCharts). Includes granularity
+  selector buttons. Mirrors the Livewire VisitorsChart widget.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { Card, Chart, Button } from '@artisanpack-ui/vue';
+
+import type { ChartSeries } from '@artisanpack-ui/vue';
+
+export interface ChartDataPoint {
+    date: string;
+    pageviews: number;
+    visitors: number;
+}
+
+export type Granularity = 'hour' | 'day' | 'week' | 'month';
+
+const props = withDefaults( defineProps<{
+    /** Time-series data points from the API. */
+    chartData: ChartDataPoint[];
+    /** Available granularity options. */
+    granularityOptions?: Granularity[];
+    /** The initial granularity. */
+    defaultGranularity?: Granularity;
+}>(), {
+    granularityOptions: () => [ 'day', 'week', 'month' ],
+    defaultGranularity: 'day',
+} );
+
+const emit = defineEmits<{
+    granularityChange: [granularity: Granularity];
+}>();
+
+const granularity = ref<Granularity>( props.defaultGranularity );
+
+const granularityLabels: Record<Granularity, string> = {
+    hour: 'Hourly',
+    day: 'Daily',
+    week: 'Weekly',
+    month: 'Monthly',
+};
+
+function handleGranularityChange( newGranularity: Granularity ): void {
+    granularity.value = newGranularity;
+    emit( 'granularityChange', newGranularity );
+}
+
+const chartSeries = computed<ChartSeries[]>( () => [
+    {
+        name: 'Pageviews',
+        data: props.chartData.map( ( d ) => d.pageviews ),
+    },
+    {
+        name: 'Visitors',
+        data: props.chartData.map( ( d ) => d.visitors ),
+    },
+] );
+
+const categories = computed( () => props.chartData.map( ( d ) => d.date ) );
+</script>
+
+<template>
+    <Card title="Visitors &amp; Pageviews">
+        <template #menu>
+            <div class="flex gap-1">
+                <Button
+                    v-for="option in props.granularityOptions"
+                    :key="option"
+                    :label="granularityLabels[option]"
+                    size="xs"
+                    :color="granularity === option ? 'primary' : 'ghost'"
+                    @click="handleGranularityChange( option )"
+                />
+            </div>
+        </template>
+
+        <p
+            v-if="props.chartData.length === 0"
+            class="text-base-content/50 text-center py-8"
+        >
+            No data available for this period.
+        </p>
+        <Chart
+            v-else
+            type="area"
+            :series="chartSeries"
+            :labels="categories"
+            :height="300"
+        />
+    </Card>
+</template>

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -188,6 +188,7 @@ class AnalyticsServiceProvider extends ServiceProvider
         $this->publishViews();
         $this->publishTracker();
         $this->publishReactComponents();
+        $this->publishVueComponents();
         $this->registerMiddleware();
         $this->registerRoutes();
         $this->registerCommands();
@@ -347,6 +348,23 @@ class AnalyticsServiceProvider extends ServiceProvider
             $this->publishes( [
                 __DIR__ . '/../resources/js/react' => resource_path( 'js/vendor/artisanpack-analytics/react' ),
             ], 'analytics-react' );
+        }
+    }
+
+    /**
+     * Publish the Vue dashboard components.
+     *
+     * Publishes Vue SFC components to the consuming application's
+     * resources directory for use with Inertia.js.
+     *
+     * @since 1.1.0
+     */
+    protected function publishVueComponents(): void
+    {
+        if ( $this->app->runningInConsole() ) {
+            $this->publishes( [
+                __DIR__ . '/../resources/js/vue' => resource_path( 'js/vendor/artisanpack-analytics/vue' ),
+            ], 'analytics-vue' );
         }
     }
 

--- a/tests/Feature/VueComponentsTest.php
+++ b/tests/Feature/VueComponentsTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\AnalyticsServiceProvider;
+
+test( 'vue components are registered as publishable assets', function (): void {
+	$serviceProvider = app()->getProvider( AnalyticsServiceProvider::class );
+
+	expect( $serviceProvider )->not->toBeNull();
+
+	$publishes = AnalyticsServiceProvider::pathsToPublish( AnalyticsServiceProvider::class, 'analytics-vue' );
+
+	expect( $publishes )->not->toBeEmpty();
+} );
+
+test( 'vue component source directory exists', function (): void {
+	$vueDir = __DIR__ . '/../../resources/js/vue';
+
+	expect( is_dir( $vueDir ) )->toBeTrue();
+} );
+
+test( 'all vue widget components exist', function ( string $component ): void {
+	$filePath = __DIR__ . "/../../resources/js/vue/widgets/{$component}.vue";
+
+	expect( file_exists( $filePath ) )->toBeTrue();
+} )->with( [
+	'StatsCards',
+	'VisitorsChart',
+	'TopPages',
+	'TrafficSources',
+	'RealtimeVisitors',
+] );
+
+test( 'all vue dashboard components exist', function ( string $component ): void {
+	$filePath = __DIR__ . "/../../resources/js/vue/{$component}.vue";
+
+	expect( file_exists( $filePath ) )->toBeTrue();
+} )->with( [
+	'AnalyticsDashboard',
+	'PageAnalytics',
+	'SiteSelector',
+	'MultiTenantDashboard',
+] );
+
+test( 'vue barrel export file exists', function (): void {
+	$filePath = __DIR__ . '/../../resources/js/vue/index.ts';
+
+	expect( file_exists( $filePath ) )->toBeTrue();
+} );
+
+test( 'vue composable file exists', function (): void {
+	$filePath = __DIR__ . '/../../resources/js/vue/useAnalyticsApi.ts';
+
+	expect( file_exists( $filePath ) )->toBeTrue();
+} );
+
+test( 'vue components publish to correct destination', function (): void {
+	$publishes   = AnalyticsServiceProvider::pathsToPublish( AnalyticsServiceProvider::class, 'analytics-vue' );
+	$destination = resource_path( 'js/vendor/artisanpack-analytics/vue' );
+
+	expect( array_values( $publishes ) )->toContain( $destination );
+} );
+
+test( 'vue barrel export references all components', function (): void {
+	$indexContent = file_get_contents( __DIR__ . '/../../resources/js/vue/index.ts' );
+
+	expect( $indexContent )
+		->toContain( 'StatsCards' )
+		->toContain( 'VisitorsChart' )
+		->toContain( 'TopPages' )
+		->toContain( 'TrafficSources' )
+		->toContain( 'RealtimeVisitors' )
+		->toContain( 'AnalyticsDashboard' )
+		->toContain( 'PageAnalytics' )
+		->toContain( 'SiteSelector' )
+		->toContain( 'MultiTenantDashboard' )
+		->toContain( 'useAnalyticsApi' );
+} );


### PR DESCRIPTION
## Description

Create Vue 3 equivalents of all Livewire dashboard components, shipped as publishable assets within the analytics Composer package. Each component is built with `<script setup lang="ts">` using `@artisanpack-ui/vue` components (Stat, Table, Chart, Card, Select, Tabs, Badge, Loading, Sparkline, Grid) and consumes `@artisanpack-ui/tokens` for consistent styling.

**Closes:** #30

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #30

## Motivation and Context

Laravel applications using Vue via Inertia.js need native Vue equivalents of the Livewire dashboard widgets. This adds Vue 3 SFC components with full visual parity to the React and Livewire versions.

## Changes Made

- **AnalyticsDashboard** — Main dashboard layout with Tabs, date range Select, and composed widgets
- **StatsCards** — Key metric cards using Stat with conditional comparison indicators
- **VisitorsChart** — Time-series area chart using Chart (ApexCharts) with granularity selector
- **TopPages** — Sortable table of most visited pages using Table
- **TrafficSources** — Traffic sources table with percentages using Table
- **RealtimeVisitors** — Live visitor count with polling, type-safe normalization, null previousCount
- **PageAnalytics** — Per-page analytics with inline Sparkline, full and compact views
- **SiteSelector** — Multi-tenant site picker using Select
- **MultiTenantDashboard** — Dashboard wrapper with SiteSelector, syncs initialSiteId via watch
- **useAnalyticsApi** — Vue composable for API fetching with AbortController and optional polling
- **Barrel export** at `resources/js/vue/index.ts`
- **Publishable assets** via `php artisan vendor:publish --tag=analytics-vue`
- **Service provider** updated with `publishVueComponents()` method

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: release/1.1

**Tests Performed:**
1. 15 feature tests verify all component files exist, barrel exports reference all components, publish tag is registered, and publish destination is correct
2. Manual testing in the ArtisanPack UI dev app with a dedicated Vue Components test page
3. All components render correctly with sample data using @artisanpack-ui/vue styling
4. CodeRabbit review — 3 passes, all findings addressed

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** Components inherit accessibility from @artisanpack-ui/vue (Tabs has WAI-ARIA pattern, Table has proper semantics, Select has label association).

## Tests Added

- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** 15 Pest tests in `tests/Feature/VueComponentsTest.php` covering file existence, publish tag registration, barrel export completeness, and publish destination.

## Documentation

- [x] Inline code documentation added

**Documentation details:** All components and the composable have doc comments with `@since 1.1.0` tags and prop descriptions.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full Vue analytics dashboard: stats cards, visitors chart, top pages, traffic sources, page-level analytics, realtime visitors, site selector, and multi-site dashboard. Also adds a unified import surface and a client composable to fetch analytics data.
* **Tests**
  * Feature tests verifying dashboard assets, component exports, and source presence.
* **Chore**
  * Service provider updated to publish Vue dashboard assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->