### PR TITLE
enhancement: Add consent management React and Vue components

### DIFF
--- a/resources/js/react/ConsentBanner.tsx
+++ b/resources/js/react/ConsentBanner.tsx
@@ -1,0 +1,243 @@
+/**
+ * ConsentBanner React component.
+ *
+ * A GDPR/CCPA-compliant cookie consent banner with accept, reject, and
+ * customize options. Integrates with the consent API via the useConsent
+ * hook and uses @artisanpack-ui/react Button and Card components.
+ *
+ * @since 1.1.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Button, Card, Toggle } from '@artisanpack-ui/react';
+
+import { useConsent } from './useConsent';
+
+import type { UseConsentOptions } from './useConsent';
+
+export interface ConsentBannerProps extends UseConsentOptions {
+    /** Banner position on screen. Defaults to 'bottom'. */
+    position?: 'top' | 'bottom';
+    /** Title text for the banner. */
+    title?: string;
+    /** Description text displayed below the title. */
+    description?: string;
+    /** Label for the accept all button. */
+    acceptLabel?: string;
+    /** Label for the reject all button. */
+    rejectLabel?: string;
+    /** Label for the customize button. */
+    customizeLabel?: string;
+    /** Label for the save preferences button. */
+    saveLabel?: string;
+    /** Callback invoked after consent is saved. */
+    onConsentSaved?: ( categories: Record<string, boolean> ) => void;
+    /** Optional CSS class name for the container. */
+    className?: string;
+}
+
+export default function ConsentBanner( {
+    position = 'bottom',
+    title = 'Privacy Settings',
+    description = 'We use cookies to understand how you use our website and improve your experience.',
+    acceptLabel = 'Accept All',
+    rejectLabel = 'Reject All',
+    customizeLabel = 'Customize',
+    saveLabel = 'Save Preferences',
+    onConsentSaved,
+    className = '',
+    ...consentOptions
+}: ConsentBannerProps ): React.ReactElement | null {
+    const {
+        loading,
+        consentRequired,
+        categories,
+        acceptAll,
+        rejectAll,
+        updateConsent,
+    } = useConsent( consentOptions );
+
+    const [ visible, setVisible ] = useState( false );
+    const [ showDetails, setShowDetails ] = useState( false );
+    const [ localCategories, setLocalCategories ] = useState<Record<string, boolean>>( {} );
+
+    // Show the banner if consent is required and no consent has been given yet
+    useEffect( () => {
+        if ( ! consentRequired ) {
+            return;
+        }
+
+        const stored = typeof localStorage !== 'undefined'
+            ? localStorage.getItem( 'ap_analytics_consent' )
+            : null;
+
+        if ( ! stored ) {
+            setVisible( true );
+        }
+    }, [ consentRequired ] );
+
+    // Sync local toggle state with API categories
+    useEffect( () => {
+        const state: Record<string, boolean> = {};
+
+        for ( const [ key, item ] of Object.entries( categories ) ) {
+            state[ key ] = item.required || item.granted;
+        }
+
+        setLocalCategories( state );
+    }, [ categories ] );
+
+    if ( ! visible ) {
+        return null;
+    }
+
+    const handleAcceptAll = async (): Promise<void> => {
+        try {
+            await acceptAll();
+            setVisible( false );
+            onConsentSaved?.( Object.fromEntries(
+                Object.keys( categories ).map( ( key ) => [ key, true ] ),
+            ) );
+        } catch ( err ) {
+            console.error( 'Failed to accept all consent:', err );
+        }
+    };
+
+    const handleRejectAll = async (): Promise<void> => {
+        try {
+            await rejectAll();
+            setVisible( false );
+
+            const result: Record<string, boolean> = {};
+
+            for ( const [ key, item ] of Object.entries( categories ) ) {
+                result[ key ] = item.required;
+            }
+
+            onConsentSaved?.( result );
+        } catch ( err ) {
+            console.error( 'Failed to reject all consent:', err );
+        }
+    };
+
+    const handleSavePreferences = async (): Promise<void> => {
+        try {
+            await updateConsent( localCategories );
+            setVisible( false );
+            onConsentSaved?.( { ...localCategories } );
+        } catch ( err ) {
+            console.error( 'Failed to save consent preferences:', err );
+        }
+    };
+
+    const handleToggleCategory = ( key: string, value: boolean ): void => {
+        if ( categories[ key ]?.required ) {
+            return;
+        }
+
+        setLocalCategories( ( prev ) => ( { ...prev, [ key ]: value } ) );
+    };
+
+    const positionClasses = position === 'bottom'
+        ? 'bottom-0'
+        : 'top-0';
+
+    return (
+        <div
+            className={`fixed ${positionClasses} inset-x-0 z-50 p-4 ${className}`.trim()}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="consent-banner-title"
+        >
+            <div className="mx-auto max-w-4xl">
+                <Card>
+                    <div className="flex items-start justify-between mb-4">
+                        <div>
+                            <h3
+                                id="consent-banner-title"
+                                className="text-lg font-semibold"
+                            >
+                                {title}
+                            </h3>
+                            <p className="text-sm opacity-70 mt-1">
+                                {description}
+                            </p>
+                        </div>
+                        <Button
+                            color="ghost"
+                            size="sm"
+                            onClick={() => setShowDetails( ! showDetails )}
+                            aria-expanded={showDetails}
+                            aria-controls="consent-details"
+                        >
+                            {showDetails ? 'Hide Details' : customizeLabel}
+                        </Button>
+                    </div>
+
+                    {showDetails && (
+                        <div id="consent-details" className="space-y-3 mb-6">
+                            {Object.entries( categories ).map( ( [ key, item ] ) => (
+                                <label
+                                    key={key}
+                                    className="flex items-start gap-3 p-3 rounded-lg bg-base-200/50"
+                                >
+                                    <div className="mt-1">
+                                        <Toggle
+                                            checked={localCategories[ key ] ?? false}
+                                            onChange={( e ) => handleToggleCategory( key, e.target.checked )}
+                                            disabled={item.required}
+                                            size="sm"
+                                            color="primary"
+                                        />
+                                    </div>
+                                    <div className="flex-1">
+                                        <span className="font-medium">
+                                            {item.name}
+                                            {item.required && (
+                                                <span className="text-xs opacity-50 ml-1">
+                                                    (Required)
+                                                </span>
+                                            )}
+                                        </span>
+                                        <p className="text-sm opacity-70 mt-0.5">
+                                            {item.description}
+                                        </p>
+                                    </div>
+                                </label>
+                            ) )}
+                        </div>
+                    )}
+
+                    <div className="flex flex-wrap items-center justify-end gap-3">
+                        <Button
+                            color="ghost"
+                            size="sm"
+                            onClick={handleRejectAll}
+                            disabled={loading}
+                        >
+                            {rejectLabel}
+                        </Button>
+                        {showDetails && (
+                            <Button
+                                color="neutral"
+                                size="sm"
+                                onClick={handleSavePreferences}
+                                disabled={loading}
+                            >
+                                {saveLabel}
+                            </Button>
+                        )}
+                        <Button
+                            color="primary"
+                            size="sm"
+                            onClick={handleAcceptAll}
+                            disabled={loading}
+                        >
+                            {acceptLabel}
+                        </Button>
+                    </div>
+                </Card>
+            </div>
+        </div>
+    );
+}

--- a/resources/js/react/ConsentPreferences.tsx
+++ b/resources/js/react/ConsentPreferences.tsx
@@ -142,7 +142,7 @@ export default function ConsentPreferences( {
                                 )}
                             </div>
                             <p className="text-sm opacity-70 mt-1">{item.description}</p>
