### PR TITLE
fix: give analytics foreign keys explicit names for MySQL (#43)

### DIFF
--- a/database/migrations/2025_01_01_000002_create_analytics_visitors_table.php
+++ b/database/migrations/2025_01_01_000002_create_analytics_visitors_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
 	{
 		Schema::create( 'analytics_visitors', function ( Blueprint $table ) {
 			$table->uuid( 'id' )->primary();
-			$table->foreignId( 'site_id' )->nullable()->constrained( 'analytics_sites' )->nullOnDelete()->index();
+			$table->foreignId( 'site_id' )->nullable()->index();
 			$table->string( 'fingerprint', 64 );
 			$table->foreignId( 'user_id' )->nullable()->index();
 
@@ -65,6 +65,12 @@ return new class extends Migration
 			$table->string( 'tenant_id' )->nullable()->index();
 
 			$table->timestamps();
+
+			// Foreign keys
+			$table->foreign( 'site_id', 'analytics_visitors_site_id_fk' )
+				->references( 'id' )
+				->on( 'analytics_sites' )
+				->nullOnDelete();
 
 			// Indexes
 			$table->unique( [ 'site_id', 'fingerprint' ] );

--- a/database/migrations/2025_01_01_000003_create_analytics_sessions_table.php
+++ b/database/migrations/2025_01_01_000003_create_analytics_sessions_table.php
@@ -66,12 +66,12 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign keys
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_sessions_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_sessions_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->cascadeOnDelete();

--- a/database/migrations/2025_01_01_000004_create_analytics_page_views_table.php
+++ b/database/migrations/2025_01_01_000004_create_analytics_page_views_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
 	{
 		Schema::create( 'analytics_page_views', function ( Blueprint $table ) {
 			$table->id();
-			$table->foreignId( 'site_id' )->nullable()->constrained( 'analytics_sites' )->nullOnDelete()->index();
+			$table->foreignId( 'site_id' )->nullable()->index();
 			$table->uuid( 'session_id' );
 			$table->uuid( 'visitor_id' );
 
@@ -56,12 +56,17 @@ return new class extends Migration
 			$table->timestamp( 'created_at' )->useCurrent();
 
 			// Foreign keys
-			$table->foreign( 'session_id' )
+			$table->foreign( 'site_id', 'analytics_page_views_site_id_fk' )
+				->references( 'id' )
+				->on( 'analytics_sites' )
+				->nullOnDelete();
+
+			$table->foreign( 'session_id', 'analytics_page_views_session_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sessions' )
 				->cascadeOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_page_views_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->cascadeOnDelete();

--- a/database/migrations/2025_01_01_000005_create_analytics_events_table.php
+++ b/database/migrations/2025_01_01_000005_create_analytics_events_table.php
@@ -49,17 +49,17 @@ return new class extends Migration
 			$table->timestamp( 'created_at' )->useCurrent();
 
 			// Foreign keys
-			$table->foreign( 'session_id' )
+			$table->foreign( 'session_id', 'analytics_events_session_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sessions' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_events_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->nullOnDelete();
 
-			$table->foreign( 'page_view_id' )
+			$table->foreign( 'page_view_id', 'analytics_events_page_view_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_page_views' )
 				->nullOnDelete();

--- a/database/migrations/2025_01_01_000006_create_analytics_goals_table.php
+++ b/database/migrations/2025_01_01_000006_create_analytics_goals_table.php
@@ -51,7 +51,7 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign key
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_goals_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();

--- a/database/migrations/2025_01_01_000007_create_analytics_conversions_table.php
+++ b/database/migrations/2025_01_01_000007_create_analytics_conversions_table.php
@@ -41,32 +41,32 @@ return new class extends Migration
 			$table->timestamp( 'created_at' )->useCurrent();
 
 			// Foreign keys
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_conversions_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();
 
-			$table->foreign( 'goal_id' )
+			$table->foreign( 'goal_id', 'analytics_conversions_goal_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_goals' )
 				->cascadeOnDelete();
 
-			$table->foreign( 'session_id' )
+			$table->foreign( 'session_id', 'analytics_conversions_session_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sessions' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_conversions_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->nullOnDelete();
 
-			$table->foreign( 'event_id' )
+			$table->foreign( 'event_id', 'analytics_conversions_event_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_events' )
 				->nullOnDelete();
 
-			$table->foreign( 'page_view_id' )
+			$table->foreign( 'page_view_id', 'analytics_conversions_page_view_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_page_views' )
 				->nullOnDelete();

--- a/database/migrations/2025_01_01_000008_create_analytics_consents_table.php
+++ b/database/migrations/2025_01_01_000008_create_analytics_consents_table.php
@@ -51,12 +51,12 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign keys
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_consents_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_consents_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->cascadeOnDelete();

--- a/database/migrations/2025_01_01_000009_create_analytics_aggregates_table.php
+++ b/database/migrations/2025_01_01_000009_create_analytics_aggregates_table.php
@@ -49,7 +49,7 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign key
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_aggregates_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();

--- a/tests/Feature/MigrationForeignKeyNamesTest.php
+++ b/tests/Feature/MigrationForeignKeyNamesTest.php
@@ -32,16 +32,28 @@ function analyticsCompileMigration( string $migrationFile ): array
 		 */
 		public array $captured = [];
 
+		/**
+		 * Report a fixed MySQL version so the grammar compiles without a live server.
+		 */
 		public function getServerVersion(): string
 		{
 			return '8.0.30';
 		}
 
+		/**
+		 * Always compile as MySQL rather than MariaDB.
+		 */
 		public function isMaria(): bool
 		{
 			return false;
 		}
 
+		/**
+		 * Capture compiled DDL instead of executing it against a database.
+		 *
+		 * @param string               $query
+		 * @param array<string, mixed> $bindings
+		 */
 		public function statement( $query, $bindings = [] ): bool
 		{
 			$this->captured[] = $query;

--- a/tests/Feature/MigrationForeignKeyNamesTest.php
+++ b/tests/Feature/MigrationForeignKeyNamesTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Regression coverage for issue #43.
+ *
+ * Compiles every analytics migration against the MySQL schema grammar and
+ * asserts that every foreign key carries an explicit, deterministic, unique
+ * name. Previously the `->constrained()->nullOnDelete()->index()` chain set
+ * `index => true` on the ForeignKeyDefinition, which MySQL rendered as the
+ * literal constraint name `1`, colliding with the next unnamed key and
+ * breaking `migrate:fresh` on MySQL 8.
+ *
+ * The migrations are compiled against a fake MySQL connection that captures
+ * the generated DDL instead of executing it, so the test needs no live
+ * database server while still exercising the real MySQL grammar.
+ */
+
+/**
+ * Compile a migration's up() against the MySQL grammar and return its DDL.
+ *
+ * @return array<int, string> The SQL statements the migration generates.
+ */
+function analyticsCompileMigration( string $migrationFile ): array
+{
+	$connection = new class( new PDO( 'sqlite::memory:' ) ) extends Illuminate\Database\MySqlConnection {
+		/**
+		 * @var array<int, string>
+		 */
+		public array $captured = [];
+
+		public function getServerVersion(): string
+		{
+			return '8.0.30';
+		}
+
+		public function isMaria(): bool
+		{
+			return false;
+		}
+
+		public function statement( $query, $bindings = [] ): bool
+		{
+			$this->captured[] = $query;
+
+			return true;
+		}
+	};
+
+	$originalDefault    = config( 'database.default' );
+	$originalConnection = config( 'database.connections.mysql_fake' );
+
+	try {
+		config()->set( 'database.connections.mysql_fake', [ 'driver' => 'mysql', 'database' => 'test', 'prefix' => '' ] );
+		DB::extend( 'mysql_fake', fn (): Illuminate\Database\Connection => $connection );
+		DB::purge( 'mysql_fake' );
+		config()->set( 'database.default', 'mysql_fake' );
+
+		$migration = require $migrationFile;
+		$migration->up();
+
+		return $connection->captured;
+	} finally {
+		config()->set( 'database.default', $originalDefault );
+		config()->set( 'database.connections.mysql_fake', $originalConnection );
+		DB::purge( 'mysql_fake' );
+	}
+}
+
+/**
+ * Extract the foreign key constraint names from compiled DDL.
+ *
+ * @param array<int, string> $statements
+ *
+ * @return array<int, string>
+ */
+function analyticsForeignKeyNames( array $statements ): array
+{
+	$names = [];
+
+	foreach ( $statements as $statement ) {
+		if ( preg_match_all( '/add constraint `([^`]+)` foreign key/', $statement, $matches ) ) {
+			foreach ( $matches[1] as $name ) {
+				$names[] = $name;
+			}
+		}
+	}
+
+	return $names;
+}
+
+$migrationFiles = glob( dirname( __DIR__, 2 ) . '/database/migrations/2025_01_01_*.php' );
+
+if ( false === $migrationFiles || [] === $migrationFiles ) {
+	throw new RuntimeException( 'No analytics migration files were found to test.' );
+}
+
+test( 'every analytics foreign key has an explicit, non-numeric name', function ( string $migrationFile ): void {
+	$statements = analyticsCompileMigration( $migrationFile );
+
+	expect( $statements )->not->toBeEmpty();
+
+	$names = analyticsForeignKeyNames( $statements );
+
+	foreach ( $names as $name ) {
+		expect( $name )->not->toMatch( '/^\d+$/' );
+		expect( $name )->toStartWith( 'analytics_' );
+		expect( $name )->toEndWith( '_fk' );
+	}
+} )->with( $migrationFiles );
+
+test( 'foreign key names are unique within each analytics table', function ( string $migrationFile ): void {
+	$names = analyticsForeignKeyNames( analyticsCompileMigration( $migrationFile ) );
+
+	expect( $names )->toEqual( array_values( array_unique( $names ) ) );
+} )->with( $migrationFiles );
+
+test( 'analytics_page_views declares the three named foreign keys from issue #43', function (): void {
+	$pageViews = dirname( __DIR__, 2 ) . '/database/migrations/2025_01_01_000004_create_analytics_page_views_table.php';
+
+	$names = analyticsForeignKeyNames( analyticsCompileMigration( $pageViews ) );
+
+	expect( $names )->toContain(
+		'analytics_page_views_site_id_fk',
+		'analytics_page_views_session_id_fk',
+		'analytics_page_views_visitor_id_fk',
+	);
+} );


### PR DESCRIPTION
## Description

`php artisan migrate:fresh` failed against MySQL 8 with `SQLSTATE[HY000]: General error: 1826 Duplicate foreign key constraint name '1'` on `analytics_page_views` (and was at risk on other analytics tables).

Root cause: in the `analytics_visitors` and `analytics_page_views` migrations, the chain `->foreignId('site_id')->constrained(...)->nullOnDelete()->index()` set `index => true` on the resulting `ForeignKeyDefinition`. MySQL rendered that boolean as the literal constraint name `` `1` ``, which then collided with the next auto-named foreign key in the same table. SQLite ignored it, so it only surfaced on MySQL.

**Closes:** #43

## Type of Change

- [x] Bug fix (fixes an issue)

## Related Issue

**Issue:** #43

## Motivation and Context

The dev-app had to add `artisanpack-ui/analytics` to `extra.laravel.dont-discover` to unblock `migrate:fresh`. This PR fixes the underlying migrations so the workaround can be removed and the package migrates cleanly on MySQL 8.

## Changes Made

- Removed the broken `->constrained()->nullOnDelete()->index()` chain from `analytics_visitors` and `analytics_page_views`; declared those foreign keys explicitly instead.
- Gave every foreign key across all analytics migrations an explicit, deterministic name (`analytics_{table}_{column}_fk`) so creation, rollback, and re-runs are stable.
- Added `analytics_page_views_site_id_fk`, `analytics_page_views_session_id_fk`, and `analytics_page_views_visitor_id_fk` as named constraints.
- Added a regression test that compiles every analytics migration through the real MySQL schema grammar (offline, no live server) and asserts each foreign key name is explicit, non-numeric, and unique.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS (Darwin 25.5.0)
- PHP Version: 8.4
- Project Version: 1.1.1
- Database: MySQL 8 (via the dev-app) + SQLite (package suite)

**Tests Performed:**
1. Ran the new regression test; verified it fails on the old buggy chain and passes on the fix.
2. Ran the full package suite: 402 passed, 2 skipped (1001 assertions).
3. Removed the `dont-discover` workaround in the dev-app and ran `php artisan migrate:fresh` against MySQL 8 — all 9 analytics tables created cleanly with no duplicate-constraint error.
4. Confirmed via `information_schema.KEY_COLUMN_USAGE` that all 19 analytics foreign keys exist with their deterministic names.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** N/A — database migration change with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/MigrationForeignKeyNamesTest.php` compiles each migration against the MySQL grammar via a capturing fake connection and asserts foreign-key constraint names are explicit, non-numeric, and unique.

## Documentation

- [ ] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** None required; behavior unchanged aside from deterministic constraint names.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Database**
  * Standardized foreign-key naming across analytics tables using explicit, consistent constraint identifiers

* **Tests**
  * Added a feature test to validate foreign-key constraint names are present, uniquely named, and follow the expected naming pattern

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/analytics/pull/48?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->