### PR TITLE
Release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2026-05-20
+
+### Fixed
+
+- **MySQL migration foreign key constraint name collision**: Gave the analytics foreign keys explicit names so migrations no longer fail on MySQL with duplicate auto-generated constraint names.
+
 ## [1.1.0] - 2026-04-10
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Privacy-first analytics package for Laravel with local database storage, external provider support (GA4, Plausible), and a beautiful Livewire dashboard.",
   "type": "library",
   "license": "MIT",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "keywords": [
     "laravel",
     "analytics",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fa19f26f412e4fa5523eed12296db4c4",
+    "content-hash": "4eb721cb1b8da7d515c5c7d4b724d185",
     "packages": [
         {
             "name": "brick/math",

--- a/database/migrations/2025_01_01_000002_create_analytics_visitors_table.php
+++ b/database/migrations/2025_01_01_000002_create_analytics_visitors_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
 	{
 		Schema::create( 'analytics_visitors', function ( Blueprint $table ) {
 			$table->uuid( 'id' )->primary();
-			$table->foreignId( 'site_id' )->nullable()->constrained( 'analytics_sites' )->nullOnDelete()->index();
+			$table->foreignId( 'site_id' )->nullable()->index();
 			$table->string( 'fingerprint', 64 );
 			$table->foreignId( 'user_id' )->nullable()->index();
 
@@ -65,6 +65,12 @@ return new class extends Migration
 			$table->string( 'tenant_id' )->nullable()->index();
 
 			$table->timestamps();
+
+			// Foreign keys
+			$table->foreign( 'site_id', 'analytics_visitors_site_id_fk' )
+				->references( 'id' )
+				->on( 'analytics_sites' )
+				->nullOnDelete();
 
 			// Indexes
 			$table->unique( [ 'site_id', 'fingerprint' ] );

--- a/database/migrations/2025_01_01_000003_create_analytics_sessions_table.php
+++ b/database/migrations/2025_01_01_000003_create_analytics_sessions_table.php
@@ -66,12 +66,12 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign keys
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_sessions_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_sessions_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->cascadeOnDelete();

--- a/database/migrations/2025_01_01_000004_create_analytics_page_views_table.php
+++ b/database/migrations/2025_01_01_000004_create_analytics_page_views_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
 	{
 		Schema::create( 'analytics_page_views', function ( Blueprint $table ) {
 			$table->id();
-			$table->foreignId( 'site_id' )->nullable()->constrained( 'analytics_sites' )->nullOnDelete()->index();
+			$table->foreignId( 'site_id' )->nullable()->index();
 			$table->uuid( 'session_id' );
 			$table->uuid( 'visitor_id' );
 
@@ -56,12 +56,17 @@ return new class extends Migration
 			$table->timestamp( 'created_at' )->useCurrent();
 
 			// Foreign keys
-			$table->foreign( 'session_id' )
+			$table->foreign( 'site_id', 'analytics_page_views_site_id_fk' )
+				->references( 'id' )
+				->on( 'analytics_sites' )
+				->nullOnDelete();
+
+			$table->foreign( 'session_id', 'analytics_page_views_session_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sessions' )
 				->cascadeOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_page_views_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->cascadeOnDelete();

--- a/database/migrations/2025_01_01_000005_create_analytics_events_table.php
+++ b/database/migrations/2025_01_01_000005_create_analytics_events_table.php
@@ -49,17 +49,17 @@ return new class extends Migration
 			$table->timestamp( 'created_at' )->useCurrent();
 
 			// Foreign keys
-			$table->foreign( 'session_id' )
+			$table->foreign( 'session_id', 'analytics_events_session_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sessions' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_events_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->nullOnDelete();
 
-			$table->foreign( 'page_view_id' )
+			$table->foreign( 'page_view_id', 'analytics_events_page_view_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_page_views' )
 				->nullOnDelete();

--- a/database/migrations/2025_01_01_000006_create_analytics_goals_table.php
+++ b/database/migrations/2025_01_01_000006_create_analytics_goals_table.php
@@ -51,7 +51,7 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign key
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_goals_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();

--- a/database/migrations/2025_01_01_000007_create_analytics_conversions_table.php
+++ b/database/migrations/2025_01_01_000007_create_analytics_conversions_table.php
@@ -41,32 +41,32 @@ return new class extends Migration
 			$table->timestamp( 'created_at' )->useCurrent();
 
 			// Foreign keys
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_conversions_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();
 
-			$table->foreign( 'goal_id' )
+			$table->foreign( 'goal_id', 'analytics_conversions_goal_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_goals' )
 				->cascadeOnDelete();
 
-			$table->foreign( 'session_id' )
+			$table->foreign( 'session_id', 'analytics_conversions_session_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sessions' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_conversions_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->nullOnDelete();
 
-			$table->foreign( 'event_id' )
+			$table->foreign( 'event_id', 'analytics_conversions_event_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_events' )
 				->nullOnDelete();
 
-			$table->foreign( 'page_view_id' )
+			$table->foreign( 'page_view_id', 'analytics_conversions_page_view_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_page_views' )
 				->nullOnDelete();

--- a/database/migrations/2025_01_01_000008_create_analytics_consents_table.php
+++ b/database/migrations/2025_01_01_000008_create_analytics_consents_table.php
@@ -51,12 +51,12 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign keys
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_consents_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();
 
-			$table->foreign( 'visitor_id' )
+			$table->foreign( 'visitor_id', 'analytics_consents_visitor_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_visitors' )
 				->cascadeOnDelete();

--- a/database/migrations/2025_01_01_000009_create_analytics_aggregates_table.php
+++ b/database/migrations/2025_01_01_000009_create_analytics_aggregates_table.php
@@ -49,7 +49,7 @@ return new class extends Migration
 			$table->timestamps();
 
 			// Foreign key
-			$table->foreign( 'site_id' )
+			$table->foreign( 'site_id', 'analytics_aggregates_site_id_fk' )
 				->references( 'id' )
 				->on( 'analytics_sites' )
 				->nullOnDelete();

--- a/tests/Feature/MigrationForeignKeyNamesTest.php
+++ b/tests/Feature/MigrationForeignKeyNamesTest.php
@@ -32,16 +32,28 @@ function analyticsCompileMigration( string $migrationFile ): array
 		 */
 		public array $captured = [];
 
+		/**
+		 * Report a fixed MySQL version so the grammar compiles without a live server.
+		 */
 		public function getServerVersion(): string
 		{
 			return '8.0.30';
 		}
 
+		/**
+		 * Always compile as MySQL rather than MariaDB.
+		 */
 		public function isMaria(): bool
 		{
 			return false;
 		}
 
+		/**
+		 * Capture compiled DDL instead of executing it against a database.
+		 *
+		 * @param string               $query
+		 * @param array<string, mixed> $bindings
+		 */
 		public function statement( $query, $bindings = [] ): bool
 		{
 			$this->captured[] = $query;

--- a/tests/Feature/MigrationForeignKeyNamesTest.php
+++ b/tests/Feature/MigrationForeignKeyNamesTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Regression coverage for issue #43.
+ *
+ * Compiles every analytics migration against the MySQL schema grammar and
+ * asserts that every foreign key carries an explicit, deterministic, unique
+ * name. Previously the `->constrained()->nullOnDelete()->index()` chain set
+ * `index => true` on the ForeignKeyDefinition, which MySQL rendered as the
+ * literal constraint name `1`, colliding with the next unnamed key and
+ * breaking `migrate:fresh` on MySQL 8.
+ *
+ * The migrations are compiled against a fake MySQL connection that captures
+ * the generated DDL instead of executing it, so the test needs no live
+ * database server while still exercising the real MySQL grammar.
+ */
+
+/**
+ * Compile a migration's up() against the MySQL grammar and return its DDL.
+ *
+ * @return array<int, string> The SQL statements the migration generates.
+ */
+function analyticsCompileMigration( string $migrationFile ): array
+{
+	$connection = new class( new PDO( 'sqlite::memory:' ) ) extends Illuminate\Database\MySqlConnection {
+		/**
+		 * @var array<int, string>
+		 */
+		public array $captured = [];
+
+		public function getServerVersion(): string
+		{
+			return '8.0.30';
+		}
+
+		public function isMaria(): bool
+		{
+			return false;
+		}
+
+		public function statement( $query, $bindings = [] ): bool
+		{
+			$this->captured[] = $query;
+
+			return true;
+		}
+	};
+
+	$originalDefault    = config( 'database.default' );
+	$originalConnection = config( 'database.connections.mysql_fake' );
+
+	try {
+		config()->set( 'database.connections.mysql_fake', [ 'driver' => 'mysql', 'database' => 'test', 'prefix' => '' ] );
+		DB::extend( 'mysql_fake', fn (): Illuminate\Database\Connection => $connection );
+		DB::purge( 'mysql_fake' );
+		config()->set( 'database.default', 'mysql_fake' );
+
+		$migration = require $migrationFile;
+		$migration->up();
+
+		return $connection->captured;
+	} finally {
+		config()->set( 'database.default', $originalDefault );
+		config()->set( 'database.connections.mysql_fake', $originalConnection );
+		DB::purge( 'mysql_fake' );
+	}
+}
+
+/**
+ * Extract the foreign key constraint names from compiled DDL.
+ *
+ * @param array<int, string> $statements
+ *
+ * @return array<int, string>
+ */
+function analyticsForeignKeyNames( array $statements ): array
+{
+	$names = [];
+
+	foreach ( $statements as $statement ) {
+		if ( preg_match_all( '/add constraint `([^`]+)` foreign key/', $statement, $matches ) ) {
+			foreach ( $matches[1] as $name ) {
+				$names[] = $name;
+			}
+		}
+	}
+
+	return $names;
+}
+
+$migrationFiles = glob( dirname( __DIR__, 2 ) . '/database/migrations/2025_01_01_*.php' );
+
+if ( false === $migrationFiles || [] === $migrationFiles ) {
+	throw new RuntimeException( 'No analytics migration files were found to test.' );
+}
+
+test( 'every analytics foreign key has an explicit, non-numeric name', function ( string $migrationFile ): void {
+	$statements = analyticsCompileMigration( $migrationFile );
+
+	expect( $statements )->not->toBeEmpty();
+
+	$names = analyticsForeignKeyNames( $statements );
+
+	foreach ( $names as $name ) {
+		expect( $name )->not->toMatch( '/^\d+$/' );
+		expect( $name )->toStartWith( 'analytics_' );
+		expect( $name )->toEndWith( '_fk' );
+	}
+} )->with( $migrationFiles );
+
+test( 'foreign key names are unique within each analytics table', function ( string $migrationFile ): void {
+	$names = analyticsForeignKeyNames( analyticsCompileMigration( $migrationFile ) );
+
+	expect( $names )->toEqual( array_values( array_unique( $names ) ) );
+} )->with( $migrationFiles );
+
+test( 'analytics_page_views declares the three named foreign keys from issue #43', function (): void {
+	$pageViews = dirname( __DIR__, 2 ) . '/database/migrations/2025_01_01_000004_create_analytics_page_views_table.php';
+
+	$names = analyticsForeignKeyNames( analyticsCompileMigration( $pageViews ) );
+
+	expect( $names )->toContain(
+		'analytics_page_views_site_id_fk',
+		'analytics_page_views_session_id_fk',
+		'analytics_page_views_visitor_id_fk',
+	);
+} );


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.1.1
- **Release Date:** 2026-05-20
- **Release Type:** Patch
- **Release Branch:** `release/1.1.1`
- **Target Branch:** `main`

## Release Summary

Patch release fixing a MySQL migration failure caused by duplicate auto-generated foreign key constraint names. The analytics foreign keys now carry explicit names so migrations run cleanly on MySQL.

## Changelog

### Fixed
- **MySQL migration foreign key constraint name collision**: Gave the analytics foreign keys explicit names so migrations no longer fail on MySQL with duplicate auto-generated constraint names.

## Breaking Changes

- [x] No breaking changes

## Testing Checklist

- [x] All automated tests passing (402 passed, 2 skipped, 1001 assertions)
- [x] Security scan completed (see notes)
- [x] Database migrations tested

**Testing notes:** php-cs-fixer clean (0/160 fixed), phpcs clean (160/160), full Pest suite green.

## Documentation Checklist

- [x] CHANGELOG updated

## Pre-Release Checklist

- [x] Version number updated in all necessary files (composer.json -> 1.1.1)
- [x] Release branch created/updated: `release/1.1.1`
- [x] Dependencies updated and tested (composer.lock synced)

## Notes

Dependency audit surfaced 10 advisories across 6 packages, including `symfony/yaml` (CVE-2026-45133, stack exhaustion via unbounded recursion). These are transitive/dev dependencies and not introduced by this release - flagged here for awareness but not blocking the patch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved MySQL migration foreign key constraint name collision by explicitly naming analytics foreign keys to prevent duplicate auto-generated constraint names during migrations.

* **Tests**
  * Added regression tests to verify foreign key constraint naming and prevent duplicate constraint issues.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/analytics/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->