-                            {item.granted_at && (
+                            {item.granted_at && ! isNaN( Date.parse( item.granted_at ) ) && (
                                 <p className="text-xs opacity-50 mt-1">
                                     Granted on {new Date( item.granted_at ).toISOString().slice( 0, 10 )}
                                 </p>

--- a/resources/js/react/ConsentPreferences.tsx
+++ b/resources/js/react/ConsentPreferences.tsx
@@ -127,12 +127,13 @@ export default function ConsentPreferences( {
                                 checked={localCategories[ key ] ?? false}
                                 onChange={( e ) => handleToggle( key, e.target.checked )}
                                 disabled={item.required}
+                                aria-labelledby={`consent-label-${key}`}
                                 color="primary"
                             />
                         </div>
                         <div className="flex-1">
                             <div className="flex items-center gap-2">
-                                <span className="font-medium">{item.name}</span>
+                                <span id={`consent-label-${key}`} className="font-medium">{item.name}</span>
                                 {item.required && (
                                     <Badge color="neutral" size="sm">Required</Badge>
                                 )}
@@ -143,7 +144,7 @@ export default function ConsentPreferences( {
                             <p className="text-sm opacity-70 mt-1">{item.description}</p>
                             {item.granted_at && (
                                 <p className="text-xs opacity-50 mt-1">
-                                    Granted on {new Date( item.granted_at ).toLocaleDateString()}
+                                    Granted on {new Date( item.granted_at ).toISOString().slice( 0, 10 )}
                                 </p>
                             )}
                         </div>

--- a/resources/js/react/ConsentPreferences.tsx
+++ b/resources/js/react/ConsentPreferences.tsx
@@ -1,0 +1,186 @@
+/**
+ * ConsentPreferences React component.
+ *
+ * A detailed consent preferences panel that allows users to individually
+ * manage tracking categories. Uses @artisanpack-ui/react Card, Button,
+ * Toggle, and Badge components. Can be displayed inline or within a modal.
+ *
+ * @since 1.1.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Badge, Button, Card, Toggle } from '@artisanpack-ui/react';
+
+import { useConsent } from './useConsent';
+
+import type { UseConsentOptions } from './useConsent';
+
+export interface ConsentPreferencesProps extends UseConsentOptions {
+    /** Title text for the preferences panel. */
+    title?: string;
+    /** Description text displayed below the title. */
+    description?: string;
+    /** Label for the save button. */
+    saveLabel?: string;
+    /** Label for the accept all button. */
+    acceptAllLabel?: string;
+    /** Label for the reject all button. */
+    rejectAllLabel?: string;
+    /** Whether to show accept/reject all buttons. Defaults to true. */
+    showBulkActions?: boolean;
+    /** Callback invoked after preferences are saved. */
+    onSaved?: ( categories: Record<string, boolean> ) => void;
+    /** Optional CSS class name for the container. */
+    className?: string;
+}
+
+export default function ConsentPreferences( {
+    title = 'Cookie Preferences',
+    description = 'Manage your cookie and tracking preferences below. Required cookies cannot be disabled.',
+    saveLabel = 'Save Preferences',
+    acceptAllLabel = 'Accept All',
+    rejectAllLabel = 'Reject All',
+    showBulkActions = true,
+    onSaved,
+    className = '',
+    ...consentOptions
+}: ConsentPreferencesProps ): React.ReactElement {
+    const {
+        loading,
+        categories,
+        acceptAll,
+        rejectAll,
+        updateConsent,
+    } = useConsent( consentOptions );
+
+    const [ localCategories, setLocalCategories ] = useState<Record<string, boolean>>( {} );
+
+    useEffect( () => {
+        const state: Record<string, boolean> = {};
+
+        for ( const [ key, item ] of Object.entries( categories ) ) {
+            state[ key ] = item.required || item.granted;
+        }
+
+        setLocalCategories( state );
+    }, [ categories ] );
+
+    const handleToggle = ( key: string, value: boolean ): void => {
+        if ( categories[ key ]?.required ) {
+            return;
+        }
+
+        setLocalCategories( ( prev ) => ( { ...prev, [ key ]: value } ) );
+    };
+
+    const handleSave = async (): Promise<void> => {
+        try {
+            await updateConsent( localCategories );
+            onSaved?.( { ...localCategories } );
+        } catch ( err ) {
+            console.error( 'Failed to save consent preferences:', err );
+        }
+    };
+
+    const handleAcceptAll = async (): Promise<void> => {
+        try {
+            await acceptAll();
+            onSaved?.( Object.fromEntries(
+                Object.keys( categories ).map( ( key ) => [ key, true ] ),
+            ) );
+        } catch ( err ) {
+            console.error( 'Failed to accept all consent:', err );
+        }
+    };
+
+    const handleRejectAll = async (): Promise<void> => {
+        try {
+            await rejectAll();
+
+            const result: Record<string, boolean> = {};
+
+            for ( const [ key, item ] of Object.entries( categories ) ) {
+                result[ key ] = item.required;
+            }
+
+            onSaved?.( result );
+        } catch ( err ) {
+            console.error( 'Failed to reject all consent:', err );
+        }
+    };
+
+    return (
+        <Card className={className}>
+            <div className="mb-6">
+                <h3 className="text-lg font-semibold">{title}</h3>
+                <p className="text-sm opacity-70 mt-1">{description}</p>
+            </div>
+
+            <div className="space-y-4 mb-6">
+                {Object.entries( categories ).map( ( [ key, item ] ) => (
+                    <div
+                        key={key}
+                        className="flex items-start gap-4 p-4 rounded-lg bg-base-200/50"
+                    >
+                        <div className="mt-0.5">
+                            <Toggle
+                                checked={localCategories[ key ] ?? false}
+                                onChange={( e ) => handleToggle( key, e.target.checked )}
+                                disabled={item.required}
+                                color="primary"
+                            />
+                        </div>
+                        <div className="flex-1">
+                            <div className="flex items-center gap-2">
+                                <span className="font-medium">{item.name}</span>
+                                {item.required && (
+                                    <Badge color="neutral" size="sm">Required</Badge>
+                                )}
+                                {item.granted && ! item.required && (
+                                    <Badge color="success" size="sm">Granted</Badge>
+                                )}
+                            </div>
+                            <p className="text-sm opacity-70 mt-1">{item.description}</p>
+                            {item.granted_at && (
+                                <p className="text-xs opacity-50 mt-1">
+                                    Granted on {new Date( item.granted_at ).toLocaleDateString()}
+                                </p>
+                            )}
+                        </div>
+                    </div>
+                ) )}
+            </div>
+
+            <div className="flex flex-wrap items-center justify-end gap-3">
+                {showBulkActions && (
+                    <>
+                        <Button
+                            color="ghost"
+                            size="sm"
+                            onClick={handleRejectAll}
+                            disabled={loading}
+                        >
+                            {rejectAllLabel}
+                        </Button>
+                        <Button
+                            color="ghost"
+                            size="sm"
+                            onClick={handleAcceptAll}
+                            disabled={loading}
+                        >
+                            {acceptAllLabel}
+                        </Button>
+                    </>
+                )}
+                <Button
+                    color="primary"
+                    size="sm"
+                    onClick={handleSave}
+                    disabled={loading}
+                >
+                    {saveLabel}
+                </Button>
+            </div>
+        </Card>
+    );
+}

--- a/resources/js/react/ConsentStatus.tsx
+++ b/resources/js/react/ConsentStatus.tsx
@@ -1,0 +1,76 @@
+/**
+ * ConsentStatus React component.
+ *
+ * A small indicator showing the current consent state. Can be used as a
+ * persistent UI element to let users revisit their consent preferences.
+ * Uses @artisanpack-ui/react Badge and Button components.
+ *
+ * @since 1.1.0
+ */
+
+import React from 'react';
+import { Badge, Button } from '@artisanpack-ui/react';
+
+import { useConsent } from './useConsent';
+
+import type { UseConsentOptions } from './useConsent';
+
+export interface ConsentStatusProps extends UseConsentOptions {
+    /** Label text for the status indicator. */
+    label?: string;
+    /** Callback when the user clicks to manage preferences. */
+    onManageClick?: () => void;
+    /** Label for the manage button. */
+    manageLabel?: string;
+    /** Whether to show the manage button. Defaults to true. */
+    showManageButton?: boolean;
+    /** Optional CSS class name for the container. */
+    className?: string;
+}
+
+export default function ConsentStatus( {
+    label = 'Privacy',
+    onManageClick,
+    manageLabel = 'Manage',
+    showManageButton = true,
+    className = '',
+    ...consentOptions
+}: ConsentStatusProps ): React.ReactElement | null {
+    const { consentRequired, categories } = useConsent( consentOptions );
+
+    if ( ! consentRequired ) {
+        return null;
+    }
+
+    const totalCategories = Object.keys( categories ).length;
+    const grantedCount = Object.values( categories ).filter( ( c ) => c.granted ).length;
+    const allGranted = totalCategories > 0 && grantedCount === totalCategories;
+    const noneGranted = totalCategories > 0 && grantedCount === 0;
+
+    let statusColor: 'success' | 'warning' | 'error' = 'warning';
+    let statusText = `${grantedCount}/${totalCategories}`;
+
+    if ( allGranted ) {
+        statusColor = 'success';
+        statusText = 'All accepted';
+    } else if ( noneGranted ) {
+        statusColor = 'error';
+        statusText = 'None accepted';
+    }
+
+    return (
+        <div className={`inline-flex items-center gap-2 ${className}`.trim()}>
+            <span className="text-sm font-medium">{label}</span>
+            <Badge color={statusColor} size="sm">{statusText}</Badge>
+            {showManageButton && onManageClick && (
+                <Button
+                    color="ghost"
+                    size="xs"
+                    onClick={onManageClick}
+                >
+                    {manageLabel}
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/resources/js/react/index.ts
+++ b/resources/js/react/index.ts
@@ -22,5 +22,11 @@ export { default as PageAnalytics } from './PageAnalytics';
 export { default as SiteSelector } from './SiteSelector';
 export { default as MultiTenantDashboard } from './MultiTenantDashboard';
 
+// Consent components
+export { default as ConsentBanner } from './ConsentBanner';
+export { default as ConsentPreferences } from './ConsentPreferences';
+export { default as ConsentStatus } from './ConsentStatus';
+
 // Hooks
 export { useAnalyticsApi } from './useAnalyticsApi';
+export { useConsent } from './useConsent';

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -157,6 +157,35 @@ function getVisitorId(): string | null {
 }
 
 /**
+ * Read stored consent choices from localStorage or cookie.
+ */
+function readStoredConsent(): Record<string, boolean> | null {
+    let raw: string | null = null;
+
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            raw = localStorage.getItem( STORAGE_KEY );
+        }
+    } catch {
+        // Ignore localStorage read failure
+    }
+
+    if ( ! raw ) {
+        raw = getCookie( COOKIE_NAME );
+    }
+
+    if ( ! raw ) {
+        return null;
+    }
+
+    try {
+        return JSON.parse( raw );
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Persist consent categories to localStorage and cookie.
  */
 function persistLocally( categories: Record<string, boolean> ): void {
@@ -190,7 +219,22 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
     const [ loading, setLoading ] = useState( false );
     const [ error, setError ] = useState<string | null>( null );
     const [ consentRequired, setConsentRequired ] = useState( initialConsentRequired );
-    const [ categories, setCategories ] = useState<Record<string, ConsentStatusItem>>( initialCategories );
+    const [ categories, setCategories ] = useState<Record<string, ConsentStatusItem>>( () => {
+        // Hydrate from stored consent so hasConsent() works before the first
+        // API fetch completes (or when fetchOnMount is false)
+        const hydrated = { ...initialCategories };
+        const stored = readStoredConsent();
+
+        if ( stored ) {
+            for ( const [ key, granted ] of Object.entries( stored ) ) {
+                if ( hydrated[ key ] ) {
+                    hydrated[ key ] = { ...hydrated[ key ], granted };
+                }
+            }
+        }
+
+        return hydrated;
+    } );
     const abortRef = useRef<AbortController | null>( null );
 
     const fetchStatus = useCallback( async (): Promise<void> => {
@@ -225,6 +269,11 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             }
 
             const json: ConsentStatusResponse = await response.json();
+
+            if ( ! json.success ) {
+                throw new Error( 'Consent status request was not successful' );
+            }
+
             setConsentRequired( json.consent_required );
             setCategories( json.categories ?? {} );
         } catch ( err ) {
@@ -261,7 +310,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
                 nextCategories[ key ] = {
                     ...nextCategories[ key ],
                     granted,
-                    granted_at: granted ? new Date().toISOString() : nextCategories[ key ].granted_at,
+                    granted_at: granted ? new Date().toISOString() : null,
                 };
             }
         }
@@ -307,6 +356,10 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             }
 
             const json: ConsentUpdateResponse = await response.json();
+
+            if ( ! json.success ) {
+                throw new Error( 'Consent update request was not successful' );
+            }
 
             // Only apply server response if this is still the latest request
             if ( requestId === updateRequestIdRef.current ) {

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -141,7 +141,22 @@ function getVisitorId(): string | null {
         return cookieId;
     }
 
-    // Generate a new visitor ID
+    // No existing visitor ID found — return null so callers can decide
+    // whether to create one (e.g. only after consent is granted)
+    return null;
+}
+
+/**
+ * Get or create a visitor ID. Only call this when the user has given
+ * consent so we don't mint tracker identifiers before consent.
+ */
+function getOrCreateVisitorId(): string {
+    const existing = getVisitorId();
+
+    if ( existing ) {
+        return existing;
+    }
+
     const id = generateUuid();
     setCookie( VISITOR_COOKIE, id, COOKIE_EXPIRY_DAYS );
 
@@ -320,15 +335,13 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         );
 
         // Apply changes optimistically so the UI updates immediately
+        categoriesRef.current = nextCategories;
         setCategories( nextCategories );
         persistLocally( mergedState );
 
-        // Sync with server if a visitor ID is available
-        const visitorId = getVisitorId();
-
-        if ( ! visitorId ) {
-            return;
-        }
+        // Sync with server — create a visitor ID if needed since the user
+        // is actively giving/revoking consent
+        const visitorId = getOrCreateVisitorId();
 
         const requestId = ++updateRequestIdRef.current;
 
@@ -364,6 +377,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             // Only apply server response if this is still the latest request
             if ( requestId === updateRequestIdRef.current ) {
                 const serverCategories = json.categories ?? {};
+                categoriesRef.current = serverCategories;
                 setCategories( serverCategories );
 
                 // Persist server-validated state to keep local storage in sync
@@ -376,6 +390,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             // Only rollback and surface error if this is still the latest request
             if ( requestId === updateRequestIdRef.current ) {
                 setError( err instanceof Error ? err.message : 'An unexpected error occurred' );
+                categoriesRef.current = prevCategories;
                 setCategories( prevCategories );
                 persistLocally( prevMergedState );
             }

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -112,30 +112,45 @@ function generateUuid(): string {
  * and the visitor cookie so subsequent calls return the same ID.
  */
 function getVisitorId(): string | null {
-    if ( typeof localStorage === 'undefined' ) {
-        return null;
-    }
-
     // Check localStorage first
-    let id = localStorage.getItem( VISITOR_KEY );
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            const stored = localStorage.getItem( VISITOR_KEY );
 
-    if ( id ) {
-        return id;
+            if ( stored ) {
+                return stored;
+            }
+        }
+    } catch {
+        // localStorage may be blocked (e.g. Safari private browsing)
     }
 
     // Fall back to the tracker cookie
-    id = getCookie( VISITOR_COOKIE );
+    const cookieId = getCookie( VISITOR_COOKIE );
 
-    if ( id ) {
-        localStorage.setItem( VISITOR_KEY, id );
+    if ( cookieId ) {
+        try {
+            if ( typeof localStorage !== 'undefined' ) {
+                localStorage.setItem( VISITOR_KEY, cookieId );
+            }
+        } catch {
+            // Ignore localStorage write failure
+        }
 
-        return id;
+        return cookieId;
     }
 
     // Generate a new visitor ID
-    id = generateUuid();
-    localStorage.setItem( VISITOR_KEY, id );
+    const id = generateUuid();
     setCookie( VISITOR_COOKIE, id, COOKIE_EXPIRY_DAYS );
+
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            localStorage.setItem( VISITOR_KEY, id );
+        }
+    } catch {
+        // Ignore localStorage write failure
+    }
 
     return id;
 }
@@ -144,13 +159,17 @@ function getVisitorId(): string | null {
  * Persist consent categories to localStorage and cookie.
  */
 function persistLocally( categories: Record<string, boolean> ): void {
-    if ( typeof localStorage === 'undefined' ) {
-        return;
-    }
-
     const value = JSON.stringify( categories );
-    localStorage.setItem( STORAGE_KEY, value );
+
     setCookie( COOKIE_NAME, value, COOKIE_EXPIRY_DAYS );
+
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            localStorage.setItem( STORAGE_KEY, value );
+        }
+    } catch {
+        // Ignore localStorage write failure
+    }
 }
 
 /**

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -1,0 +1,322 @@
+/**
+ * React hook for managing user consent preferences.
+ *
+ * Integrates with the analytics consent API endpoints to check, grant,
+ * and revoke consent for tracking categories (analytics, marketing, etc.).
+ * Supports GDPR and CCPA compliance modes with localStorage persistence
+ * and cookie synchronization.
+ *
+ * @since 1.1.0
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { ConsentStatusItem, ConsentStatusResponse, ConsentUpdateResponse } from '../types';
+
+/** Storage keys for consent data. */
+const STORAGE_KEY = 'ap_analytics_consent';
+const VISITOR_KEY = 'ap_visitor_id';
+const COOKIE_NAME = 'ap_consent';
+const COOKIE_EXPIRY_DAYS = 365;
+
+export interface UseConsentOptions {
+    /** The API route prefix. Defaults to 'api/analytics'. */
+    apiPrefix?: string;
+    /** Whether to fetch consent status on mount. Defaults to true. */
+    fetchOnMount?: boolean;
+    /** Initial categories to populate before any API call. Useful for SSR or demos. */
+    initialCategories?: Record<string, ConsentStatusItem>;
+    /** Initial consent-required flag. Useful for SSR or demos. */
+    initialConsentRequired?: boolean;
+}
+
+export interface UseConsentResult {
+    /** Whether consent data is currently loading. */
+    loading: boolean;
+    /** Error message if the last operation failed. */
+    error: string | null;
+    /** Whether consent is required by the application config. */
+    consentRequired: boolean;
+    /** Current consent status by category key. */
+    categories: Record<string, ConsentStatusItem>;
+    /** Check if a specific category has been granted. */
+    hasConsent: ( category: string ) => boolean;
+    /** Grant consent for the given categories. */
+    grantConsent: ( categories: string[] ) => Promise<void>;
+    /** Revoke consent for the given categories. */
+    revokeConsent: ( categories: string[] ) => Promise<void>;
+    /** Accept all consent categories. */
+    acceptAll: () => Promise<void>;
+    /** Reject all non-required consent categories. */
+    rejectAll: () => Promise<void>;
+    /** Update consent for specific categories. */
+    updateConsent: ( updates: Record<string, boolean> ) => Promise<void>;
+    /** Refresh consent status from the server. */
+    refresh: () => Promise<void>;
+}
+
+/**
+ * Set a cookie value with expiry.
+ */
+function setCookie( name: string, value: string, days: number ): void {
+    if ( typeof document === 'undefined' ) {
+        return;
+    }
+
+    const date = new Date();
+    date.setTime( date.getTime() + days * 24 * 60 * 60 * 1000 );
+    document.cookie = `${name}=${encodeURIComponent( value )}; expires=${date.toUTCString()}; path=/; SameSite=Lax`;
+}
+
+/**
+ * Get the CSRF token from the meta tag.
+ */
+function getCsrfToken(): string {
+    if ( typeof document === 'undefined' ) {
+        return '';
+    }
+
+    return document.querySelector( 'meta[name="csrf-token"]' )?.getAttribute( 'content' ) ?? '';
+}
+
+/**
+ * Get or create a visitor ID from localStorage.
+ */
+function getVisitorId(): string | null {
+    if ( typeof localStorage === 'undefined' ) {
+        return null;
+    }
+
+    return localStorage.getItem( VISITOR_KEY );
+}
+
+/**
+ * Persist consent categories to localStorage and cookie.
+ */
+function persistLocally( categories: Record<string, boolean> ): void {
+    if ( typeof localStorage === 'undefined' ) {
+        return;
+    }
+
+    const value = JSON.stringify( categories );
+    localStorage.setItem( STORAGE_KEY, value );
+    setCookie( COOKIE_NAME, value, COOKIE_EXPIRY_DAYS );
+}
+
+/**
+ * Hook for managing consent preferences with API integration.
+ */
+export function useConsent( options: UseConsentOptions = {} ): UseConsentResult {
+    const {
+        apiPrefix = 'api/analytics',
+        fetchOnMount = true,
+        initialCategories = {},
+        initialConsentRequired = false,
+    } = options;
+
+    const [ loading, setLoading ] = useState( false );
+    const [ error, setError ] = useState<string | null>( null );
+    const [ consentRequired, setConsentRequired ] = useState( initialConsentRequired );
+    const [ categories, setCategories ] = useState<Record<string, ConsentStatusItem>>( initialCategories );
+    const abortRef = useRef<AbortController | null>( null );
+
+    const fetchStatus = useCallback( async (): Promise<void> => {
+        const visitorId = getVisitorId();
+
+        if ( ! visitorId ) {
+            return;
+        }
+
+        abortRef.current?.abort();
+        const controller = new AbortController();
+        abortRef.current = controller;
+
+        setLoading( true );
+        setError( null );
+
+        try {
+            const response = await fetch(
+                `/${apiPrefix}/consent?visitor_id=${encodeURIComponent( visitorId )}`,
+                {
+                    headers: {
+                        Accept: 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    credentials: 'same-origin',
+                    signal: controller.signal,
+                },
+            );
+
+            if ( ! response.ok ) {
+                throw new Error( `HTTP ${response.status}: ${response.statusText}` );
+            }
+
+            const json: ConsentStatusResponse = await response.json();
+            setConsentRequired( json.consent_required );
+            setCategories( json.categories ?? {} );
+        } catch ( err ) {
+            if ( err instanceof DOMException && err.name === 'AbortError' ) {
+                return;
+            }
+
+            setError( err instanceof Error ? err.message : 'An unexpected error occurred' );
+        } finally {
+            if ( ! controller.signal.aborted ) {
+                setLoading( false );
+            }
+        }
+    }, [ apiPrefix ] );
+
+    const updateConsent = useCallback( async ( updates: Record<string, boolean> ): Promise<void> => {
+        // Save previous state for rollback on server error
+        let prevCategories: Record<string, ConsentStatusItem> = {};
+        let prevMergedState: Record<string, boolean> = {};
+        let mergedState: Record<string, boolean> = {};
+
+        // Apply changes optimistically so the UI updates immediately
+        setCategories( ( prev ) => {
+            prevCategories = prev;
+            prevMergedState = Object.fromEntries(
+                Object.entries( prev ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+            );
+
+            const next = { ...prev };
+
+            for ( const [ key, granted ] of Object.entries( updates ) ) {
+                if ( next[ key ] ) {
+                    next[ key ] = {
+                        ...next[ key ],
+                        granted,
+                        granted_at: granted ? new Date().toISOString() : next[ key ].granted_at,
+                    };
+                }
+            }
+
+            mergedState = Object.fromEntries(
+                Object.entries( next ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+            );
+
+            return next;
+        } );
+
+        persistLocally( mergedState );
+
+        // Sync with server if a visitor ID is available
+        const visitorId = getVisitorId();
+
+        if ( ! visitorId ) {
+            return;
+        }
+
+        setLoading( true );
+        setError( null );
+
+        try {
+            const response = await fetch( `/${apiPrefix}/consent`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-TOKEN': getCsrfToken(),
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify( {
+                    visitor_id: visitorId,
+                    categories: updates,
+                } ),
+            } );
+
+            if ( ! response.ok ) {
+                throw new Error( `HTTP ${response.status}: ${response.statusText}` );
+            }
+
+            const json: ConsentUpdateResponse = await response.json();
+            setCategories( json.categories ?? {} );
+        } catch ( err ) {
+            setError( err instanceof Error ? err.message : 'An unexpected error occurred' );
+
+            // Rollback optimistic update on server error
+            setCategories( prevCategories );
+            persistLocally( prevMergedState );
+        } finally {
+            setLoading( false );
+        }
+    }, [ apiPrefix ] );
+
+    const hasConsent = useCallback( ( category: string ): boolean => {
+        return categories[ category ]?.granted ?? false;
+    }, [ categories ] );
+
+    const grantConsent = useCallback( async ( cats: string[] ): Promise<void> => {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories ) ) {
+            updates[ key ] = categories[ key ].granted;
+        }
+
+        for ( const cat of cats ) {
+            updates[ cat ] = true;
+        }
+
+        await updateConsent( updates );
+    }, [ categories, updateConsent ] );
+
+    const revokeConsent = useCallback( async ( cats: string[] ): Promise<void> => {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories ) ) {
+            updates[ key ] = categories[ key ].granted;
+        }
+
+        for ( const cat of cats ) {
+            updates[ cat ] = false;
+        }
+
+        await updateConsent( updates );
+    }, [ categories, updateConsent ] );
+
+    const acceptAll = useCallback( async (): Promise<void> => {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories ) ) {
+            updates[ key ] = true;
+        }
+
+        await updateConsent( updates );
+    }, [ categories, updateConsent ] );
+
+    const rejectAll = useCallback( async (): Promise<void> => {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories ) ) {
+            updates[ key ] = categories[ key ].required;
+        }
+
+        await updateConsent( updates );
+    }, [ categories, updateConsent ] );
+
+    useEffect( () => {
+        if ( fetchOnMount ) {
+            fetchStatus();
+        }
+
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, [ fetchStatus, fetchOnMount ] );
+
+    return {
+        loading,
+        error,
+        consentRequired,
+        categories,
+        hasConsent,
+        grantConsent,
+        revokeConsent,
+        acceptAll,
+        rejectAll,
+        updateConsent,
+        refresh: fetchStatus,
+    };
+}

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -178,11 +178,13 @@ function persistLocally( categories: Record<string, boolean> ): void {
  */
 export function useConsent( options: UseConsentOptions = {} ): UseConsentResult {
     const {
-        apiPrefix = 'api/analytics',
+        apiPrefix: rawApiPrefix = 'api/analytics',
         fetchOnMount = true,
         initialCategories = {},
         initialConsentRequired = false,
     } = options;
+
+    const apiPrefix = rawApiPrefix.replace( /^\/+|\/+$/g, '' );
 
     const [ loading, setLoading ] = useState( false );
     const [ error, setError ] = useState<string | null>( null );
@@ -304,7 +306,14 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
 
             // Only apply server response if this is still the latest request
             if ( requestId === updateRequestIdRef.current ) {
-                setCategories( json.categories ?? {} );
+                const serverCategories = json.categories ?? {};
+                setCategories( serverCategories );
+
+                // Persist server-validated state to keep local storage in sync
+                const serverMergedState = Object.fromEntries(
+                    Object.entries( serverCategories ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+                );
+                persistLocally( serverMergedState );
             }
         } catch ( err ) {
             setError( err instanceof Error ? err.message : 'An unexpected error occurred' );

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -66,7 +66,8 @@ function setCookie( name: string, value: string, days: number ): void {
 
     const date = new Date();
     date.setTime( date.getTime() + days * 24 * 60 * 60 * 1000 );
-    document.cookie = `${name}=${encodeURIComponent( value )}; expires=${date.toUTCString()}; path=/; SameSite=Lax`;
+    const secure = typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent( value )}; expires=${date.toUTCString()}; path=/; SameSite=Lax${secure}`;
 }
 
 /**
@@ -238,6 +239,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
 
     const categoriesRef = useRef( categories );
     categoriesRef.current = categories;
+    const updateRequestIdRef = useRef( 0 );
 
     const updateConsent = useCallback( async ( updates: Record<string, boolean> ): Promise<void> => {
         // Snapshot current state for optimistic update and rollback
@@ -273,6 +275,8 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             return;
         }
 
+        const requestId = ++updateRequestIdRef.current;
+
         setLoading( true );
         setError( null );
 
@@ -297,17 +301,25 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             }
 
             const json: ConsentUpdateResponse = await response.json();
-            setCategories( json.categories ?? {} );
+
+            // Only apply server response if this is still the latest request
+            if ( requestId === updateRequestIdRef.current ) {
+                setCategories( json.categories ?? {} );
+            }
         } catch ( err ) {
             setError( err instanceof Error ? err.message : 'An unexpected error occurred' );
 
-            // Rollback optimistic update on server error
-            setCategories( prevCategories );
-            persistLocally( prevMergedState );
+            // Only rollback if this is still the latest request
+            if ( requestId === updateRequestIdRef.current ) {
+                setCategories( prevCategories );
+                persistLocally( prevMergedState );
+            }
 
             throw err;
         } finally {
-            setLoading( false );
+            if ( requestId === updateRequestIdRef.current ) {
+                setLoading( false );
+            }
         }
     }, [ apiPrefix ] );
 

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -184,7 +184,8 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         initialConsentRequired = false,
     } = options;
 
-    const apiPrefix = rawApiPrefix.replace( /^\/+|\/+$/g, '' );
+    const trimmed = rawApiPrefix.replace( /^\/+|\/+$/g, '' );
+    const apiPrefix = trimmed ? `/${trimmed}` : '';
 
     const [ loading, setLoading ] = useState( false );
     const [ error, setError ] = useState<string | null>( null );
@@ -208,7 +209,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
 
         try {
             const response = await fetch(
-                `/${apiPrefix}/consent?visitor_id=${encodeURIComponent( visitorId )}`,
+                `${apiPrefix}/consent?visitor_id=${encodeURIComponent( visitorId )}`,
                 {
                     headers: {
                         Accept: 'application/json',
@@ -244,6 +245,9 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
     const updateRequestIdRef = useRef( 0 );
 
     const updateConsent = useCallback( async ( updates: Record<string, boolean> ): Promise<void> => {
+        // Cancel any in-flight status fetch so it cannot overwrite the optimistic update
+        abortRef.current?.abort();
+
         // Snapshot current state for optimistic update and rollback
         const prevCategories = categoriesRef.current;
         const prevMergedState = Object.fromEntries(
@@ -283,7 +287,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         setError( null );
 
         try {
-            const response = await fetch( `/${apiPrefix}/consent`, {
+            const response = await fetch( `${apiPrefix}/consent`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -316,10 +320,9 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
                 persistLocally( serverMergedState );
             }
         } catch ( err ) {
-            setError( err instanceof Error ? err.message : 'An unexpected error occurred' );
-
-            // Only rollback if this is still the latest request
+            // Only rollback and surface error if this is still the latest request
             if ( requestId === updateRequestIdRef.current ) {
+                setError( err instanceof Error ? err.message : 'An unexpected error occurred' );
                 setCategories( prevCategories );
                 persistLocally( prevMergedState );
             }

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -16,6 +16,7 @@ import type { ConsentStatusItem, ConsentStatusResponse, ConsentUpdateResponse } 
 /** Storage keys for consent data. */
 const STORAGE_KEY = 'ap_analytics_consent';
 const VISITOR_KEY = 'ap_visitor_id';
+const VISITOR_COOKIE = '_ap_vid';
 const COOKIE_NAME = 'ap_consent';
 const COOKIE_EXPIRY_DAYS = 365;
 
@@ -80,14 +81,63 @@ function getCsrfToken(): string {
 }
 
 /**
- * Get or create a visitor ID from localStorage.
+ * Read a cookie value by name.
+ */
+function getCookie( name: string ): string | null {
+    if ( typeof document === 'undefined' ) {
+        return null;
+    }
+
+    const match = document.cookie.match( new RegExp( `(?:^|; )${name}=([^;]*)` ) );
+
+    return match ? decodeURIComponent( match[ 1 ] ) : null;
+}
+
+/**
+ * Generate a v4-style UUID.
+ */
+function generateUuid(): string {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, ( c ) => {
+        const r = ( Math.random() * 16 ) | 0;
+
+        return ( c === 'x' ? r : ( r & 0x3 ) | 0x8 ).toString( 16 );
+    } );
+}
+
+/**
+ * Get or create a visitor ID.
+ *
+ * Checks localStorage first, then falls back to the tracker cookie (_ap_vid).
+ * If neither exists, generates a new UUID and persists it to both localStorage
+ * and the visitor cookie so subsequent calls return the same ID.
  */
 function getVisitorId(): string | null {
     if ( typeof localStorage === 'undefined' ) {
         return null;
     }
 
-    return localStorage.getItem( VISITOR_KEY );
+    // Check localStorage first
+    let id = localStorage.getItem( VISITOR_KEY );
+
+    if ( id ) {
+        return id;
+    }
+
+    // Fall back to the tracker cookie
+    id = getCookie( VISITOR_COOKIE );
+
+    if ( id ) {
+        localStorage.setItem( VISITOR_KEY, id );
+
+        return id;
+    }
+
+    // Generate a new visitor ID
+    id = generateUuid();
+    localStorage.setItem( VISITOR_KEY, id );
+    setCookie( VISITOR_COOKIE, id, COOKIE_EXPIRY_DAYS );
+
+    return id;
 }
 
 /**
@@ -239,6 +289,8 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             // Rollback optimistic update on server error
             setCategories( prevCategories );
             persistLocally( prevMergedState );
+
+            throw err;
         } finally {
             setLoading( false );
         }

--- a/resources/js/react/useConsent.ts
+++ b/resources/js/react/useConsent.ts
@@ -236,38 +236,34 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         }
     }, [ apiPrefix ] );
 
+    const categoriesRef = useRef( categories );
+    categoriesRef.current = categories;
+
     const updateConsent = useCallback( async ( updates: Record<string, boolean> ): Promise<void> => {
-        // Save previous state for rollback on server error
-        let prevCategories: Record<string, ConsentStatusItem> = {};
-        let prevMergedState: Record<string, boolean> = {};
-        let mergedState: Record<string, boolean> = {};
+        // Snapshot current state for optimistic update and rollback
+        const prevCategories = categoriesRef.current;
+        const prevMergedState = Object.fromEntries(
+            Object.entries( prevCategories ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+        );
+
+        const nextCategories = { ...prevCategories };
+
+        for ( const [ key, granted ] of Object.entries( updates ) ) {
+            if ( nextCategories[ key ] ) {
+                nextCategories[ key ] = {
+                    ...nextCategories[ key ],
+                    granted,
+                    granted_at: granted ? new Date().toISOString() : nextCategories[ key ].granted_at,
+                };
+            }
+        }
+
+        const mergedState = Object.fromEntries(
+            Object.entries( nextCategories ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+        );
 
         // Apply changes optimistically so the UI updates immediately
-        setCategories( ( prev ) => {
-            prevCategories = prev;
-            prevMergedState = Object.fromEntries(
-                Object.entries( prev ).map( ( [ k, v ] ) => [ k, v.granted ] ),
-            );
-
-            const next = { ...prev };
-
-            for ( const [ key, granted ] of Object.entries( updates ) ) {
-                if ( next[ key ] ) {
-                    next[ key ] = {
-                        ...next[ key ],
-                        granted,
-                        granted_at: granted ? new Date().toISOString() : next[ key ].granted_at,
-                    };
-                }
-            }
-
-            mergedState = Object.fromEntries(
-                Object.entries( next ).map( ( [ k, v ] ) => [ k, v.granted ] ),
-            );
-
-            return next;
-        } );
-
+        setCategories( nextCategories );
         persistLocally( mergedState );
 
         // Sync with server if a visitor ID is available

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -250,15 +250,27 @@ export interface SessionStartResponse {
 // ---------------------------------------------------------------------------
 
 export interface ConsentStatusItem {
-    category: string;
+    name: string;
+    description: string;
+    required: boolean;
     granted: boolean;
     granted_at: string | null;
-    expires_at: string | null;
 }
 
 export interface ConsentStatusResponse {
-    success: true;
-    data: ConsentStatusItem[];
+    success: boolean;
+    consent_required: boolean;
+    categories: Record<string, ConsentStatusItem>;
+}
+
+export interface ConsentUpdateRequest {
+    visitor_id: string;
+    categories: Record<string, boolean>;
+}
+
+export interface ConsentUpdateResponse {
+    success: boolean;
+    categories: Record<string, ConsentStatusItem>;
 }
 
 // ---------------------------------------------------------------------------

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -65,6 +65,8 @@ export type {
     ComparisonValue,
     ConsentStatusItem,
     ConsentStatusResponse,
+    ConsentUpdateRequest,
+    ConsentUpdateResponse,
     CountriesResponse,
     CountryBreakdownItem,
     DeviceBreakdownItem,

--- a/resources/js/vue/ConsentBanner.vue
+++ b/resources/js/vue/ConsentBanner.vue
@@ -1,0 +1,241 @@
+<!--
+  ConsentBanner Vue component.
+
+  A GDPR/CCPA-compliant cookie consent banner with accept, reject, and
+  customize options. Integrates with the consent API via the useConsent
+  composable and uses @artisanpack-ui/vue Button, Card, and Toggle
+  components.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { onMounted, ref, watch } from 'vue';
+import { Button, Card, Toggle } from '@artisanpack-ui/vue';
+
+import { useConsent } from './useConsent';
+
+import type { UseConsentOptions } from './useConsent';
+
+interface Props extends UseConsentOptions {
+    /** Banner position on screen. Defaults to 'bottom'. */
+    position?: 'top' | 'bottom';
+    /** Title text for the banner. */
+    title?: string;
+    /** Description text displayed below the title. */
+    description?: string;
+    /** Label for the accept all button. */
+    acceptLabel?: string;
+    /** Label for the reject all button. */
+    rejectLabel?: string;
+    /** Label for the customize button. */
+    customizeLabel?: string;
+    /** Label for the save preferences button. */
+    saveLabel?: string;
+}
+
+const props = withDefaults( defineProps<Props>(), {
+    position: 'bottom',
+    title: 'Privacy Settings',
+    description: 'We use cookies to understand how you use our website and improve your experience.',
+    acceptLabel: 'Accept All',
+    rejectLabel: 'Reject All',
+    customizeLabel: 'Customize',
+    saveLabel: 'Save Preferences',
+    apiPrefix: 'api/analytics',
+    fetchOnMount: true,
+    initialConsentRequired: false,
+    initialCategories: () => ( {} ),
+} );
+
+const emit = defineEmits<{
+    consentSaved: [categories: Record<string, boolean>];
+}>();
+
+const {
+    loading,
+    consentRequired,
+    categories,
+    acceptAll,
+    rejectAll,
+    updateConsent,
+} = useConsent( {
+    apiPrefix: props.apiPrefix,
+    fetchOnMount: props.fetchOnMount,
+    initialCategories: props.initialCategories,
+    initialConsentRequired: props.initialConsentRequired,
+} );
+
+const visible = ref( false );
+const showDetails = ref( false );
+const localCategories = ref<Record<string, boolean>>( {} );
+
+onMounted( () => {
+    if ( ! consentRequired.value ) {
+        return;
+    }
+
+    const stored = typeof localStorage !== 'undefined'
+        ? localStorage.getItem( 'ap_analytics_consent' )
+        : null;
+
+    if ( ! stored ) {
+        visible.value = true;
+    }
+} );
+
+watch( () => consentRequired.value, ( required ) => {
+    if ( ! required ) {
+        return;
+    }
+
+    const stored = typeof localStorage !== 'undefined'
+        ? localStorage.getItem( 'ap_analytics_consent' )
+        : null;
+
+    if ( ! stored ) {
+        visible.value = true;
+    }
+} );
+
+watch( categories, ( cats ) => {
+    const state: Record<string, boolean> = {};
+
+    for ( const [ key, item ] of Object.entries( cats ) ) {
+        state[ key ] = item.required || item.granted;
+    }
+
+    localCategories.value = state;
+}, { immediate: true } );
+
+async function handleAcceptAll(): Promise<void> {
+    await acceptAll();
+    visible.value = false;
+    emit( 'consentSaved', Object.fromEntries(
+        Object.keys( categories.value ).map( ( key ) => [ key, true ] ),
+    ) );
+}
+
+async function handleRejectAll(): Promise<void> {
+    await rejectAll();
+    visible.value = false;
+
+    const result: Record<string, boolean> = {};
+
+    for ( const [ key, item ] of Object.entries( categories.value ) ) {
+        result[ key ] = item.required;
+    }
+
+    emit( 'consentSaved', result );
+}
+
+async function handleSavePreferences(): Promise<void> {
+    await updateConsent( localCategories.value );
+    visible.value = false;
+    emit( 'consentSaved', { ...localCategories.value } );
+}
+
+function handleToggleCategory( key: string, value: boolean ): void {
+    if ( categories.value[ key ]?.required ) {
+        return;
+    }
+
+    localCategories.value[ key ] = value;
+}
+</script>
+
+<template>
+    <div
+        v-if="visible"
+        :class="[
+            'fixed inset-x-0 z-50 p-4',
+            props.position === 'bottom' ? 'bottom-0' : 'top-0',
+        ]"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="consent-banner-title"
+    >
+        <div class="mx-auto max-w-4xl">
+            <Card>
+                <div class="flex items-start justify-between mb-4">
+                    <div>
+                        <h3
+                            id="consent-banner-title"
+                            class="text-lg font-semibold"
+                        >
+                            {{ props.title }}
+                        </h3>
+                        <p class="text-sm opacity-70 mt-1">
+                            {{ props.description }}
+                        </p>
+                    </div>
+                    <Button
+                        color="ghost"
+                        size="sm"
+                        :aria-expanded="showDetails"
+                        aria-controls="consent-details"
+                        @click="showDetails = ! showDetails"
+                    >
+                        {{ showDetails ? 'Hide Details' : props.customizeLabel }}
+                    </Button>
+                </div>
+
+                <div v-if="showDetails" id="consent-details" class="space-y-3 mb-6">
+                    <label
+                        v-for="( item, key ) in categories"
+                        :key="key"
+                        class="flex items-start gap-3 p-3 rounded-lg bg-base-200/50"
+                    >
+                        <div class="mt-1">
+                            <Toggle
+                                :model-value="localCategories[ key as string ] ?? false"
+                                :disabled="item.required"
+                                size="sm"
+                                color="primary"
+                                @update:model-value="handleToggleCategory( key as string, $event as boolean )"
+                            />
+                        </div>
+                        <div class="flex-1">
+                            <span class="font-medium">
+                                {{ item.name }}
+                                <span v-if="item.required" class="text-xs opacity-50 ml-1">
+                                    (Required)
+                                </span>
+                            </span>
+                            <p class="text-sm opacity-70 mt-0.5">
+                                {{ item.description }}
+                            </p>
+                        </div>
+                    </label>
+                </div>
+
+                <div class="flex flex-wrap items-center justify-end gap-3">
+                    <Button
+                        color="ghost"
+                        size="sm"
+                        :disabled="loading"
+                        @click="handleRejectAll"
+                    >
+                        {{ props.rejectLabel }}
+                    </Button>
+                    <Button
+                        v-if="showDetails"
+                        color="neutral"
+                        size="sm"
+                        :disabled="loading"
+                        @click="handleSavePreferences"
+                    >
+                        {{ props.saveLabel }}
+                    </Button>
+                    <Button
+                        color="primary"
+                        size="sm"
+                        :disabled="loading"
+                        @click="handleAcceptAll"
+                    >
+                        {{ props.acceptLabel }}
+                    </Button>
+                </div>
+            </Card>
+        </div>
+    </div>
+</template>

--- a/resources/js/vue/ConsentPreferences.vue
+++ b/resources/js/vue/ConsentPreferences.vue
@@ -117,7 +117,7 @@ async function handleRejectAll(): Promise<void> {
 }
 
 function formatDate( dateStr: string ): string {
-    return new Date( dateStr ).toLocaleDateString();
+    return new Date( dateStr ).toISOString().slice( 0, 10 );
 }
 </script>
 
@@ -138,13 +138,14 @@ function formatDate( dateStr: string ): string {
                     <Toggle
                         :model-value="localCategories[ key as string ] ?? false"
                         :disabled="item.required"
+                        :aria-labelledby="`consent-label-${key}`"
                         color="primary"
                         @update:model-value="handleToggle( key as string, $event as boolean )"
                     />
                 </div>
                 <div class="flex-1">
                     <div class="flex items-center gap-2">
-                        <span class="font-medium">{{ item.name }}</span>
+                        <span :id="`consent-label-${key}`" class="font-medium">{{ item.name }}</span>
                         <Badge v-if="item.required" color="neutral" size="sm">
                             Required
                         </Badge>

--- a/resources/js/vue/ConsentPreferences.vue
+++ b/resources/js/vue/ConsentPreferences.vue
@@ -1,0 +1,195 @@
+<!--
+  ConsentPreferences Vue component.
+
+  A detailed consent preferences panel that allows users to individually
+  manage tracking categories. Uses @artisanpack-ui/vue Card, Button,
+  Toggle, and Badge components. Can be displayed inline or within a modal.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { ref, watch } from 'vue';
+import { Badge, Button, Card, Toggle } from '@artisanpack-ui/vue';
+
+import { useConsent } from './useConsent';
+
+import type { UseConsentOptions } from './useConsent';
+
+interface Props extends UseConsentOptions {
+    /** Title text for the preferences panel. */
+    title?: string;
+    /** Description text displayed below the title. */
+    description?: string;
+    /** Label for the save button. */
+    saveLabel?: string;
+    /** Label for the accept all button. */
+    acceptAllLabel?: string;
+    /** Label for the reject all button. */
+    rejectAllLabel?: string;
+    /** Whether to show accept/reject all buttons. Defaults to true. */
+    showBulkActions?: boolean;
+}
+
+const props = withDefaults( defineProps<Props>(), {
+    title: 'Cookie Preferences',
+    description: 'Manage your cookie and tracking preferences below. Required cookies cannot be disabled.',
+    saveLabel: 'Save Preferences',
+    acceptAllLabel: 'Accept All',
+    rejectAllLabel: 'Reject All',
+    showBulkActions: true,
+    apiPrefix: 'api/analytics',
+    fetchOnMount: true,
+    initialConsentRequired: false,
+    initialCategories: () => ( {} ),
+} );
+
+const emit = defineEmits<{
+    saved: [categories: Record<string, boolean>];
+}>();
+
+const {
+    loading,
+    categories,
+    acceptAll,
+    rejectAll,
+    updateConsent,
+} = useConsent( {
+    apiPrefix: props.apiPrefix,
+    fetchOnMount: props.fetchOnMount,
+    initialCategories: props.initialCategories,
+    initialConsentRequired: props.initialConsentRequired,
+} );
+
+const localCategories = ref<Record<string, boolean>>( {} );
+
+watch( categories, ( cats ) => {
+    const state: Record<string, boolean> = {};
+
+    for ( const [ key, item ] of Object.entries( cats ) ) {
+        state[ key ] = item.required || item.granted;
+    }
+
+    localCategories.value = state;
+}, { immediate: true } );
+
+function handleToggle( key: string, value: boolean ): void {
+    if ( categories.value[ key ]?.required ) {
+        return;
+    }
+
+    localCategories.value[ key ] = value;
+}
+
+async function handleSave(): Promise<void> {
+    try {
+        await updateConsent( localCategories.value );
+        emit( 'saved', { ...localCategories.value } );
+    } catch ( err ) {
+        console.error( 'Failed to save consent preferences:', err );
+    }
+}
+
+async function handleAcceptAll(): Promise<void> {
+    try {
+        await acceptAll();
+        emit( 'saved', Object.fromEntries(
+            Object.keys( categories.value ).map( ( key ) => [ key, true ] ),
+        ) );
+    } catch ( err ) {
+        console.error( 'Failed to accept all consent:', err );
+    }
+}
+
+async function handleRejectAll(): Promise<void> {
+    try {
+        await rejectAll();
+
+        const result: Record<string, boolean> = {};
+
+        for ( const [ key, item ] of Object.entries( categories.value ) ) {
+            result[ key ] = item.required;
+        }
+
+        emit( 'saved', result );
+    } catch ( err ) {
+        console.error( 'Failed to reject all consent:', err );
+    }
+}
+
+function formatDate( dateStr: string ): string {
+    return new Date( dateStr ).toLocaleDateString();
+}
+</script>
+
+<template>
+    <Card>
+        <div class="mb-6">
+            <h3 class="text-lg font-semibold">{{ props.title }}</h3>
+            <p class="text-sm opacity-70 mt-1">{{ props.description }}</p>
+        </div>
+
+        <div class="space-y-4 mb-6">
+            <div
+                v-for="( item, key ) in categories"
+                :key="key"
+                class="flex items-start gap-4 p-4 rounded-lg bg-base-200/50"
+            >
+                <div class="mt-0.5">
+                    <Toggle
+                        :model-value="localCategories[ key as string ] ?? false"
+                        :disabled="item.required"
+                        color="primary"
+                        @update:model-value="handleToggle( key as string, $event as boolean )"
+                    />
+                </div>
+                <div class="flex-1">
+                    <div class="flex items-center gap-2">
+                        <span class="font-medium">{{ item.name }}</span>
+                        <Badge v-if="item.required" color="neutral" size="sm">
+                            Required
+                        </Badge>
+                        <Badge v-else-if="item.granted" color="success" size="sm">
+                            Granted
+                        </Badge>
+                    </div>
+                    <p class="text-sm opacity-70 mt-1">{{ item.description }}</p>
+                    <p
+                        v-if="item.granted_at"
+                        class="text-xs opacity-50 mt-1"
+                    >
+                        Granted on {{ formatDate( item.granted_at ) }}
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div class="flex flex-wrap items-center justify-end gap-3">
+            <template v-if="props.showBulkActions">
+                <Button
+                    color="ghost"
+                    size="sm"
+                    :disabled="loading"
+                    @click="handleRejectAll"
+                >
+                    {{ props.rejectAllLabel }}
+                </Button>
+                <Button
+                    color="ghost"
+                    size="sm"
+                    :disabled="loading"
+                    @click="handleAcceptAll"
+                >
+                    {{ props.acceptAllLabel }}
+                </Button>
+            </template>
+            <Button
+                color="primary"
+                size="sm"
+                :disabled="loading"
+                @click="handleSave"
+            >
+                {{ props.saveLabel }}
+            </Button>
+        </div>
+    </Card>
+</template>

--- a/resources/js/vue/ConsentPreferences.vue
+++ b/resources/js/vue/ConsentPreferences.vue
@@ -117,7 +117,13 @@ async function handleRejectAll(): Promise<void> {
 }
 
 function formatDate( dateStr: string ): string {
-    return new Date( dateStr ).toISOString().slice( 0, 10 );
+    const d = new Date( dateStr );
+
+    if ( isNaN( d.getTime() ) ) {
+        return '';
+    }
+
+    return d.toISOString().slice( 0, 10 );
 }
 </script>
 

--- a/resources/js/vue/ConsentStatus.vue
+++ b/resources/js/vue/ConsentStatus.vue
@@ -1,0 +1,102 @@
+<!--
+  ConsentStatus Vue component.
+
+  A small indicator showing the current consent state. Can be used as a
+  persistent UI element to let users revisit their consent preferences.
+  Uses @artisanpack-ui/vue Badge and Button components.
+
+  @since 1.1.0
+-->
+<script setup lang="ts">
+import { computed } from 'vue';
+import { Badge, Button } from '@artisanpack-ui/vue';
+
+import { useConsent } from './useConsent';
+
+import type { UseConsentOptions } from './useConsent';
+
+interface Props extends UseConsentOptions {
+    /** Label text for the status indicator. */
+    label?: string;
+    /** Label for the manage button. */
+    manageLabel?: string;
+    /** Whether to show the manage button. Defaults to true. */
+    showManageButton?: boolean;
+}
+
+const props = withDefaults( defineProps<Props>(), {
+    label: 'Privacy',
+    manageLabel: 'Manage',
+    showManageButton: true,
+    apiPrefix: 'api/analytics',
+    fetchOnMount: true,
+    initialConsentRequired: false,
+    initialCategories: () => ( {} ),
+} );
+
+const emit = defineEmits<{
+    manageClick: [];
+}>();
+
+const { consentRequired, categories } = useConsent( {
+    apiPrefix: props.apiPrefix,
+    fetchOnMount: props.fetchOnMount,
+    initialCategories: props.initialCategories,
+    initialConsentRequired: props.initialConsentRequired,
+} );
+
+const totalCategories = computed( () => Object.keys( categories.value ).length );
+const grantedCount = computed( () =>
+    Object.values( categories.value ).filter( ( c ) => c.granted ).length,
+);
+const allGranted = computed( () =>
+    totalCategories.value > 0 && grantedCount.value === totalCategories.value,
+);
+const noneGranted = computed( () =>
+    totalCategories.value > 0 && grantedCount.value === 0,
+);
+
+const statusColor = computed( (): 'success' | 'warning' | 'error' => {
+    if ( allGranted.value ) {
+        return 'success';
+    }
+
+    if ( noneGranted.value ) {
+        return 'error';
+    }
+
+    return 'warning';
+} );
+
+const statusText = computed( () => {
+    if ( allGranted.value ) {
+        return 'All accepted';
+    }
+
+    if ( noneGranted.value ) {
+        return 'None accepted';
+    }
+
+    return `${grantedCount.value}/${totalCategories.value}`;
+} );
+</script>
+
+<template>
+    <div
+        v-if="consentRequired"
+        class="inline-flex items-center gap-2"
+    >
+        <span class="text-sm font-medium">{{ props.label }}</span>
+        <Badge :color="statusColor" size="sm">
+            {{ statusText }}
+        </Badge>
+        <Button
+            v-if="props.showManageButton"
+            color="ghost"
+            size="xs"
+            @click="emit( 'manageClick' )"
+        >
+            {{ props.manageLabel }}
+        </Button>
+    </div>
+</template>

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -22,5 +22,11 @@ export { default as PageAnalytics } from './PageAnalytics.vue';
 export { default as SiteSelector } from './SiteSelector.vue';
 export { default as MultiTenantDashboard } from './MultiTenantDashboard.vue';
 
+// Consent components
+export { default as ConsentBanner } from './ConsentBanner.vue';
+export { default as ConsentPreferences } from './ConsentPreferences.vue';
+export { default as ConsentStatus } from './ConsentStatus.vue';
+
 // Composables
 export { useAnalyticsApi } from './useAnalyticsApi';
+export { useConsent } from './useConsent';

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -184,7 +184,8 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         initialConsentRequired = false,
     } = options;
 
-    const apiPrefix = rawApiPrefix.replace( /^\/+|\/+$/g, '' );
+    const trimmed = rawApiPrefix.replace( /^\/+|\/+$/g, '' );
+    const apiPrefix = trimmed ? `/${trimmed}` : '';
 
     const loading = ref( false );
     const error = ref<string | null>( null );
@@ -210,7 +211,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
 
         try {
             const response = await fetch(
-                `/${apiPrefix}/consent?visitor_id=${encodeURIComponent( visitorId )}`,
+                `${apiPrefix}/consent?visitor_id=${encodeURIComponent( visitorId )}`,
                 {
                     headers: {
                         Accept: 'application/json',
@@ -242,6 +243,9 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
     }
 
     async function updateConsent( updates: Record<string, boolean> ): Promise<void> {
+        // Cancel any in-flight status fetch so it cannot overwrite the optimistic update
+        abortController?.abort();
+
         // Save previous state for rollback on server error
         const prev = { ...categories.value };
         const prevMergedState = Object.fromEntries(
@@ -282,7 +286,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         error.value = null;
 
         try {
-            const response = await fetch( `/${apiPrefix}/consent`, {
+            const response = await fetch( `${apiPrefix}/consent`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -313,9 +317,8 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
                 persistLocally( serverMergedState );
             }
         } catch ( err ) {
-            error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
-
             if ( requestId === updateRequestId ) {
+                error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
                 categories.value = prev;
                 persistLocally( prevMergedState );
             }

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -178,11 +178,13 @@ function persistLocally( categories: Record<string, boolean> ): void {
  */
 export function useConsent( options: UseConsentOptions = {} ): UseConsentResult {
     const {
-        apiPrefix = 'api/analytics',
+        apiPrefix: rawApiPrefix = 'api/analytics',
         fetchOnMount = true,
         initialCategories = {},
         initialConsentRequired = false,
     } = options;
+
+    const apiPrefix = rawApiPrefix.replace( /^\/+|\/+$/g, '' );
 
     const loading = ref( false );
     const error = ref<string | null>( null );
@@ -302,7 +304,13 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             const json: ConsentUpdateResponse = await response.json();
 
             if ( requestId === updateRequestId ) {
-                categories.value = json.categories ?? {};
+                const serverCategories = json.categories ?? {};
+                categories.value = serverCategories;
+
+                const serverMergedState = Object.fromEntries(
+                    Object.entries( serverCategories ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+                );
+                persistLocally( serverMergedState );
             }
         } catch ( err ) {
             error.value = err instanceof Error ? err.message : 'An unexpected error occurred';

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -66,7 +66,8 @@ function setCookie( name: string, value: string, days: number ): void {
 
     const date = new Date();
     date.setTime( date.getTime() + days * 24 * 60 * 60 * 1000 );
-    document.cookie = `${name}=${encodeURIComponent( value )}; expires=${date.toUTCString()}; path=/; SameSite=Lax`;
+    const secure = typeof window !== 'undefined' && window.location.protocol === 'https:' ? '; Secure' : '';
+    document.cookie = `${name}=${encodeURIComponent( value )}; expires=${date.toUTCString()}; path=/; SameSite=Lax${secure}`;
 }
 
 /**
@@ -189,6 +190,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
     const categories = ref<Record<string, ConsentStatusItem>>( initialCategories );
 
     let abortController: AbortController | null = null;
+    let updateRequestId = 0;
 
     async function fetchStatus(): Promise<void> {
         const visitorId = getVisitorId();
@@ -272,6 +274,8 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             return;
         }
 
+        const requestId = ++updateRequestId;
+
         loading.value = true;
         error.value = null;
 
@@ -296,17 +300,23 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             }
 
             const json: ConsentUpdateResponse = await response.json();
-            categories.value = json.categories ?? {};
+
+            if ( requestId === updateRequestId ) {
+                categories.value = json.categories ?? {};
+            }
         } catch ( err ) {
             error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
 
-            // Rollback optimistic update on server error
-            categories.value = prev;
-            persistLocally( prevMergedState );
+            if ( requestId === updateRequestId ) {
+                categories.value = prev;
+                persistLocally( prevMergedState );
+            }
 
             throw err;
         } finally {
-            loading.value = false;
+            if ( requestId === updateRequestId ) {
+                loading.value = false;
+            }
         }
     }
 

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -157,6 +157,35 @@ function getVisitorId(): string | null {
 }
 
 /**
+ * Read stored consent choices from localStorage or cookie.
+ */
+function readStoredConsent(): Record<string, boolean> | null {
+    let raw: string | null = null;
+
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            raw = localStorage.getItem( STORAGE_KEY );
+        }
+    } catch {
+        // Ignore localStorage read failure
+    }
+
+    if ( ! raw ) {
+        raw = getCookieValue( COOKIE_NAME );
+    }
+
+    if ( ! raw ) {
+        return null;
+    }
+
+    try {
+        return JSON.parse( raw );
+    } catch {
+        return null;
+    }
+}
+
+/**
  * Persist consent categories to localStorage and cookie.
  */
 function persistLocally( categories: Record<string, boolean> ): void {
@@ -187,10 +216,23 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
     const trimmed = rawApiPrefix.replace( /^\/+|\/+$/g, '' );
     const apiPrefix = trimmed ? `/${trimmed}` : '';
 
+    // Hydrate initial categories from stored consent so hasConsent() works
+    // before the first API fetch completes (or when fetchOnMount is false)
+    const hydratedCategories = { ...initialCategories };
+    const stored = readStoredConsent();
+
+    if ( stored ) {
+        for ( const [ key, granted ] of Object.entries( stored ) ) {
+            if ( hydratedCategories[ key ] ) {
+                hydratedCategories[ key ] = { ...hydratedCategories[ key ], granted };
+            }
+        }
+    }
+
     const loading = ref( false );
     const error = ref<string | null>( null );
     const consentRequired = ref( initialConsentRequired );
-    const categories = ref<Record<string, ConsentStatusItem>>( initialCategories );
+    const categories = ref<Record<string, ConsentStatusItem>>( hydratedCategories );
 
     let abortController: AbortController | null = null;
     let updateRequestId = 0;
@@ -227,6 +269,11 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             }
 
             const json: ConsentStatusResponse = await response.json();
+
+            if ( ! json.success ) {
+                throw new Error( 'Consent status request was not successful' );
+            }
+
             consentRequired.value = json.consent_required;
             categories.value = json.categories ?? {};
         } catch ( err ) {
@@ -260,7 +307,7 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
                 next[ key ] = {
                     ...next[ key ],
                     granted,
-                    granted_at: granted ? new Date().toISOString() : next[ key ].granted_at,
+                    granted_at: granted ? new Date().toISOString() : null,
                 };
             }
         }
@@ -306,6 +353,10 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             }
 
             const json: ConsentUpdateResponse = await response.json();
+
+            if ( ! json.success ) {
+                throw new Error( 'Consent update request was not successful' );
+            }
 
             if ( requestId === updateRequestId ) {
                 const serverCategories = json.categories ?? {};

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -16,6 +16,7 @@ import type { ConsentStatusItem, ConsentStatusResponse, ConsentUpdateResponse } 
 /** Storage keys for consent data. */
 const STORAGE_KEY = 'ap_analytics_consent';
 const VISITOR_KEY = 'ap_visitor_id';
+const VISITOR_COOKIE = '_ap_vid';
 const COOKIE_NAME = 'ap_consent';
 const COOKIE_EXPIRY_DAYS = 365;
 
@@ -80,14 +81,60 @@ function getCsrfToken(): string {
 }
 
 /**
- * Get the visitor ID from localStorage.
+ * Read a cookie value by name.
+ */
+function getCookieValue( name: string ): string | null {
+    if ( typeof document === 'undefined' ) {
+        return null;
+    }
+
+    const match = document.cookie.match( new RegExp( `(?:^|; )${name}=([^;]*)` ) );
+
+    return match ? decodeURIComponent( match[ 1 ] ) : null;
+}
+
+/**
+ * Generate a v4-style UUID.
+ */
+function generateUuid(): string {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace( /[xy]/g, ( c ) => {
+        const r = ( Math.random() * 16 ) | 0;
+
+        return ( c === 'x' ? r : ( r & 0x3 ) | 0x8 ).toString( 16 );
+    } );
+}
+
+/**
+ * Get or create a visitor ID.
+ *
+ * Checks localStorage first, then falls back to the tracker cookie (_ap_vid).
+ * If neither exists, generates a new UUID and persists it to both localStorage
+ * and the visitor cookie so subsequent calls return the same ID.
  */
 function getVisitorId(): string | null {
     if ( typeof localStorage === 'undefined' ) {
         return null;
     }
 
-    return localStorage.getItem( VISITOR_KEY );
+    let id = localStorage.getItem( VISITOR_KEY );
+
+    if ( id ) {
+        return id;
+    }
+
+    id = getCookieValue( VISITOR_COOKIE );
+
+    if ( id ) {
+        localStorage.setItem( VISITOR_KEY, id );
+
+        return id;
+    }
+
+    id = generateUuid();
+    localStorage.setItem( VISITOR_KEY, id );
+    setCookie( VISITOR_COOKIE, id, COOKIE_EXPIRY_DAYS );
+
+    return id;
 }
 
 /**
@@ -234,6 +281,8 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
             // Rollback optimistic update on server error
             categories.value = prev;
             persistLocally( prevMergedState );
+
+            throw err;
         } finally {
             loading.value = false;
         }

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -112,27 +112,45 @@ function generateUuid(): string {
  * and the visitor cookie so subsequent calls return the same ID.
  */
 function getVisitorId(): string | null {
-    if ( typeof localStorage === 'undefined' ) {
-        return null;
+    // Check localStorage first
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            const stored = localStorage.getItem( VISITOR_KEY );
+
+            if ( stored ) {
+                return stored;
+            }
+        }
+    } catch {
+        // localStorage may be blocked (e.g. Safari private browsing)
     }
 
-    let id = localStorage.getItem( VISITOR_KEY );
+    // Fall back to the tracker cookie
+    const cookieId = getCookieValue( VISITOR_COOKIE );
 
-    if ( id ) {
-        return id;
+    if ( cookieId ) {
+        try {
+            if ( typeof localStorage !== 'undefined' ) {
+                localStorage.setItem( VISITOR_KEY, cookieId );
+            }
+        } catch {
+            // Ignore localStorage write failure
+        }
+
+        return cookieId;
     }
 
-    id = getCookieValue( VISITOR_COOKIE );
-
-    if ( id ) {
-        localStorage.setItem( VISITOR_KEY, id );
-
-        return id;
-    }
-
-    id = generateUuid();
-    localStorage.setItem( VISITOR_KEY, id );
+    // Generate a new visitor ID
+    const id = generateUuid();
     setCookie( VISITOR_COOKIE, id, COOKIE_EXPIRY_DAYS );
+
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            localStorage.setItem( VISITOR_KEY, id );
+        }
+    } catch {
+        // Ignore localStorage write failure
+    }
 
     return id;
 }
@@ -141,13 +159,17 @@ function getVisitorId(): string | null {
  * Persist consent categories to localStorage and cookie.
  */
 function persistLocally( categories: Record<string, boolean> ): void {
-    if ( typeof localStorage === 'undefined' ) {
-        return;
-    }
-
     const value = JSON.stringify( categories );
-    localStorage.setItem( STORAGE_KEY, value );
+
     setCookie( COOKIE_NAME, value, COOKIE_EXPIRY_DAYS );
+
+    try {
+        if ( typeof localStorage !== 'undefined' ) {
+            localStorage.setItem( STORAGE_KEY, value );
+        }
+    } catch {
+        // Ignore localStorage write failure
+    }
 }
 
 /**

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -9,7 +9,7 @@
  * @since 1.1.0
  */
 
-import { computed, onUnmounted, ref, type Ref } from 'vue';
+import { computed, onMounted, onUnmounted, ref, type Ref } from 'vue';
 
 import type { ConsentStatusItem, ConsentStatusResponse, ConsentUpdateResponse } from '../types';
 
@@ -362,9 +362,11 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         await updateConsent( updates );
     }
 
-    if ( fetchOnMount ) {
-        fetchStatus();
-    }
+    onMounted( () => {
+        if ( fetchOnMount ) {
+            fetchStatus();
+        }
+    } );
 
     onUnmounted( () => {
         abortController?.abort();

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -141,7 +141,22 @@ function getVisitorId(): string | null {
         return cookieId;
     }
 
-    // Generate a new visitor ID
+    // No existing visitor ID found — return null so callers can decide
+    // whether to create one (e.g. only after consent is granted)
+    return null;
+}
+
+/**
+ * Get or create a visitor ID. Only call this when the user has given
+ * consent so we don't mint tracker identifiers before consent.
+ */
+function getOrCreateVisitorId(): string {
+    const existing = getVisitorId();
+
+    if ( existing ) {
+        return existing;
+    }
+
     const id = generateUuid();
     setCookie( VISITOR_COOKIE, id, COOKIE_EXPIRY_DAYS );
 
@@ -320,12 +335,9 @@ export function useConsent( options: UseConsentOptions = {} ): UseConsentResult 
         );
         persistLocally( mergedState );
 
-        // Sync with server if a visitor ID is available
-        const visitorId = getVisitorId();
-
-        if ( ! visitorId ) {
-            return;
-        }
+        // Sync with server — create a visitor ID if needed since the user
+        // is actively giving/revoking consent
+        const visitorId = getOrCreateVisitorId();
 
         const requestId = ++updateRequestId;
 

--- a/resources/js/vue/useConsent.ts
+++ b/resources/js/vue/useConsent.ts
@@ -1,0 +1,315 @@
+/**
+ * Vue composable for managing user consent preferences.
+ *
+ * Integrates with the analytics consent API endpoints to check, grant,
+ * and revoke consent for tracking categories (analytics, marketing, etc.).
+ * Supports GDPR and CCPA compliance modes with localStorage persistence
+ * and cookie synchronization.
+ *
+ * @since 1.1.0
+ */
+
+import { computed, onUnmounted, ref, type Ref } from 'vue';
+
+import type { ConsentStatusItem, ConsentStatusResponse, ConsentUpdateResponse } from '../types';
+
+/** Storage keys for consent data. */
+const STORAGE_KEY = 'ap_analytics_consent';
+const VISITOR_KEY = 'ap_visitor_id';
+const COOKIE_NAME = 'ap_consent';
+const COOKIE_EXPIRY_DAYS = 365;
+
+export interface UseConsentOptions {
+    /** The API route prefix. Defaults to 'api/analytics'. */
+    apiPrefix?: string;
+    /** Whether to fetch consent status on mount. Defaults to true. */
+    fetchOnMount?: boolean;
+    /** Initial categories to populate before any API call. Useful for SSR or demos. */
+    initialCategories?: Record<string, ConsentStatusItem>;
+    /** Initial consent-required flag. Useful for SSR or demos. */
+    initialConsentRequired?: boolean;
+}
+
+export interface UseConsentResult {
+    /** Whether consent data is currently loading. */
+    loading: Ref<boolean>;
+    /** Error message if the last operation failed. */
+    error: Ref<string | null>;
+    /** Whether consent is required by the application config. */
+    consentRequired: Ref<boolean>;
+    /** Current consent status by category key. */
+    categories: Ref<Record<string, ConsentStatusItem>>;
+    /** Check if a specific category has been granted. */
+    hasConsent: ( category: string ) => boolean;
+    /** Grant consent for the given categories. */
+    grantConsent: ( categories: string[] ) => Promise<void>;
+    /** Revoke consent for the given categories. */
+    revokeConsent: ( categories: string[] ) => Promise<void>;
+    /** Accept all consent categories. */
+    acceptAll: () => Promise<void>;
+    /** Reject all non-required consent categories. */
+    rejectAll: () => Promise<void>;
+    /** Update consent for specific categories. */
+    updateConsent: ( updates: Record<string, boolean> ) => Promise<void>;
+    /** Refresh consent status from the server. */
+    refresh: () => Promise<void>;
+}
+
+/**
+ * Set a cookie value with expiry.
+ */
+function setCookie( name: string, value: string, days: number ): void {
+    if ( typeof document === 'undefined' ) {
+        return;
+    }
+
+    const date = new Date();
+    date.setTime( date.getTime() + days * 24 * 60 * 60 * 1000 );
+    document.cookie = `${name}=${encodeURIComponent( value )}; expires=${date.toUTCString()}; path=/; SameSite=Lax`;
+}
+
+/**
+ * Get the CSRF token from the meta tag.
+ */
+function getCsrfToken(): string {
+    if ( typeof document === 'undefined' ) {
+        return '';
+    }
+
+    return document.querySelector( 'meta[name="csrf-token"]' )?.getAttribute( 'content' ) ?? '';
+}
+
+/**
+ * Get the visitor ID from localStorage.
+ */
+function getVisitorId(): string | null {
+    if ( typeof localStorage === 'undefined' ) {
+        return null;
+    }
+
+    return localStorage.getItem( VISITOR_KEY );
+}
+
+/**
+ * Persist consent categories to localStorage and cookie.
+ */
+function persistLocally( categories: Record<string, boolean> ): void {
+    if ( typeof localStorage === 'undefined' ) {
+        return;
+    }
+
+    const value = JSON.stringify( categories );
+    localStorage.setItem( STORAGE_KEY, value );
+    setCookie( COOKIE_NAME, value, COOKIE_EXPIRY_DAYS );
+}
+
+/**
+ * Composable for managing consent preferences with API integration.
+ */
+export function useConsent( options: UseConsentOptions = {} ): UseConsentResult {
+    const {
+        apiPrefix = 'api/analytics',
+        fetchOnMount = true,
+        initialCategories = {},
+        initialConsentRequired = false,
+    } = options;
+
+    const loading = ref( false );
+    const error = ref<string | null>( null );
+    const consentRequired = ref( initialConsentRequired );
+    const categories = ref<Record<string, ConsentStatusItem>>( initialCategories );
+
+    let abortController: AbortController | null = null;
+
+    async function fetchStatus(): Promise<void> {
+        const visitorId = getVisitorId();
+
+        if ( ! visitorId ) {
+            return;
+        }
+
+        abortController?.abort();
+        const controller = new AbortController();
+        abortController = controller;
+
+        loading.value = true;
+        error.value = null;
+
+        try {
+            const response = await fetch(
+                `/${apiPrefix}/consent?visitor_id=${encodeURIComponent( visitorId )}`,
+                {
+                    headers: {
+                        Accept: 'application/json',
+                        'X-Requested-With': 'XMLHttpRequest',
+                    },
+                    credentials: 'same-origin',
+                    signal: controller.signal,
+                },
+            );
+
+            if ( ! response.ok ) {
+                throw new Error( `HTTP ${response.status}: ${response.statusText}` );
+            }
+
+            const json: ConsentStatusResponse = await response.json();
+            consentRequired.value = json.consent_required;
+            categories.value = json.categories ?? {};
+        } catch ( err ) {
+            if ( err instanceof DOMException && err.name === 'AbortError' ) {
+                return;
+            }
+
+            error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
+        } finally {
+            if ( ! controller.signal.aborted ) {
+                loading.value = false;
+            }
+        }
+    }
+
+    async function updateConsent( updates: Record<string, boolean> ): Promise<void> {
+        // Save previous state for rollback on server error
+        const prev = { ...categories.value };
+        const prevMergedState = Object.fromEntries(
+            Object.entries( prev ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+        );
+
+        // Apply changes optimistically so the UI updates immediately
+        const next = { ...categories.value };
+
+        for ( const [ key, granted ] of Object.entries( updates ) ) {
+            if ( next[ key ] ) {
+                next[ key ] = {
+                    ...next[ key ],
+                    granted,
+                    granted_at: granted ? new Date().toISOString() : next[ key ].granted_at,
+                };
+            }
+        }
+
+        categories.value = next;
+
+        // Persist the full merged state, not just the partial updates
+        const mergedState = Object.fromEntries(
+            Object.entries( next ).map( ( [ k, v ] ) => [ k, v.granted ] ),
+        );
+        persistLocally( mergedState );
+
+        // Sync with server if a visitor ID is available
+        const visitorId = getVisitorId();
+
+        if ( ! visitorId ) {
+            return;
+        }
+
+        loading.value = true;
+        error.value = null;
+
+        try {
+            const response = await fetch( `/${apiPrefix}/consent`, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                    'X-Requested-With': 'XMLHttpRequest',
+                    'X-CSRF-TOKEN': getCsrfToken(),
+                },
+                credentials: 'same-origin',
+                body: JSON.stringify( {
+                    visitor_id: visitorId,
+                    categories: updates,
+                } ),
+            } );
+
+            if ( ! response.ok ) {
+                throw new Error( `HTTP ${response.status}: ${response.statusText}` );
+            }
+
+            const json: ConsentUpdateResponse = await response.json();
+            categories.value = json.categories ?? {};
+        } catch ( err ) {
+            error.value = err instanceof Error ? err.message : 'An unexpected error occurred';
+
+            // Rollback optimistic update on server error
+            categories.value = prev;
+            persistLocally( prevMergedState );
+        } finally {
+            loading.value = false;
+        }
+    }
+
+    function hasConsent( category: string ): boolean {
+        return categories.value[ category ]?.granted ?? false;
+    }
+
+    async function grantConsent( cats: string[] ): Promise<void> {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories.value ) ) {
+            updates[ key ] = categories.value[ key ].granted;
+        }
+
+        for ( const cat of cats ) {
+            updates[ cat ] = true;
+        }
+
+        await updateConsent( updates );
+    }
+
+    async function revokeConsent( cats: string[] ): Promise<void> {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories.value ) ) {
+            updates[ key ] = categories.value[ key ].granted;
+        }
+
+        for ( const cat of cats ) {
+            updates[ cat ] = false;
+        }
+
+        await updateConsent( updates );
+    }
+
+    async function acceptAll(): Promise<void> {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories.value ) ) {
+            updates[ key ] = true;
+        }
+
+        await updateConsent( updates );
+    }
+
+    async function rejectAll(): Promise<void> {
+        const updates: Record<string, boolean> = {};
+
+        for ( const key of Object.keys( categories.value ) ) {
+            updates[ key ] = categories.value[ key ].required;
+        }
+
+        await updateConsent( updates );
+    }
+
+    if ( fetchOnMount ) {
+        fetchStatus();
+    }
+
+    onUnmounted( () => {
+        abortController?.abort();
+    } );
+
+    return {
+        loading,
+        error,
+        consentRequired,
+        categories,
+        hasConsent,
+        grantConsent,
+        revokeConsent,
+        acceptAll,
+        rejectAll,
+        updateConsent,
+        refresh: fetchStatus,
+    };
+}

--- a/tests/Feature/ReactComponentsTest.php
+++ b/tests/Feature/ReactComponentsTest.php
@@ -48,17 +48,30 @@ test( 'all react dashboard components exist', function ( string $component ): vo
 	'MultiTenantDashboard',
 ] );
 
+test( 'all react consent components exist', function ( string $component ): void {
+	$filePath = __DIR__ . "/../../resources/js/react/{$component}.tsx";
+
+	expect( file_exists( $filePath ) )->toBeTrue();
+} )->with( [
+	'ConsentBanner',
+	'ConsentPreferences',
+	'ConsentStatus',
+] );
+
 test( 'react barrel export file exists', function (): void {
 	$filePath = __DIR__ . '/../../resources/js/react/index.ts';
 
 	expect( file_exists( $filePath ) )->toBeTrue();
 } );
 
-test( 'react hook file exists', function (): void {
-	$filePath = __DIR__ . '/../../resources/js/react/useAnalyticsApi.ts';
+test( 'react hook files exist', function ( string $hook ): void {
+	$filePath = __DIR__ . "/../../resources/js/react/{$hook}.ts";
 
 	expect( file_exists( $filePath ) )->toBeTrue();
-} );
+} )->with( [
+	'useAnalyticsApi',
+	'useConsent',
+] );
 
 test( 'react components publish to correct destination', function (): void {
 	$publishes = AnalyticsServiceProvider::pathsToPublish( AnalyticsServiceProvider::class, 'analytics-react' );
@@ -81,5 +94,9 @@ test( 'react barrel export references all components', function (): void {
 		->toContain( 'PageAnalytics' )
 		->toContain( 'SiteSelector' )
 		->toContain( 'MultiTenantDashboard' )
-		->toContain( 'useAnalyticsApi' );
+		->toContain( 'ConsentBanner' )
+		->toContain( 'ConsentPreferences' )
+		->toContain( 'ConsentStatus' )
+		->toContain( 'useAnalyticsApi' )
+		->toContain( 'useConsent' );
 } );

--- a/tests/Feature/VueComponentsTest.php
+++ b/tests/Feature/VueComponentsTest.php
@@ -43,17 +43,30 @@ test( 'all vue dashboard components exist', function ( string $component ): void
 	'MultiTenantDashboard',
 ] );
 
+test( 'all vue consent components exist', function ( string $component ): void {
+	$filePath = __DIR__ . "/../../resources/js/vue/{$component}.vue";
+
+	expect( file_exists( $filePath ) )->toBeTrue();
+} )->with( [
+	'ConsentBanner',
+	'ConsentPreferences',
+	'ConsentStatus',
+] );
+
 test( 'vue barrel export file exists', function (): void {
 	$filePath = __DIR__ . '/../../resources/js/vue/index.ts';
 
 	expect( file_exists( $filePath ) )->toBeTrue();
 } );
 
-test( 'vue composable file exists', function (): void {
-	$filePath = __DIR__ . '/../../resources/js/vue/useAnalyticsApi.ts';
+test( 'vue composable files exist', function ( string $composable ): void {
+	$filePath = __DIR__ . "/../../resources/js/vue/{$composable}.ts";
 
 	expect( file_exists( $filePath ) )->toBeTrue();
-} );
+} )->with( [
+	'useAnalyticsApi',
+	'useConsent',
+] );
 
 test( 'vue components publish to correct destination', function (): void {
 	$publishes   = AnalyticsServiceProvider::pathsToPublish( AnalyticsServiceProvider::class, 'analytics-vue' );
@@ -75,5 +88,9 @@ test( 'vue barrel export references all components', function (): void {
 		->toContain( 'PageAnalytics' )
 		->toContain( 'SiteSelector' )
 		->toContain( 'MultiTenantDashboard' )
-		->toContain( 'useAnalyticsApi' );
+		->toContain( 'ConsentBanner' )
+		->toContain( 'ConsentPreferences' )
+		->toContain( 'ConsentStatus' )
+		->toContain( 'useAnalyticsApi' )
+		->toContain( 'useConsent' );
 } );


### PR DESCRIPTION
## Description

Add React and Vue consent management components that provide a native UI layer for the existing consent API endpoints. Components support GDPR and CCPA compliance modes from the package config.

**Closes:** #34

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #34

## Motivation and Context

The analytics package includes GDPR-compliant consent management (ConsentService, Consent model, consent API endpoints), but the consent UI previously only existed as Livewire/Blade components. React and Vue applications need native consent UI components.

## Changes Made

- Added `useConsent` React hook and Vue composable for programmatic consent management
- Added `ConsentBanner` — GDPR/CCPA cookie consent banner with accept/reject/customize
- Added `ConsentPreferences` — detailed per-category consent preferences panel
- Added `ConsentStatus` — compact consent state indicator with manage callback
- Updated `ConsentStatusItem` type to match actual API response shape (added `name`, `description`, `required` fields)
- Added `ConsentUpdateRequest` and `ConsentUpdateResponse` types
- Updated barrel exports for both React and Vue
- Components use `@artisanpack-ui/react` and `@artisanpack-ui/vue` (Button, Card, Toggle, Badge)
- SSR-safe with guarded `localStorage`/`document` access
- Optimistic local updates with server rollback on failure
- Support `initialCategories`/`initialConsentRequired` props for SSR and demo use

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4.3
- Project Version: 1.1.0-dev

**Tests Performed:**
1. All 38 React/Vue component tests pass (file existence, barrel exports, consent components)
2. All 10 ConsentService tests pass
3. Visual testing in dev app with sample consent categories
4. Verified ConsentBanner show/hide, ConsentPreferences toggles, ConsentStatus indicator

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** Banner uses `role="dialog"`, `aria-modal`, `aria-labelledby`, and `aria-expanded` for details toggle. Toggle components inherit accessibility from @artisanpack-ui packages.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Updated `ReactComponentsTest.php` and `VueComponentsTest.php` with tests for consent component existence, hook/composable existence, and barrel export references.

## Documentation

- [x] Inline code documentation added

**Documentation details:** All components, hooks, composables, interfaces, and functions have JSDoc/TSDoc comments with `@since 1.1.0` tags.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added complete consent UI for React and Vue: banner (accept/reject/customize), preferences panel (per‑category toggles, save), and status badge with optional Manage action. Labels, position, and visibility behavior configurable; required categories are locked.
  * Added a consent hook/composable to manage consent state, local persistence, and server synchronization; exported from React/Vue barrels.

* **Types**
  * Updated consent API request/response shapes and category metadata.

* **Tests**
  * Added tests asserting new consent components and composables/hooks are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->