### PR TITLE
feat: bot-aware query scoping and dashboard toggles (#26, #46, #47)

### DIFF
--- a/resources/js/react/pages/AnalyticsDashboard.tsx
+++ b/resources/js/react/pages/AnalyticsDashboard.tsx
@@ -47,8 +47,12 @@ export interface AnalyticsDashboardProps {
     dateRangePresets?: Record<string, string>;
     /** Current filters. */
     filters?: Record<string, unknown>;
+    /** Whether bot traffic is included. Bots are excluded by default. */
+    includeBots?: boolean;
     /** Callback when the date range preset changes. */
     onDateRangeChange?: ( preset: string ) => void;
+    /** Callback when the include-bots toggle changes. */
+    onIncludeBotsChange?: ( includeBots: boolean ) => void;
     /** Optional CSS class name for the container. */
     className?: string;
 }
@@ -73,13 +77,19 @@ export default function AnalyticsDashboard( {
     trafficSources,
     dateRangePreset = '30d',
     dateRangePresets = defaultPresets,
+    includeBots = false,
     onDateRangeChange,
+    onIncludeBotsChange,
     className = '',
 }: AnalyticsDashboardProps ): React.ReactElement {
     const [ activeTab, setActiveTab ] = useState( 'overview' );
 
     const handlePresetChange = ( e: React.ChangeEvent<HTMLSelectElement> ): void => {
         onDateRangeChange?.( e.target.value );
+    };
+
+    const handleIncludeBotsChange = ( e: React.ChangeEvent<HTMLInputElement> ): void => {
+        onIncludeBotsChange?.( e.target.checked );
     };
 
     const presetOptions = useMemo( () => {
@@ -140,12 +150,24 @@ export default function AnalyticsDashboard( {
             <Card>
                 <div className="flex items-center justify-between">
                     <h2 className="text-2xl font-bold">Analytics Dashboard</h2>
-                    <div className="w-48">
-                        <Select
-                            options={presetOptions}
-                            value={dateRangePreset}
-                            onChange={handlePresetChange}
-                        />
+                    <div className="flex items-center gap-4">
+                        <label className="flex items-center gap-2 text-sm cursor-pointer select-none">
+                            <input
+                                type="checkbox"
+                                className="toggle toggle-sm"
+                                checked={includeBots}
+                                onChange={handleIncludeBotsChange}
+                                aria-label="Include bot traffic"
+                            />
+                            <span>Include bot traffic</span>
+                        </label>
+                        <div className="w-48">
+                            <Select
+                                options={presetOptions}
+                                value={dateRangePreset}
+                                onChange={handlePresetChange}
+                            />
+                        </div>
                     </div>
                 </div>
             </Card>

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -277,6 +277,15 @@ export interface ConsentUpdateResponse {
 // Query parameter helpers (for building requests)
 // ---------------------------------------------------------------------------
 
+/**
+ * Bot-traffic filter mode.
+ *
+ * - `exclude` (default): hide bot traffic.
+ * - `include`: show human and bot traffic together.
+ * - `only`: show bot traffic only.
+ */
+export type BotFilterMode = 'exclude' | 'include' | 'only';
+
 export interface AnalyticsQueryParams {
     period?: DateRangePreset;
     start_date?: string;
@@ -288,6 +297,7 @@ export interface AnalyticsQueryParams {
     goal_id?: number;
     limit?: number;
     compare?: boolean;
+    bots?: BotFilterMode;
 }
 
 export interface RealtimeQueryParams {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -57,6 +57,7 @@ export type {
 // API response interfaces
 export type {
     AnalyticsQueryParams,
+    BotFilterMode,
     BrowserBreakdownItem,
     BrowserBreakdownResponse,
     ApiDataResponse,

--- a/resources/js/vue/pages/AnalyticsDashboard.vue
+++ b/resources/js/vue/pages/AnalyticsDashboard.vue
@@ -46,8 +46,11 @@ const props = withDefaults( defineProps<{
     dateRangePreset?: string;
     /** Available date range presets. */
     dateRangePresets?: Record<string, string>;
+    /** Whether bot traffic is included. Bots are excluded by default. */
+    includeBots?: boolean;
 }>(), {
     dateRangePreset: '30d',
+    includeBots: false,
     dateRangePresets: () => ( {
         today: 'Today',
         yesterday: 'Yesterday',
@@ -64,6 +67,7 @@ const props = withDefaults( defineProps<{
 
 const emit = defineEmits<{
     dateRangeChange: [preset: string];
+    includeBotsChange: [includeBots: boolean];
 }>();
 
 const activeTab = ref( 'overview' );
@@ -77,6 +81,10 @@ const presetOptions = computed( () => {
 
 function handlePresetChange( event: Event ): void {
     emit( 'dateRangeChange', ( event.target as HTMLSelectElement ).value );
+}
+
+function handleIncludeBotsChange( event: Event ): void {
+    emit( 'includeBotsChange', ( event.target as HTMLInputElement ).checked );
 }
 
 const tabs: TabItem[] = [
@@ -93,12 +101,24 @@ const tabs: TabItem[] = [
         <Card>
             <div class="flex items-center justify-between">
                 <h2 class="text-2xl font-bold">Analytics Dashboard</h2>
-                <div class="w-48">
-                    <Select
-                        :options="presetOptions"
-                        :model-value="props.dateRangePreset"
-                        @change="handlePresetChange"
-                    />
+                <div class="flex items-center gap-4">
+                    <label class="flex items-center gap-2 text-sm cursor-pointer select-none">
+                        <input
+                            type="checkbox"
+                            class="toggle toggle-sm"
+                            :checked="props.includeBots"
+                            aria-label="Include bot traffic"
+                            @change="handleIncludeBotsChange"
+                        />
+                        <span>Include bot traffic</span>
+                    </label>
+                    <div class="w-48">
+                        <Select
+                            :options="presetOptions"
+                            :model-value="props.dateRangePreset"
+                            @change="handlePresetChange"
+                        />
+                    </div>
                 </div>
             </div>
         </Card>

--- a/resources/views/livewire/analytics-dashboard.blade.php
+++ b/resources/views/livewire/analytics-dashboard.blade.php
@@ -37,6 +37,16 @@
 				/>
 			</x-artisanpack-dropdown>
 
+			{{-- Bot Traffic Toggle --}}
+			<x-artisanpack-button
+				wire:click="toggleBots"
+				class="btn-sm {{ $includeBots ? 'btn-primary' : 'btn-outline' }}"
+				icon="o-bug-ant"
+				:label="$includeBots ? __( 'Bots included' ) : __( 'Exclude bots' )"
+				:tooltip="$includeBots ? __( 'Bot traffic is included. Click to exclude.' ) : __( 'Bot traffic is excluded. Click to include.' )"
+				aria-pressed="{{ $includeBots ? 'true' : 'false' }}"
+			/>
+
 			{{-- Refresh Button --}}
 			<x-artisanpack-button
 				wire:click="refreshData"

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -577,14 +577,15 @@ class Analytics implements AnalyticsQueryInterface, AnalyticsServiceInterface
      * Uses the first provider that supports queries.
      *
      * @param  int  $minutes  The number of minutes to consider as "real-time".
+     * @param  array<string, mixed>  $filters  Optional filters to apply (including bot scoping).
      *
      * @return int The number of active visitors.
      *
      * @since 1.0.0
      */
-    public function getRealTimeVisitors( int $minutes = 5 ): int
+    public function getRealTimeVisitors( int $minutes = 5, array $filters = [] ): int
     {
-        return $this->queryWithProvider( fn ( AnalyticsQueryInterface $p ) => $p->getRealTimeVisitors( $minutes ), 0 );
+        return $this->queryWithProvider( fn ( AnalyticsQueryInterface $p ) => $p->getRealTimeVisitors( $minutes, $filters ), 0 );
     }
 
     /**

--- a/src/Contracts/AnalyticsQueryInterface.php
+++ b/src/Contracts/AnalyticsQueryInterface.php
@@ -159,11 +159,12 @@ interface AnalyticsQueryInterface
 	/**
 	 * Get real-time visitor count.
 	 *
-	 * @param int $minutes The number of minutes to consider as "real-time".
+	 * @param int                  $minutes The number of minutes to consider as "real-time".
+	 * @param array<string, mixed> $filters Optional filters to apply (including bot scoping).
 	 *
 	 * @return int The number of active visitors.
 	 *
 	 * @since 1.0.0
 	 */
-	public function getRealTimeVisitors( int $minutes = 5): int;
+	public function getRealTimeVisitors( int $minutes = 5, array $filters = []): int;
 }

--- a/src/Http/Controllers/AnalyticsQueryController.php
+++ b/src/Http/Controllers/AnalyticsQueryController.php
@@ -334,6 +334,13 @@ class AnalyticsQueryController extends Controller
 			$filters['goal_id'] = (int) $goalId;
 		}
 
+		// Bot-traffic filter. Bots are excluded by default; the toggle on the
+		// dashboard opts back in via ?bots=include (or ?bots=only).
+		$bots = $request->query( 'bots' );
+		if ( is_string( $bots ) && in_array( $bots, [ 'exclude', 'include', 'only' ], true ) ) {
+			$filters['bots'] = $bots;
+		}
+
 		return $filters;
 	}
 

--- a/src/Http/Controllers/AnalyticsQueryController.php
+++ b/src/Http/Controllers/AnalyticsQueryController.php
@@ -207,7 +207,7 @@ class AnalyticsQueryController extends Controller
 		// Clamp minutes to a reasonable range
 		$minutes = max( 1, min( 30, $minutes ) );
 
-		$realtime = $this->analyticsQuery->getRealtime( $minutes );
+		$realtime = $this->analyticsQuery->getRealtime( $minutes, $this->getFilters( $request ) );
 
 		return response()->json( [
 			'success' => true,

--- a/src/Http/Livewire/AnalyticsDashboard.php
+++ b/src/Http/Livewire/AnalyticsDashboard.php
@@ -135,6 +135,19 @@ class AnalyticsDashboard extends Component
 	}
 
 	/**
+	 * Toggle whether bot traffic is included in the dashboard.
+	 *
+	 * Dispatches the toggle so the dashboard and any standalone widgets that
+	 * use the analytics widget trait refresh with the new bot-filter state.
+	 *
+	 * @since 1.2.0
+	 */
+	public function toggleBots(): void
+	{
+		$this->dispatch( 'analytics-bots-toggled', includeBots: ! $this->includeBots );
+	}
+
+	/**
 	 * Refresh the dashboard data.
 	 *
 	 * @since 1.0.0

--- a/src/Http/Livewire/Concerns/WithAnalyticsWidget.php
+++ b/src/Http/Livewire/Concerns/WithAnalyticsWidget.php
@@ -6,6 +6,7 @@ namespace ArtisanPackUI\Analytics\Http\Livewire\Concerns;
 
 use ArtisanPackUI\Analytics\Data\DateRange;
 use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
+use Livewire\Attributes\On;
 
 /**
  * Trait for analytics widgets with shared functionality.
@@ -43,6 +44,13 @@ trait WithAnalyticsWidget
 	 * Site ID filter for multi-site support.
 	 */
 	public ?int $siteId = null;
+
+	/**
+	 * Whether bot traffic is included in the widget's data.
+	 *
+	 * Bots are excluded by default; the dashboard toggle opts back in.
+	 */
+	public bool $includeBots = false;
 
 	/**
 	 * Initialize the widget with default date range.
@@ -88,6 +96,23 @@ trait WithAnalyticsWidget
 		$this->dateRangePreset = 'custom';
 		$this->customStartDate = $startDate;
 		$this->customEndDate   = $endDate;
+		$this->refreshData();
+	}
+
+	/**
+	 * Sync the bot-inclusion state and refresh data.
+	 *
+	 * Listens for the dashboard toggle so every widget that uses this trait
+	 * stays in sync with the chosen bot-filter state.
+	 *
+	 * @param bool $includeBots Whether bot traffic should be included.
+	 *
+	 * @since 1.2.0
+	 */
+	#[On( 'analytics-bots-toggled' )]
+	public function syncBotInclusion( bool $includeBots ): void
+	{
+		$this->includeBots = $includeBots;
 		$this->refreshData();
 	}
 
@@ -222,6 +247,8 @@ trait WithAnalyticsWidget
 		if ( null !== $this->siteId ) {
 			$filters['site_id'] = $this->siteId;
 		}
+
+		$filters['bots'] = $this->includeBots ? 'include' : 'exclude';
 
 		return array_merge( $filters, $additionalFilters );
 	}

--- a/src/Providers/AbstractAnalyticsProvider.php
+++ b/src/Providers/AbstractAnalyticsProvider.php
@@ -375,12 +375,13 @@ abstract class AbstractAnalyticsProvider implements AnalyticsProviderInterface, 
      * Default implementation returns 0. Override in subclasses.
      *
      * @param  int  $minutes  The number of minutes to consider as "real-time".
+     * @param  array<string, mixed>  $filters  Optional filters to apply (including bot scoping).
      *
      * @return int The number of active visitors.
      *
      * @since 1.0.0
      */
-    public function getRealTimeVisitors( int $minutes = 5 ): int
+    public function getRealTimeVisitors( int $minutes = 5, array $filters = [] ): int
     {
         return 0;
     }

--- a/src/Providers/GoogleAnalyticsProvider.php
+++ b/src/Providers/GoogleAnalyticsProvider.php
@@ -323,12 +323,13 @@ class GoogleAnalyticsProvider extends AbstractAnalyticsProvider
      * Not supported without GA4 Data API credentials.
      *
      * @param  int  $minutes  The number of minutes to consider as "real-time".
+     * @param  array<string, mixed>  $filters  Optional filters to apply (including bot scoping).
      *
      * @return int Always returns 0 as querying is not supported.
      *
      * @since 1.0.0
      */
-    public function getRealTimeVisitors( int $minutes = 5 ): int
+    public function getRealTimeVisitors( int $minutes = 5, array $filters = [] ): int
     {
         $this->logUnsupportedQuery( 'getRealTimeVisitors' );
 

--- a/src/Providers/LocalAnalyticsProvider.php
+++ b/src/Providers/LocalAnalyticsProvider.php
@@ -517,8 +517,15 @@ class LocalAnalyticsProvider extends AbstractAnalyticsProvider
      */
     public function getRealTimeVisitors( int $minutes = 5, array $filters = [] ): int
     {
+        // Limit to scope filters that exist on the sessions table; path and
+        // event-only filters do not apply to realtime session counts.
+        $scopeFilters = array_intersect_key(
+            $filters,
+            array_flip( [ 'site_id', 'tenant_id', 'visitor_id', 'bots' ] ),
+        );
+
         return $this->safeQuery(
-            fn () => $this->applyBotFilter( Session::query()->active( $minutes ), $filters )
+            fn () => $this->applyFilters( Session::query()->active( $minutes ), $scopeFilters )
                 ->distinct( 'visitor_id' )
                 ->count( 'visitor_id' ),
             0,

--- a/src/Providers/LocalAnalyticsProvider.php
+++ b/src/Providers/LocalAnalyticsProvider.php
@@ -509,17 +509,16 @@ class LocalAnalyticsProvider extends AbstractAnalyticsProvider
      * Get real-time visitor count.
      *
      * @param  int  $minutes  The number of minutes to consider as "real-time".
+     * @param  array<string, mixed>  $filters  Optional filters to apply (including bot scoping).
      *
      * @return int The number of active visitors.
      *
      * @since 1.0.0
      */
-    public function getRealTimeVisitors( int $minutes = 5 ): int
+    public function getRealTimeVisitors( int $minutes = 5, array $filters = [] ): int
     {
         return $this->safeQuery(
-            fn () => Session::query()
-                ->active( $minutes )
-                ->whereDoesntHave( 'visitor', fn ( Builder $visitorQuery ) => $visitorQuery->where( 'is_bot', true ) )
+            fn () => $this->applyBotFilter( Session::query()->active( $minutes ), $filters )
                 ->distinct( 'visitor_id' )
                 ->count( 'visitor_id' ),
             0,

--- a/src/Providers/LocalAnalyticsProvider.php
+++ b/src/Providers/LocalAnalyticsProvider.php
@@ -519,6 +519,7 @@ class LocalAnalyticsProvider extends AbstractAnalyticsProvider
         return $this->safeQuery(
             fn () => Session::query()
                 ->active( $minutes )
+                ->whereDoesntHave( 'visitor', fn ( Builder $visitorQuery ) => $visitorQuery->where( 'is_bot', true ) )
                 ->distinct( 'visitor_id' )
                 ->count( 'visitor_id' ),
             0,
@@ -631,6 +632,49 @@ class LocalAnalyticsProvider extends AbstractAnalyticsProvider
 
         if ( isset( $filters['visitor_id'] ) ) {
             $query->where( $table . '.visitor_id', $filters['visitor_id'] );
+        }
+
+        return $this->applyBotFilter( $query, $filters );
+    }
+
+    /**
+     * Apply bot-traffic scoping to a query.
+     *
+     * Excludes bot visitors by default. The mode is read from the `bots` filter
+     * key: `exclude` (default) hides confirmed bots, `include` shows all
+     * traffic, and `only` returns just bot traffic. For the Visitor model the
+     * `is_bot` column is filtered directly; for models with a `visitor`
+     * relation the filter is applied through that relation. In `exclude` mode
+     * only rows whose visitor is a confirmed bot are removed, so rows with an
+     * unresolved visitor are still counted.
+     *
+     * @param  Builder  $query  The query builder.
+     * @param  array<string, mixed>  $filters  The filters to apply.
+     *
+     * @since 1.2.0
+     */
+    protected function applyBotFilter( Builder $query, array $filters ): Builder
+    {
+        $mode = $filters['bots'] ?? 'exclude';
+
+        if ( 'include' === $mode ) {
+            return $query;
+        }
+
+        $model = $query->getModel();
+
+        if ( $model instanceof Visitor ) {
+            $query->where( $model->getTable() . '.is_bot', 'only' === $mode );
+
+            return $query;
+        }
+
+        if ( method_exists( $model, 'visitor' ) ) {
+            if ( 'only' === $mode ) {
+                $query->whereHas( 'visitor', fn ( Builder $visitorQuery ) => $visitorQuery->where( 'is_bot', true ) );
+            } else {
+                $query->whereDoesntHave( 'visitor', fn ( Builder $visitorQuery ) => $visitorQuery->where( 'is_bot', true ) );
+            }
         }
 
         return $query;

--- a/src/Providers/PlausibleProvider.php
+++ b/src/Providers/PlausibleProvider.php
@@ -506,12 +506,13 @@ class PlausibleProvider extends AbstractAnalyticsProvider
      * Get real-time visitor count.
      *
      * @param  int  $minutes  The number of minutes to consider as "real-time".
+     * @param  array<string, mixed>  $filters  Optional filters to apply (including bot scoping).
      *
      * @return int The number of active visitors.
      *
      * @since 1.0.0
      */
-    public function getRealTimeVisitors( int $minutes = 5 ): int
+    public function getRealTimeVisitors( int $minutes = 5, array $filters = [] ): int
     {
         if ( ! $this->supportsQueries() ) {
             $this->logMissingApiKey( 'getRealTimeVisitors' );

--- a/src/Services/AnalyticsQuery.php
+++ b/src/Services/AnalyticsQuery.php
@@ -50,6 +50,15 @@ class AnalyticsQuery
     protected string $cacheTag = 'analytics';
 
     /**
+     * Pending bot-filter mode for the next query.
+     *
+     * One of 'exclude', 'include', or 'only'. Null falls back to the default
+     * ('exclude'). Reset to null after each query so the modifier applies to a
+     * single call only.
+     */
+    protected ?string $pendingBotMode = null;
+
+    /**
      * Create a new AnalyticsQuery instance.
      *
      * @param  AnalyticsQueryInterface  $provider  The query provider.
@@ -61,6 +70,62 @@ class AnalyticsQuery
         $this->provider      = $provider;
         $this->cacheEnabled  = config( 'artisanpack.analytics.dashboard.cache_enabled', true );
         $this->cacheDuration = config( 'artisanpack.analytics.dashboard.cache_duration', 300 );
+    }
+
+    /**
+     * Include bot traffic alongside human traffic in the next query.
+     *
+     * @return static The current instance for method chaining.
+     *
+     * @since 1.2.0
+     */
+    public function includeBots(): static
+    {
+        $this->pendingBotMode = 'include';
+
+        return $this;
+    }
+
+    /**
+     * Include bot traffic alongside human traffic in the next query.
+     *
+     * Alias of includeBots().
+     *
+     * @return static The current instance for method chaining.
+     *
+     * @since 1.2.0
+     */
+    public function withBots(): static
+    {
+        return $this->includeBots();
+    }
+
+    /**
+     * Restrict the next query to bot traffic only.
+     *
+     * @return static The current instance for method chaining.
+     *
+     * @since 1.2.0
+     */
+    public function onlyBots(): static
+    {
+        $this->pendingBotMode = 'only';
+
+        return $this;
+    }
+
+    /**
+     * Exclude bot traffic from the next query (the default behaviour).
+     *
+     * @return static The current instance for method chaining.
+     *
+     * @since 1.2.0
+     */
+    public function excludeBots(): static
+    {
+        $this->pendingBotMode = 'exclude';
+
+        return $this;
     }
 
     /**
@@ -78,6 +143,7 @@ class AnalyticsQuery
      */
     public function getStats( DateRange $range, bool $withCompare = true, array $filters = [] ): array
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'stats', $range, $filters, $withCompare );
 
         $stats = $this->cached( $cacheKey, function () use ( $range, $withCompare, $filters ): array {
@@ -120,6 +186,7 @@ class AnalyticsQuery
      */
     public function getPageViews( DateRange $range, string $granularity = 'day', array $filters = [] ): Collection
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'pageviews', $range, $filters, $granularity );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getPageViewsOverTime( $range, $granularity, $filters ) );
@@ -137,6 +204,7 @@ class AnalyticsQuery
      */
     public function getPageViewCount( DateRange $range, array $filters = [] ): int
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'pageview_count', $range, $filters );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getPageViews( $range, $filters ) );
@@ -154,6 +222,7 @@ class AnalyticsQuery
      */
     public function getVisitors( DateRange $range, array $filters = [] ): int
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'visitors', $range, $filters );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getVisitors( $range, $filters ) );
@@ -171,6 +240,7 @@ class AnalyticsQuery
      */
     public function getSessions( DateRange $range, array $filters = [] ): int
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'sessions', $range, $filters );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getSessions( $range, $filters ) );
@@ -189,6 +259,7 @@ class AnalyticsQuery
      */
     public function getTopPages( DateRange $range, int $limit = 10, array $filters = [] ): Collection
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'top_pages', $range, $filters, $limit );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getTopPages( $range, $limit, $filters ) );
@@ -207,6 +278,7 @@ class AnalyticsQuery
      */
     public function getTrafficSources( DateRange $range, int $limit = 10, array $filters = [] ): Collection
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'traffic_sources', $range, $filters, $limit );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getTrafficSources( $range, $limit, $filters ) );
@@ -224,6 +296,7 @@ class AnalyticsQuery
      */
     public function getBounceRate( DateRange $range, array $filters = [] ): float
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'bounce_rate', $range, $filters );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getBounceRate( $range, $filters ) );
@@ -241,6 +314,7 @@ class AnalyticsQuery
      */
     public function getAverageSessionDuration( DateRange $range, array $filters = [] ): int
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'avg_session_duration', $range, $filters );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getAverageSessionDuration( $range, $filters ) );
@@ -258,6 +332,7 @@ class AnalyticsQuery
      */
     public function getAveragePagesPerSession( DateRange $range, array $filters = [] ): float
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'avg_pages_per_session', $range, $filters );
 
         return $this->cached( $cacheKey, function () use ( $range, $filters ): float {
@@ -299,6 +374,7 @@ class AnalyticsQuery
      */
     public function getDeviceBreakdown( DateRange $range, array $filters = [] ): Collection
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'device_breakdown', $range, $filters );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getDeviceBreakdown( $range, $filters ) );
@@ -317,6 +393,7 @@ class AnalyticsQuery
      */
     public function getBrowserBreakdown( DateRange $range, int $limit = 10, array $filters = [] ): Collection
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'browser_breakdown', $range, $filters, $limit );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getBrowserBreakdown( $range, $limit, $filters ) );
@@ -335,6 +412,7 @@ class AnalyticsQuery
      */
     public function getCountryBreakdown( DateRange $range, int $limit = 10, array $filters = [] ): Collection
     {
+        $filters  = $this->resolveBotMode( $filters );
         $cacheKey = $this->buildCacheKey( 'country_breakdown', $range, $filters, $limit );
 
         return $this->cached( $cacheKey, fn () => $this->provider->getCountryBreakdown( $range, $limit, $filters ) );
@@ -354,6 +432,7 @@ class AnalyticsQuery
     public function getPageAnalytics( string $path, DateRange $range, array $filters = [] ): array
     {
         $filters['path'] = $path;
+        $filters         = $this->resolveBotMode( $filters );
         $cacheKey        = $this->buildCacheKey( 'page_analytics', $range, $filters );
 
         return $this->cached( $cacheKey, function () use ( $range, $filters ): array {
@@ -715,6 +794,30 @@ class AnalyticsQuery
         $this->cacheDuration = $seconds;
 
         return $this;
+    }
+
+    /**
+     * Resolve the bot-filter mode into the filters array.
+     *
+     * Honours an explicit `bots` filter, then the pending modifier, then
+     * defaults to excluding bots. The pending modifier is consumed so it only
+     * affects a single query.
+     *
+     * @param  array<string, mixed>  $filters  The filters to resolve.
+     *
+     * @return array<string, mixed>
+     *
+     * @since 1.2.0
+     */
+    protected function resolveBotMode( array $filters ): array
+    {
+        if ( ! isset( $filters['bots'] ) ) {
+            $filters['bots'] = $this->pendingBotMode ?? 'exclude';
+        }
+
+        $this->pendingBotMode = null;
+
+        return $filters;
     }
 
     /**

--- a/src/Services/AnalyticsQuery.php
+++ b/src/Services/AnalyticsQuery.php
@@ -168,7 +168,7 @@ class AnalyticsQuery
         } );
 
         // Real-time visitors should never be cached
-        $stats['realtime_visitors'] = $this->provider->getRealTimeVisitors();
+        $stats['realtime_visitors'] = $this->provider->getRealTimeVisitors( 5, $filters );
 
         return $stats;
     }
@@ -349,15 +349,18 @@ class AnalyticsQuery
      * Real-time data is never cached.
      *
      * @param  int  $minutes  The number of minutes to consider as "real-time".
+     * @param  array<string, mixed>  $filters  Optional filters to apply (including bot scoping).
      *
      * @return array<string, mixed>
      *
      * @since 1.0.0
      */
-    public function getRealtime( int $minutes = 5 ): array
+    public function getRealtime( int $minutes = 5, array $filters = [] ): array
     {
+        $filters = $this->resolveBotMode( $filters );
+
         return [
-            'active_visitors' => $this->provider->getRealTimeVisitors( $minutes ),
+            'active_visitors' => $this->provider->getRealTimeVisitors( $minutes, $filters ),
             'timestamp'       => now()->toIso8601String(),
         ];
     }

--- a/tests/Feature/BotAwareQueryScopingTest.php
+++ b/tests/Feature/BotAwareQueryScopingTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Data\DateRange;
+use ArtisanPackUI\Analytics\Models\PageView;
+use ArtisanPackUI\Analytics\Models\Session;
+use ArtisanPackUI\Analytics\Models\Visitor;
+use ArtisanPackUI\Analytics\Providers\LocalAnalyticsProvider;
+use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    config()->set( 'artisanpack.analytics.local.queue_processing', false );
+    config()->set( 'artisanpack.analytics.local.enabled', true );
+} );
+
+/**
+ * Create a visitor with the given bot state and return its UUID.
+ */
+function scopeVisitor( bool $isBot, string $deviceType = 'desktop' ): string
+{
+    $visitor = Visitor::create( [
+        'fingerprint'   => bin2hex( random_bytes( 16 ) ),
+        'first_seen_at' => now(),
+        'last_seen_at'  => now(),
+        'device_type'   => $deviceType,
+        'is_bot'        => $isBot,
+        'bot_score'     => $isBot ? 90 : null,
+    ] );
+
+    return (string) $visitor->id;
+}
+
+/**
+ * Create a page view tied to a visitor id.
+ */
+function scopePageView( string $visitorId, string $path = '/' ): void
+{
+    PageView::create( [
+        'path'       => $path,
+        'session_id' => 'session-' . $visitorId,
+        'visitor_id' => $visitorId,
+        'created_at' => now(),
+    ] );
+}
+
+/**
+ * Create a session tied to a visitor id.
+ */
+function scopeSession( string $visitorId ): void
+{
+    Session::create( [
+        'session_id'       => 'session-' . $visitorId,
+        'visitor_id'       => $visitorId,
+        'started_at'       => now(),
+        'last_activity_at' => now(),
+        'entry_page'       => '/',
+        'is_bounce'        => false,
+        'referrer_type'    => 'direct',
+    ] );
+}
+
+test( 'page views exclude confirmed bots by default', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    $human = scopeVisitor( false );
+    $bot   = scopeVisitor( true );
+    scopePageView( $human, '/human' );
+    scopePageView( $bot, '/bot' );
+
+    expect( $provider->getPageViews( DateRange::today() ) )->toBe( 1 );
+} );
+
+test( 'page views include bots when requested', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    scopePageView( scopeVisitor( false ), '/human' );
+    scopePageView( scopeVisitor( true ), '/bot' );
+
+    expect( $provider->getPageViews( DateRange::today(), [ 'bots' => 'include' ] ) )->toBe( 2 );
+} );
+
+test( 'only bots mode returns just bot traffic', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    scopePageView( scopeVisitor( false ), '/human' );
+    scopePageView( scopeVisitor( true ), '/bot' );
+
+    expect( $provider->getPageViews( DateRange::today(), [ 'bots' => 'only' ] ) )->toBe( 1 );
+} );
+
+test( 'unique visitors exclude bot visitors by default', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    scopePageView( scopeVisitor( false ), '/a' );
+    scopePageView( scopeVisitor( false ), '/b' );
+    scopePageView( scopeVisitor( true ), '/c' );
+
+    expect( $provider->getVisitors( DateRange::today() ) )->toBe( 2 );
+} );
+
+test( 'sessions exclude bot sessions by default', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    scopeSession( scopeVisitor( false ) );
+    scopeSession( scopeVisitor( true ) );
+
+    expect( $provider->getSessions( DateRange::today() ) )->toBe( 1 );
+    expect( $provider->getSessions( DateRange::today(), [ 'bots' => 'include' ] ) )->toBe( 2 );
+} );
+
+test( 'device breakdown excludes bot visitors by default', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    $human = scopeVisitor( false, 'desktop' );
+    $bot   = scopeVisitor( true, 'mobile' );
+    scopeSession( $human );
+    scopeSession( $bot );
+
+    $breakdown = $provider->getDeviceBreakdown( DateRange::today() );
+
+    expect( $breakdown->pluck( 'device_type' )->all() )->toContain( 'desktop' );
+    expect( $breakdown->pluck( 'device_type' )->all() )->not->toContain( 'mobile' );
+} );
+
+test( 'page views with an unresolved visitor are still counted when excluding bots', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    // No matching Visitor row exists for this id.
+    scopePageView( 'orphan-visitor', '/orphan' );
+
+    expect( $provider->getPageViews( DateRange::today() ) )->toBe( 1 );
+} );
+
+test( 'realtime visitors exclude bots', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    scopeSession( scopeVisitor( false ) );
+    scopeSession( scopeVisitor( true ) );
+
+    expect( $provider->getRealTimeVisitors() )->toBe( 1 );
+} );
+
+test( 'analytics query defaults to excluding bots', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    scopePageView( scopeVisitor( false ), '/human' );
+    scopePageView( scopeVisitor( true ), '/bot' );
+
+    expect( $query->getPageViewCount( DateRange::today() ) )->toBe( 1 );
+} );
+
+test( 'analytics query includeBots modifier opts bots back in', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    scopePageView( scopeVisitor( false ), '/human' );
+    scopePageView( scopeVisitor( true ), '/bot' );
+
+    expect( $query->includeBots()->getPageViewCount( DateRange::today() ) )->toBe( 2 );
+} );
+
+test( 'analytics query withBots is an alias of includeBots', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    scopePageView( scopeVisitor( false ), '/human' );
+    scopePageView( scopeVisitor( true ), '/bot' );
+
+    expect( $query->withBots()->getPageViewCount( DateRange::today() ) )->toBe( 2 );
+} );
+
+test( 'analytics query onlyBots restricts to bot traffic', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    scopePageView( scopeVisitor( false ), '/human' );
+    scopePageView( scopeVisitor( true ), '/bot' );
+
+    expect( $query->onlyBots()->getPageViewCount( DateRange::today() ) )->toBe( 1 );
+} );
+
+test( 'bot modifier only affects a single query', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    scopePageView( scopeVisitor( false ), '/human' );
+    scopePageView( scopeVisitor( true ), '/bot' );
+
+    $query->includeBots()->getPageViewCount( DateRange::today() );
+
+    // The next call should fall back to the default (exclude).
+    expect( $query->getPageViewCount( DateRange::today() ) )->toBe( 1 );
+} );

