### PR TITLE
feat: add BotDetector service with confidence scoring

### DIFF
--- a/config/analytics.php
+++ b/config/analytics.php
@@ -441,6 +441,73 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Bot Detection
+    |--------------------------------------------------------------------------
+    |
+    | Settings for the multi-signal bot detection system. The BotDetector
+    | service combines user agent, JavaScript fingerprint, engagement, and
+    | request pattern signals into a confidence score (0-100). Visitors that
+    | meet or exceed the threshold are considered bots.
+    |
+    */
+    'bot_detection' => [
+        /*
+        |----------------------------------------------------------------------
+        | Enabled
+        |----------------------------------------------------------------------
+        |
+        | Master switch for behavioral bot detection. When disabled, the
+        | BotDetector never flags visitors as bots.
+        |
+        */
+        'enabled' => env( 'ANALYTICS_BOT_DETECTION_ENABLED', true ),
+
+        /*
+        |----------------------------------------------------------------------
+        | Threshold
+        |----------------------------------------------------------------------
+        |
+        | The minimum confidence score (0-100) required to flag a visitor as
+        | a bot. Lower values are more aggressive; higher values reduce false
+        | positives.
+        |
+        */
+        'threshold' => env( 'ANALYTICS_BOT_DETECTION_THRESHOLD', 70 ),
+
+        /*
+        |----------------------------------------------------------------------
+        | Whitelist
+        |----------------------------------------------------------------------
+        |
+        | User agents and IP addresses that bypass bot scoring entirely.
+        | User agents are matched as case-insensitive substrings; IPs must
+        | match exactly.
+        |
+        */
+        'whitelist' => [
+            'user_agents' => [],
+            'ips'         => [],
+        ],
+
+        /*
+        |----------------------------------------------------------------------
+        | Signals
+        |----------------------------------------------------------------------
+        |
+        | Toggle individual signal categories on or off. Disabled categories
+        | contribute zero points to the confidence score.
+        |
+        */
+        'signals' => [
+            'user_agent'       => true,
+            'engagement'       => true,
+            'request_patterns' => true,
+            'js_fingerprint'   => true,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Data Retention
     |--------------------------------------------------------------------------
     |

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -22,10 +22,12 @@ use ArtisanPackUI\Analytics\Http\Middleware\PrivacyFilter;
 use ArtisanPackUI\Analytics\Http\Middleware\ResolveSite;
 use ArtisanPackUI\Analytics\Http\Middleware\TenantResolver;
 use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
+use ArtisanPackUI\Analytics\Services\BotDetector;
 use ArtisanPackUI\Analytics\Services\ConsentService;
 use ArtisanPackUI\Analytics\Services\CrossTenantReporting;
 use ArtisanPackUI\Analytics\Services\DataDeletionService;
 use ArtisanPackUI\Analytics\Services\DataExportService;
+use ArtisanPackUI\Analytics\Services\DeviceDetector;
 use ArtisanPackUI\Analytics\Services\EventProcessor;
 use ArtisanPackUI\Analytics\Services\FunnelAnalyzer;
 use ArtisanPackUI\Analytics\Services\GoalMatcher;
@@ -170,6 +172,13 @@ class AnalyticsServiceProvider extends ServiceProvider
         // Register CrossTenantReporting
         $this->app->singleton( CrossTenantReporting::class, function () {
             return new CrossTenantReporting;
+        } );
+
+        // Register the BotDetector service
+        $this->app->singleton( BotDetector::class, function ( $app ) {
+            return new BotDetector(
+                $app->make( DeviceDetector::class ),
+            );
         } );
     }
 

--- a/src/Services/BotDetector.php
+++ b/src/Services/BotDetector.php
@@ -1,0 +1,545 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Services;
+
+use ArtisanPackUI\Analytics\Models\PageView;
+use ArtisanPackUI\Analytics\Models\Visitor;
+use Illuminate\Support\Collection;
+
+/**
+ * Bot detection service.
+ *
+ * Implements a multi-signal confidence scoring system (0-100) for identifying
+ * bot traffic. Each signal contributes points toward a bot confidence score
+ * which is summed and capped at 100. A configurable threshold (default 70)
+ * determines whether a visitor is considered a bot.
+ *
+ * @since   1.2.0
+ *
+ * @package ArtisanPackUI\Analytics\Services
+ */
+class BotDetector
+{
+	/**
+	 * Score awarded when the user agent matches a known bot pattern.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_KNOWN_BOT = 100;
+
+	/**
+	 * Score awarded when the user agent is empty or missing.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_EMPTY_USER_AGENT = 80;
+
+	/**
+	 * Score awarded when headless browser indicators are present.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_HEADLESS = 40;
+
+	/**
+	 * Score awarded when WebDriver automation is detected.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_WEBDRIVER = 50;
+
+	/**
+	 * Score awarded when expected browser APIs are missing.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_MISSING_APIS = 30;
+
+	/**
+	 * Score awarded for zero engagement across 3 or more page views.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_ZERO_ENGAGEMENT = 35;
+
+	/**
+	 * Score awarded for rapid sequential requests.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_RAPID_REQUESTS = 30;
+
+	/**
+	 * Score awarded when no referrer variation exists across a session.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_NO_REFERRER_VARIATION = 15;
+
+	/**
+	 * Score awarded for perfectly timed request intervals.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_PERFECT_INTERVALS = 20;
+
+	/**
+	 * Score awarded for suspiciously short page view times.
+	 *
+	 * @var int
+	 */
+	protected const SCORE_SHORT_PAGE_VIEWS = 25;
+
+	/**
+	 * Maximum possible bot confidence score.
+	 *
+	 * @var int
+	 */
+	protected const MAX_SCORE = 100;
+
+	/**
+	 * Create a new bot detector instance.
+	 *
+	 * @param DeviceDetector $deviceDetector The device detector used for user agent matching.
+	 *
+	 * @since 1.2.0
+	 */
+	public function __construct( protected DeviceDetector $deviceDetector )
+	{
+	}
+
+	/**
+	 * Calculate the bot confidence score for a visitor.
+	 *
+	 * @param Visitor $visitor The visitor to score.
+	 *
+	 * @return int A confidence score between 0 and 100.
+	 *
+	 * @since 1.2.0
+	 */
+	public function score( Visitor $visitor ): int
+	{
+		if ( $this->isWhitelisted( $visitor ) ) {
+			return 0;
+		}
+
+		if ( $this->signalEnabled( 'user_agent' ) && $this->deviceDetector->isBot( $visitor->user_agent ) ) {
+			return self::SCORE_KNOWN_BOT;
+		}
+
+		$score = 0;
+
+		$score += $this->userAgentScore( $visitor );
+		$score += $this->fingerprintScore( $visitor );
+		$score += $this->engagementScore( $visitor );
+		$score += $this->requestPatternScore( $visitor );
+
+		return min( $score, self::MAX_SCORE );
+	}
+
+	/**
+	 * Determine whether a visitor should be considered a bot.
+	 *
+	 * @param Visitor $visitor The visitor to evaluate.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	public function isBot( Visitor $visitor ): bool
+	{
+		if ( ! $this->enabled() ) {
+			return false;
+		}
+
+		if ( $this->isWhitelisted( $visitor ) ) {
+			return false;
+		}
+
+		return $this->score( $visitor ) >= $this->threshold();
+	}
+
+	/**
+	 * Get the configured bot confidence threshold.
+	 *
+	 * @return int
+	 *
+	 * @since 1.2.0
+	 */
+	public function threshold(): int
+	{
+		return (int) config( 'artisanpack.analytics.bot_detection.threshold', 70 );
+	}
+
+	/**
+	 * Determine whether bot detection is enabled.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	public function enabled(): bool
+	{
+		return (bool) config( 'artisanpack.analytics.bot_detection.enabled', true );
+	}
+
+	/**
+	 * Determine whether a visitor is whitelisted from bot scoring.
+	 *
+	 * @param Visitor $visitor The visitor to check.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	public function isWhitelisted( Visitor $visitor ): bool
+	{
+		/** @var array<int, string> $userAgents */
+		$userAgents = config( 'artisanpack.analytics.bot_detection.whitelist.user_agents', [] );
+
+		if ( null !== $visitor->user_agent && '' !== $visitor->user_agent ) {
+			$userAgentLower = strtolower( $visitor->user_agent );
+
+			foreach ( $userAgents as $pattern ) {
+				if ( '' !== $pattern && str_contains( $userAgentLower, strtolower( $pattern ) ) ) {
+					return true;
+				}
+			}
+		}
+
+		/** @var array<int, string> $ips */
+		$ips = config( 'artisanpack.analytics.bot_detection.whitelist.ips', [] );
+
+		if ( null !== $visitor->ip_address && in_array( $visitor->ip_address, $ips, true ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Score user agent signals that do not match a known bot pattern.
+	 *
+	 * @param Visitor $visitor The visitor to score.
+	 *
+	 * @return int
+	 *
+	 * @since 1.2.0
+	 */
+	protected function userAgentScore( Visitor $visitor ): int
+	{
+		if ( ! $this->signalEnabled( 'user_agent' ) ) {
+			return 0;
+		}
+
+		if ( null === $visitor->user_agent || '' === trim( $visitor->user_agent ) ) {
+			return self::SCORE_EMPTY_USER_AGENT;
+		}
+
+		return 0;
+	}
+
+	/**
+	 * Score JavaScript fingerprint signals.
+	 *
+	 * @param Visitor $visitor The visitor to score.
+	 *
+	 * @return int
+	 *
+	 * @since 1.2.0
+	 */
+	protected function fingerprintScore( Visitor $visitor ): int
+	{
+		if ( ! $this->signalEnabled( 'js_fingerprint' ) ) {
+			return 0;
+		}
+
+		$pageViews = $this->pageViews( $visitor );
+		$score     = 0;
+
+		if ( $this->fingerprintFlag( $pageViews, 'webdriver' ) ) {
+			$score += self::SCORE_WEBDRIVER;
+		}
+
+		if ( $this->fingerprintFlag( $pageViews, 'headless' ) ) {
+			$score += self::SCORE_HEADLESS;
+		}
+
+		if ( $this->fingerprintFlag( $pageViews, 'missing_apis' ) ) {
+			$score += self::SCORE_MISSING_APIS;
+		}
+
+		return $score;
+	}
+
+	/**
+	 * Score engagement signals.
+	 *
+	 * @param Visitor $visitor The visitor to score.
+	 *
+	 * @return int
+	 *
+	 * @since 1.2.0
+	 */
+	protected function engagementScore( Visitor $visitor ): int
+	{
+		if ( ! $this->signalEnabled( 'engagement' ) ) {
+			return 0;
+		}
+
+		$pageViews = $this->pageViews( $visitor );
+		$score     = 0;
+
+		if ( $this->hasZeroEngagement( $pageViews ) ) {
+			$score += self::SCORE_ZERO_ENGAGEMENT;
+		}
+
+		if ( $this->hasShortPageViews( $pageViews ) ) {
+			$score += self::SCORE_SHORT_PAGE_VIEWS;
+		}
+
+		return $score;
+	}
+
+	/**
+	 * Score request pattern signals.
+	 *
+	 * @param Visitor $visitor The visitor to score.
+	 *
+	 * @return int
+	 *
+	 * @since 1.2.0
+	 */
+	protected function requestPatternScore( Visitor $visitor ): int
+	{
+		if ( ! $this->signalEnabled( 'request_patterns' ) ) {
+			return 0;
+		}
+
+		$pageViews = $this->pageViews( $visitor );
+		$score     = 0;
+
+		if ( $this->hasRapidRequests( $pageViews ) ) {
+			$score += self::SCORE_RAPID_REQUESTS;
+		}
+
+		if ( $this->hasNoReferrerVariation( $pageViews ) ) {
+			$score += self::SCORE_NO_REFERRER_VARIATION;
+		}
+
+		if ( $this->hasPerfectIntervals( $pageViews ) ) {
+			$score += self::SCORE_PERFECT_INTERVALS;
+		}
+
+		return $score;
+	}
+
+	/**
+	 * Determine whether the visitor shows zero engagement across 3+ page views.
+	 *
+	 * @param Collection<int, PageView> $pageViews The visitor's page views.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	protected function hasZeroEngagement( Collection $pageViews ): bool
+	{
+		if ( $pageViews->count() < 3 ) {
+			return false;
+		}
+
+		foreach ( $pageViews as $pageView ) {
+			if ( (int) $pageView->engaged_time > 0 || (int) $pageView->scroll_depth > 0 ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Determine whether the visitor's average page view time is under one second.
+	 *
+	 * @param Collection<int, PageView> $pageViews The visitor's page views.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	protected function hasShortPageViews( Collection $pageViews ): bool
+	{
+		$times = $pageViews
+			->map( fn ( PageView $pageView ): ?int => $pageView->time_on_page )
+			->filter( fn ( ?int $time ): bool => null !== $time )
+			->values();
+
+		if ( $times->count() < 3 ) {
+			return false;
+		}
+
+		return $times->avg() < 1;
+	}
+
+	/**
+	 * Determine whether the visitor made requests faster than 10 pages per minute.
+	 *
+	 * @param Collection<int, PageView> $pageViews The visitor's page views.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	protected function hasRapidRequests( Collection $pageViews ): bool
+	{
+		$timestamps = $this->timestamps( $pageViews );
+
+		if ( $timestamps->count() < 2 ) {
+			return false;
+		}
+
+		$spanSeconds = $timestamps->last() - $timestamps->first();
+
+		if ( $spanSeconds <= 0 ) {
+			return true;
+		}
+
+		$pagesPerMinute = $timestamps->count() / ( $spanSeconds / 60 );
+
+		return $pagesPerMinute > 10;
+	}
+
+	/**
+	 * Determine whether the visitor used a single referrer across 3+ page views.
+	 *
+	 * @param Collection<int, PageView> $pageViews The visitor's page views.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	protected function hasNoReferrerVariation( Collection $pageViews ): bool
+	{
+		if ( $pageViews->count() < 3 ) {
+			return false;
+		}
+
+		return $pageViews
+			->map( fn ( PageView $pageView ): ?string => $pageView->referrer_path )
+			->unique()
+			->count() <= 1;
+	}
+
+	/**
+	 * Determine whether requests arrived at perfectly even intervals.
+	 *
+	 * @param Collection<int, PageView> $pageViews The visitor's page views.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	protected function hasPerfectIntervals( Collection $pageViews ): bool
+	{
+		$timestamps = $this->timestamps( $pageViews );
+
+		if ( $timestamps->count() < 3 ) {
+			return false;
+		}
+
+		$intervals = [];
+
+		for ( $index = 1; $index < $timestamps->count(); $index++ ) {
+			$intervals[] = $timestamps->get( $index ) - $timestamps->get( $index - 1 );
+		}
+
+		// Even intervals are only suspicious when there is an actual gap between requests.
+		if ( max( $intervals ) <= 0 ) {
+			return false;
+		}
+
+		return 1 === count( array_unique( $intervals ) );
+	}
+
+	/**
+	 * Get the visitor's page views as a collection.
+	 *
+	 * @param Visitor $visitor The visitor.
+	 *
+	 * @return Collection<int, PageView>
+	 *
+	 * @since 1.2.0
+	 */
+	protected function pageViews( Visitor $visitor ): Collection
+	{
+		/** @var Collection<int, PageView> $pageViews */
+		$pageViews = $visitor->pageViews;
+
+		return $pageViews;
+	}
+
+	/**
+	 * Get the sorted page view timestamps in epoch seconds.
+	 *
+	 * @param Collection<int, PageView> $pageViews The visitor's page views.
+	 *
+	 * @return Collection<int, int>
+	 *
+	 * @since 1.2.0
+	 */
+	protected function timestamps( Collection $pageViews ): Collection
+	{
+		return $pageViews
+			->map( fn ( PageView $pageView ): ?int => $pageView->created_at?->getTimestamp() )
+			->filter( fn ( ?int $timestamp ): bool => null !== $timestamp )
+			->sort()
+			->values();
+	}
+
+	/**
+	 * Determine whether any page view fingerprint reports the given flag.
+	 *
+	 * @param Collection<int, PageView> $pageViews The visitor's page views.
+	 * @param string                    $flag      The fingerprint flag key.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	protected function fingerprintFlag( Collection $pageViews, string $flag ): bool
+	{
+		foreach ( $pageViews as $pageView ) {
+			$customData = $pageView->custom_data;
+
+			if ( ! is_array( $customData ) ) {
+				continue;
+			}
+
+			$fingerprint = is_array( $customData['fingerprint'] ?? null )
+				? $customData['fingerprint']
+				: $customData;
+
+			if ( ! empty( $fingerprint[ $flag ] ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Determine whether a signal category is enabled in configuration.
+	 *
+	 * @param string $signal The signal category key.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.2.0
+	 */
+	protected function signalEnabled( string $signal ): bool
+	{
+		return (bool) config( "artisanpack.analytics.bot_detection.signals.{$signal}", true );
+	}
+}

--- a/tests/Unit/BotDetectorTest.php
+++ b/tests/Unit/BotDetectorTest.php
@@ -196,6 +196,36 @@ test( 'each signal category can be disabled independently', function (): void {
 	expect( $this->detector->score( $visitor ) )->toBe( 0 );
 } );
 
+test( 'disabling the engagement signal suppresses engagement scoring', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/a', 'created_at' => $base ],
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/b', 'created_at' => $base->copy()->addMinutes( 6 ) ],
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/c', 'created_at' => $base->copy()->addMinutes( 13 ) ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 35 );
+
+	config()->set( 'artisanpack.analytics.bot_detection.signals.engagement', false );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 0 );
+} );
+
+test( 'disabling the request patterns signal suppresses request pattern scoring', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/a', 'created_at' => $base ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/b', 'created_at' => $base->copy()->addMinutes( 10 ) ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/c', 'created_at' => $base->copy()->addMinutes( 20 ) ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 20 );
+
+	config()->set( 'artisanpack.analytics.bot_detection.signals.request_patterns', false );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 0 );
+} );
+
 test( 'disabling user agent signal stops empty user agent scoring', function (): void {
 	config()->set( 'artisanpack.analytics.bot_detection.signals.user_agent', false );
 

--- a/tests/Unit/BotDetectorTest.php
+++ b/tests/Unit/BotDetectorTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Models\PageView;
+use ArtisanPackUI\Analytics\Models\Visitor;
+use ArtisanPackUI\Analytics\Services\BotDetector;
+use ArtisanPackUI\Analytics\Services\DeviceDetector;
+use Illuminate\Support\Carbon;
+
+/**
+ * Build a visitor with a set of in-memory page views attached.
+ *
+ * @param array<string, mixed>             $attributes Visitor attributes.
+ * @param array<int, array<string, mixed>> $pageViews  Page view attribute sets.
+ *
+ * @return Visitor
+ */
+function makeVisitor( array $attributes = [], array $pageViews = [] ): Visitor
+{
+	$visitor = new Visitor( array_merge( [
+		'user_agent' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+		'ip_address' => '203.0.113.10',
+	], $attributes ) );
+
+	$views = collect( $pageViews )->map( fn ( array $data ): PageView => new PageView( $data ) );
+
+	$visitor->setRelation( 'pageViews', $views );
+
+	return $visitor;
+}
+
+beforeEach( function (): void {
+	config()->set( 'artisanpack.analytics.bot_detection', [
+		'enabled'   => true,
+		'threshold' => 70,
+		'whitelist' => [
+			'user_agents' => [],
+			'ips'         => [],
+		],
+		'signals' => [
+			'user_agent'       => true,
+			'engagement'       => true,
+			'request_patterns' => true,
+			'js_fingerprint'   => true,
+		],
+	] );
+
+	$this->detector = new BotDetector( new DeviceDetector() );
+} );
+
+test( 'score always returns a value between 0 and 100', function (): void {
+	$visitor = makeVisitor( [ 'user_agent' => null ], [
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'custom_data' => [ 'webdriver' => true, 'headless' => true, 'missing_apis' => true ] ],
+		[ 'engaged_time' => 0, 'scroll_depth' => 0 ],
+		[ 'engaged_time' => 0, 'scroll_depth' => 0 ],
+	] );
+
+	$score = $this->detector->score( $visitor );
+
+	expect( $score )->toBeGreaterThanOrEqual( 0 )->toBeLessThanOrEqual( 100 );
+} );
+
+test( 'known bot user agents score 100', function ( string $userAgent ): void {
+	$visitor = makeVisitor( [ 'user_agent' => $userAgent ] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 100 );
+} )->with( [
+	'GPTBot'    => 'Mozilla/5.0 (compatible; GPTBot/1.1; +https://openai.com/gptbot)',
+	'ClaudeBot' => 'Mozilla/5.0 (compatible; ClaudeBot/1.0; +claudebot@anthropic.com)',
+	'Googlebot' => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+] );
+
+test( 'isBot uses the configured threshold', function (): void {
+	$visitor = makeVisitor( [], [
+		[ 'custom_data' => [ 'webdriver' => true ] ],
+	] );
+
+	// WebDriver alone scores 50, below the default threshold of 70.
+	expect( $this->detector->isBot( $visitor ) )->toBeFalse();
+
+	config()->set( 'artisanpack.analytics.bot_detection.threshold', 40 );
+
+	expect( $this->detector->isBot( $visitor ) )->toBeTrue();
+} );
+
+test( 'empty user agent scores 80', function (): void {
+	$visitor = makeVisitor( [ 'user_agent' => '' ] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 80 );
+} );
+
+test( 'whitelisted user agents bypass scoring', function (): void {
+	config()->set( 'artisanpack.analytics.bot_detection.whitelist.user_agents', [ 'Googlebot' ] );
+
+	$visitor = makeVisitor( [ 'user_agent' => 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)' ] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 0 );
+	expect( $this->detector->isBot( $visitor ) )->toBeFalse();
+} );
+
+test( 'whitelisted ips bypass scoring', function (): void {
+	config()->set( 'artisanpack.analytics.bot_detection.whitelist.ips', [ '198.51.100.5' ] );
+
+	$visitor = makeVisitor( [ 'user_agent' => null, 'ip_address' => '198.51.100.5' ] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 0 );
+} );
+
+test( 'webdriver fingerprint contributes 50 points', function (): void {
+	$visitor = makeVisitor( [], [
+		[ 'custom_data' => [ 'fingerprint' => [ 'webdriver' => true ] ] ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 50 );
+} );
+
+test( 'zero engagement across three page views is flagged', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/a', 'created_at' => $base ],
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/b', 'created_at' => $base->copy()->addMinutes( 6 ) ],
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/c', 'created_at' => $base->copy()->addMinutes( 13 ) ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 35 );
+} );
+
+test( 'engagement on any page view avoids the zero engagement signal', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/a', 'created_at' => $base ],
+		[ 'engaged_time' => 12, 'scroll_depth' => 40, 'referrer_path' => '/b', 'created_at' => $base->copy()->addMinutes( 6 ) ],
+		[ 'engaged_time' => 0, 'scroll_depth' => 0, 'referrer_path' => '/c', 'created_at' => $base->copy()->addMinutes( 13 ) ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 0 );
+} );
+
+test( 'rapid sequential requests are flagged', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/a', 'created_at' => $base ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/b', 'created_at' => $base->copy()->addSeconds( 2 ) ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/c', 'created_at' => $base->copy()->addSeconds( 5 ) ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/d', 'created_at' => $base->copy()->addSeconds( 7 ) ],
+	] );
+
+	// 4 views across 7 seconds is well above 10 pages/minute.
+	expect( $this->detector->score( $visitor ) )->toBe( 30 );
+} );
+
+test( 'no referrer variation is flagged', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/same', 'created_at' => $base ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/same', 'created_at' => $base->copy()->addMinutes( 5 ) ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/same', 'created_at' => $base->copy()->addMinutes( 11 ) ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 15 );
+} );
+
+test( 'perfectly timed intervals are flagged', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/a', 'created_at' => $base ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/b', 'created_at' => $base->copy()->addMinutes( 10 ) ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'referrer_path' => '/c', 'created_at' => $base->copy()->addMinutes( 20 ) ],
+	] );
+
+	// Even 10-minute intervals, varied referrers, slow pace: only the interval signal fires.
+	expect( $this->detector->score( $visitor ) )->toBe( 20 );
+} );
+
+test( 'short page view times are flagged', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'time_on_page' => 0, 'referrer_path' => '/a', 'created_at' => $base ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'time_on_page' => 0, 'referrer_path' => '/b', 'created_at' => $base->copy()->addMinutes( 7 ) ],
+		[ 'engaged_time' => 5, 'scroll_depth' => 30, 'time_on_page' => 0, 'referrer_path' => '/c', 'created_at' => $base->copy()->addMinutes( 15 ) ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 25 );
+} );
+
+test( 'each signal category can be disabled independently', function (): void {
+	$visitor = makeVisitor( [], [
+		[ 'custom_data' => [ 'webdriver' => true ] ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 50 );
+
+	config()->set( 'artisanpack.analytics.bot_detection.signals.js_fingerprint', false );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 0 );
+} );
+
+test( 'disabling user agent signal stops empty user agent scoring', function (): void {
+	config()->set( 'artisanpack.analytics.bot_detection.signals.user_agent', false );
+
+	$visitor = makeVisitor( [ 'user_agent' => null ] );
+
+	expect( $this->detector->score( $visitor ) )->toBe( 0 );
+} );
+
+test( 'a legitimate visitor with one bad signal does not exceed the threshold', function (): void {
+	$base    = Carbon::parse( '2026-01-01 12:00:00' );
+	$visitor = makeVisitor( [], [
+		// Only the perfect-interval signal fires (20 points): real engagement, varied referrers, slow pace.
+		[ 'engaged_time' => 30, 'scroll_depth' => 80, 'time_on_page' => 45, 'referrer_path' => '/home', 'created_at' => $base ],
+		[ 'engaged_time' => 25, 'scroll_depth' => 60, 'time_on_page' => 30, 'referrer_path' => '/about', 'created_at' => $base->copy()->addMinutes( 5 ) ],
+		[ 'engaged_time' => 40, 'scroll_depth' => 90, 'time_on_page' => 60, 'referrer_path' => '/contact', 'created_at' => $base->copy()->addMinutes( 10 ) ],
+	] );
+
+	expect( $this->detector->score( $visitor ) )->toBeLessThan( 70 );
+	expect( $this->detector->isBot( $visitor ) )->toBeFalse();
+} );
+
+test( 'isBot returns false when bot detection is disabled', function (): void {
+	config()->set( 'artisanpack.analytics.bot_detection.enabled', false );
+
+	$visitor = makeVisitor( [ 'user_agent' => 'Mozilla/5.0 (compatible; GPTBot/1.1; +https://openai.com/gptbot)' ] );
+
+	expect( $this->detector->isBot( $visitor ) )->toBeFalse();
+} );
+
+test( 'the bot detector is resolvable from the container', function (): void {
+	expect( app( BotDetector::class ) )->toBeInstanceOf( BotDetector::class );
+} );


### PR DESCRIPTION
## Description

Adds a new `BotDetector` service implementing a multi-signal confidence scoring system (0–100) for identifying bot traffic. This is sub-issue #22 of the AI Bot Traffic Filtering feature (#20).

**Closes:** #22

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #22 (parent: #20)

## Motivation and Context

AI crawlers and sophisticated bots that spoof real browser user agents inflate analytics. This service provides the server-side scoring engine that combines user agent, JS fingerprint, engagement, and request-pattern signals so borderline cases are scored rather than hard-matched, reducing false positives.

## Changes Made

- `src/Services/BotDetector.php` — scoring engine with `score(Visitor): int`, `isBot(Visitor): bool`, `threshold()`, `enabled()`, `isWhitelisted(Visitor)`. Known bot UAs short-circuit to 100; score is summed and capped at 100.
- `config/analytics.php` — new `bot_detection` section: `enabled`, `threshold` (default 70), `whitelist` (user_agents + ips), per-category `signals` toggles.
- `src/AnalyticsServiceProvider.php` — registered `BotDetector` as a container singleton (depends on `DeviceDetector`).
- `tests/Unit/BotDetectorTest.php` — 20 unit tests.

### Signal sources / notes

- User agent matching reuses `DeviceDetector::isBot()` (the expanded pattern list from #21).
- Engagement and request-pattern signals are derived from the visitor's `pageViews` relation.
- JS fingerprint flags (`webdriver`, `headless`, `missing_apis`) are read from page-view `custom_data` — the tracker payload that #24 will populate — and degrade gracefully when absent.
- The `is_bot` / `bot_score` columns (#23) are not required by this service; it computes scores on demand.

## How Has This Been Tested?

**Testing Environment:**
- PHP Version: 8.4
- Project Version: release/1.2

**Tests Performed:**
1. New `BotDetectorTest` unit suite — 20 tests, 27 assertions, all passing.
2. Full package suite — 476 passed, 2 skipped.

## Accessibility Tests Run

- [x] N/A — backend service with no UI surface.

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

**Test details:** Covers score range capping, known-UA = 100, threshold-driven `isBot`, empty UA (80), UA + IP whitelist bypass, each fingerprint/engagement/request-pattern signal, independent signal toggles, the "one bad signal stays under threshold" edge case, and container resolution.

## Documentation

- [x] Inline code documentation added
- [ ] Package docs "Bot Filtering" section — deferred to the feature-level docs task in #20.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer)
- [x] Code follows project style guide
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bot detection added to analytics with configurable confidence scoring and per-signal toggles
  * Multi-signal detection: user-agent, engagement patterns, request-rate/patterns, and JS fingerprint signals
  * Whitelisting to exclude specific user agents and IPs
  * Adjustable confidence threshold for bot classification

* **Tests**
  * Comprehensive unit tests covering scoring, thresholds, whitelists, and individual signal toggles

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/analytics/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->