--- a/tests/Feature/BotAwareQueryScopingTest.php
+++ b/tests/Feature/BotAwareQueryScopingTest.php
@@ -50,11 +50,12 @@ function scopePageView( string $visitorId, string $path = '/' ): void
 /**
  * Create a session tied to a visitor id.
  */
-function scopeSession( string $visitorId ): void
+function scopeSession( string $visitorId, ?int $siteId = null ): void
 {
     Session::create( [
         'session_id'       => 'session-' . $visitorId,
         'visitor_id'       => $visitorId,
+        'site_id'          => $siteId,
         'started_at'       => now(),
         'last_activity_at' => now(),
         'entry_page'       => '/',
@@ -151,6 +152,15 @@ test( 'realtime visitors include bots when requested', function (): void {
     scopeSession( scopeVisitor( true ) );
 
     expect( $provider->getRealTimeVisitors( 5, [ 'bots' => 'include' ] ) )->toBe( 2 );
+} );
+
+test( 'realtime visitors respect site scoping', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    scopeSession( scopeVisitor( false ), 1 );
+    scopeSession( scopeVisitor( false ), 2 );
+
+    expect( $provider->getRealTimeVisitors( 5, [ 'site_id' => 1 ] ) )->toBe( 1 );
 } );
 
 test( 'analytics query realtime respects bot modifier', function (): void {

--- a/tests/Feature/BotAwareQueryScopingTest.php
+++ b/tests/Feature/BotAwareQueryScopingTest.php
@@ -135,13 +135,32 @@ test( 'page views with an unresolved visitor are still counted when excluding bo
     expect( $provider->getPageViews( DateRange::today() ) )->toBe( 1 );
 } );
 
-test( 'realtime visitors exclude bots', function (): void {
+test( 'realtime visitors exclude bots by default', function (): void {
     $provider = new LocalAnalyticsProvider;
 
     scopeSession( scopeVisitor( false ) );
     scopeSession( scopeVisitor( true ) );
 
     expect( $provider->getRealTimeVisitors() )->toBe( 1 );
+} );
+
+test( 'realtime visitors include bots when requested', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    scopeSession( scopeVisitor( false ) );
+    scopeSession( scopeVisitor( true ) );
+
+    expect( $provider->getRealTimeVisitors( 5, [ 'bots' => 'include' ] ) )->toBe( 2 );
+} );
+
+test( 'analytics query realtime respects bot modifier', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    scopeSession( scopeVisitor( false ) );
+    scopeSession( scopeVisitor( true ) );
+
+    expect( $query->getRealtime()['active_visitors'] )->toBe( 1 );
+    expect( $query->includeBots()->getRealtime()['active_visitors'] )->toBe( 2 );
 } );
 
 test( 'analytics query defaults to excluding bots', function (): void {


### PR DESCRIPTION
## Description

Excludes confirmed bot traffic from analytics data by default across the Livewire, React, and Vue dashboards, with an opt-in toggle to include or isolate bot traffic. Implements the three parallel sub-issues of #20 together since they share a single API contract (`bots=exclude|include|only`).

**Closes:** #26

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #26 (also closes #46, #47; parent #20)

## Motivation and Context

AI crawler and bot traffic inflates analytics. #26 adds backend query scoping so dashboards show real human traffic by default; #46 and #47 surface the same control in the React and Vue dashboards. They share the `bots` API parameter, so they were built together for a consistent contract.

## Changes Made

- `LocalAnalyticsProvider::applyBotFilter()` wired into `applyFilters` (inherited by all query methods) and realtime visitors. Exclude mode removes only **confirmed** bots, so rows with an unresolved visitor stay counted.
- `AnalyticsQuery` gains `includeBots()` / `withBots()` / `onlyBots()` / `excludeBots()` modifiers; bot mode is folded into filters so cache keys stay distinct. Default is exclude.
- `AnalyticsQueryController` reads `?bots=exclude|include|only` so API endpoints respect the filter.
- Livewire: `WithAnalyticsWidget` adds an `includeBots` flag + `analytics-bots-toggled` listener; `AnalyticsDashboard::toggleBots()` plus a header toggle button.
- React/Vue: shared `BotFilterMode` type + `bots` query param; "Include bot traffic" toggle on both dashboard pages emitting a host callback/event (mirrors the existing date-range pattern).

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- Browser (if applicable): manual dashboard verification
- PHP Version: 8.4
- Project Version: 1.2 (release/1.2)

**Tests Performed:**
1. Full Pest suite (516 passed, 2 skipped).
2. New `BotAwareQueryScopingTest` covering default exclude, include, only, per-call reset, orphan-visitor regression, sessions, device breakdown, realtime.
3. Manual browser check of the dashboard toggle flipping counts.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] ARIA labels checked

**Details:** Toggle controls use native checkbox inputs with `aria-label`/`aria-pressed`; consistent with existing dashboard controls.

## Tests Added

- [x] Unit/feature tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/BotAwareQueryScopingTest.php` (13 tests). No JS test harness exists in this package, so JS changes are covered by the build/types.

## Documentation

- [x] Inline code documentation added

**Documentation details:** PHPDoc/TSDoc on all new methods, props, and types.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted (php-cs-fixer)
- [x] Code follows project style guide
- [x] Self-review completed
- [x] No new warnings generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Include bot traffic" toggle to the analytics dashboard with modes to exclude, include, or show only bot traffic; dashboard metrics and realtime counts respect this setting.
* **Tests**
  * Added feature tests validating bot-aware analytics behavior, realtime counts, and edge cases.
* **Chores**
  * Backend analytics and realtime endpoints updated to honor bot-filtering options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/analytics/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->