### PR TITLE
feat: bot traffic dashboard widgets (Livewire, React, Vue)

### DIFF
--- a/resources/js/react/components/BotTraffic.tsx
+++ b/resources/js/react/components/BotTraffic.tsx
@@ -49,7 +49,9 @@ export default function BotTraffic( {
     onIncludeBotsChange,
     className = '',
 }: BotTrafficProps ): React.ReactElement {
-    const normalizedLimit = Number.isFinite( limit ) ? Math.max( 0, Math.floor( limit ) ) : 0;
+    const normalizedLimit = Number.isFinite( limit )
+        ? Math.min( 100, Math.max( 1, Math.floor( limit ) ) )
+        : 10;
 
     const { data, loading, error } = useAnalyticsApi<BotStatsData>( {
         endpoint: 'bots',

--- a/resources/js/react/components/BotTraffic.tsx
+++ b/resources/js/react/components/BotTraffic.tsx
@@ -1,0 +1,144 @@
+/**
+ * BotTraffic React component.
+ *
+ * Surfaces bot traffic that is filtered out of the main reports by default:
+ * total bot visits, the bot share of total traffic, the busiest bot user
+ * agents, and a bot-only visit trend. Mirrors the Livewire BotTraffic widget.
+ *
+ * @since 1.2.0
+ */
+
+import React from 'react';
+import { Card, Table, Loading } from '@artisanpack-ui/react';
+
+import { useAnalyticsApi } from '../hooks/useAnalyticsApi';
+
+import type { TableHeader } from '@artisanpack-ui/react';
+import type { BotAgentItem, BotStatsData, DateRangePreset } from '../../types';
+
+export interface BotTrafficProps {
+    /** Date range preset to query. Defaults to '30d'. */
+    period?: DateRangePreset;
+    /** Optional site ID filter. */
+    siteId?: number;
+    /** Maximum number of bot user agents to display. */
+    limit?: number;
+    /** Initial data (e.g. from Inertia page props) to render before fetching. */
+    initialData?: BotStatsData;
+    /** Current bot-inclusion state of the main dashboard charts. */
+    includeBots?: boolean;
+    /** Called when the user toggles bot traffic in the main dashboard charts. */
+    onIncludeBotsChange?: ( includeBots: boolean ) => void;
+    /** Optional CSS class name for the container. */
+    className?: string;
+}
+
+const agentHeaders: TableHeader<BotAgentItem>[] = [
+    { key: 'user_agent', label: 'Bot user agent' },
+    { key: 'visits', label: 'Visits' },
+];
+
+const numberFormatter = new Intl.NumberFormat();
+
+export default function BotTraffic( {
+    period = '30d',
+    siteId,
+    limit = 10,
+    initialData,
+    includeBots,
+    onIncludeBotsChange,
+    className = '',
+}: BotTrafficProps ): React.ReactElement {
+    const { data, loading, error } = useAnalyticsApi<BotStatsData>( {
+        endpoint: 'bots',
+        params: { period, site_id: siteId, limit },
+        initialData,
+        fetchOnMount: ! initialData,
+    } );
+
+    const stats = data ?? initialData;
+    const trend = stats?.trend ?? [];
+    const trendMax = Math.max( 1, ...trend.map( ( point ) => point.visits ) );
+    const safeLimit = Number.isFinite( limit ) ? Math.max( 0, Math.floor( limit ) ) : 0;
+    const topAgents = ( stats?.top_agents ?? [] ).slice( 0, safeLimit );
+
+    return (
+        <Card title="Bot Traffic" className={className}>
+            <p className="text-sm text-base-content/60 mb-4">
+                Traffic identified as bots and excluded from your reports by default.
+            </p>
+
+            {onIncludeBotsChange && (
+                <label className="flex items-center gap-2 text-sm cursor-pointer select-none mb-4">
+                    <input
+                        type="checkbox"
+                        className="toggle toggle-sm"
+                        checked={includeBots ?? false}
+                        onChange={( event ) => onIncludeBotsChange( event.target.checked )}
+                        aria-label="Include bot traffic in dashboard charts"
+                    />
+                    <span>Include bot traffic in dashboard charts</span>
+                </label>
+            )}
+
+            {loading && ! stats ? (
+                <div className="flex justify-center py-8">
+                    <Loading size="lg" />
+                </div>
+            ) : error && ! stats ? (
+                <p className="text-error text-center py-4">{error}</p>
+            ) : (
+                <div className="space-y-6">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <div className="rounded-box bg-base-200 p-4">
+                            <div className="text-xs uppercase tracking-wide text-base-content/50">
+                                Bot visits
+                            </div>
+                            <div className="text-2xl font-bold font-mono">
+                                {numberFormatter.format( stats?.bot_visits ?? 0 )}
+                            </div>
+                        </div>
+                        <div className="rounded-box bg-base-200 p-4">
+                            <div className="text-xs uppercase tracking-wide text-base-content/50">
+                                % of total traffic
+                            </div>
+                            <div className="text-2xl font-bold font-mono">
+                                {( stats?.bot_percentage ?? 0 ).toFixed( 1 )}%
+                            </div>
+                        </div>
+                    </div>
+
+                    {trend.length > 0 && (
+                        <div>
+                            <div className="text-xs uppercase tracking-wide text-base-content/50 mb-2">
+                                Bot traffic trend
+                            </div>
+                            <div
+                                className="flex items-end gap-px h-16"
+                                role="img"
+                                aria-label="Bot visits over time for the selected date range."
+                            >
+                                {trend.map( ( point, index ) => (
+                                    <div
+                                        key={`${point.date}-${index}`}
+                                        className="flex-1 bg-primary/60 rounded-t min-h-[2px]"
+                                        style={{
+                                            height: `${Math.max( 2, Math.round( ( point.visits / trendMax ) * 100 ) )}%`,
+                                        }}
+                                        title={`${point.date}: ${numberFormatter.format( point.visits )}`}
+                                    />
+                                ) )}
+                            </div>
+                        </div>
+                    )}
+
+                    <Table<BotAgentItem>
+                        headers={agentHeaders}
+                        rows={topAgents}
+                        striped
+                    />
+                </div>
+            )}
+        </Card>
+    );
+}

--- a/resources/js/react/components/BotTraffic.tsx
+++ b/resources/js/react/components/BotTraffic.tsx
@@ -49,9 +49,11 @@ export default function BotTraffic( {
     onIncludeBotsChange,
     className = '',
 }: BotTrafficProps ): React.ReactElement {
+    const normalizedLimit = Number.isFinite( limit ) ? Math.max( 0, Math.floor( limit ) ) : 0;
+
     const { data, loading, error } = useAnalyticsApi<BotStatsData>( {
         endpoint: 'bots',
-        params: { period, site_id: siteId, limit },
+        params: { period, site_id: siteId, limit: normalizedLimit },
         initialData,
         fetchOnMount: ! initialData,
     } );
@@ -59,8 +61,7 @@ export default function BotTraffic( {
     const stats = data ?? initialData;
     const trend = stats?.trend ?? [];
     const trendMax = Math.max( 1, ...trend.map( ( point ) => point.visits ) );
-    const safeLimit = Number.isFinite( limit ) ? Math.max( 0, Math.floor( limit ) ) : 0;
-    const topAgents = ( stats?.top_agents ?? [] ).slice( 0, safeLimit );
+    const topAgents = ( stats?.top_agents ?? [] ).slice( 0, normalizedLimit );
 
     return (
         <Card title="Bot Traffic" className={className}>

--- a/resources/js/react/index.ts
+++ b/resources/js/react/index.ts
@@ -15,6 +15,7 @@ export { default as VisitorsChart } from './components/VisitorsChart';
 export { default as TopPages } from './components/TopPages';
 export { default as TrafficSources } from './components/TrafficSources';
 export { default as RealtimeVisitors } from './components/RealtimeVisitors';
+export { default as BotTraffic } from './components/BotTraffic';
 
 // Components (consent)
 export { default as ConsentBanner } from './components/ConsentBanner';

--- a/resources/js/types/api.ts
+++ b/resources/js/types/api.ts
@@ -143,6 +143,28 @@ export interface RealtimeResponse {
     data: RealtimeData;
 }
 
+// --- /bots ---
+
+export interface BotAgentItem {
+    user_agent: string;
+    visits: number;
+}
+
+export interface BotTrendPoint {
+    date: string;
+    visits: number;
+}
+
+export interface BotStatsData {
+    bot_visits: number;
+    total_visits: number;
+    bot_percentage: number;
+    top_agents: BotAgentItem[];
+    trend: BotTrendPoint[];
+}
+
+export type BotStatsResponse = ApiSuccessResponse<BotStatsData>;
+
 // --- /visitors ---
 
 export interface VisitorStatsData {

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -57,7 +57,11 @@ export type {
 // API response interfaces
 export type {
     AnalyticsQueryParams,
+    BotAgentItem,
     BotFilterMode,
+    BotStatsData,
+    BotStatsResponse,
+    BotTrendPoint,
     BrowserBreakdownItem,
     BrowserBreakdownResponse,
     ApiDataResponse,

--- a/resources/js/vue/components/BotTraffic.vue
+++ b/resources/js/vue/components/BotTraffic.vue
@@ -1,0 +1,153 @@
+<!--
+  BotTraffic Vue component.
+
+  Surfaces bot traffic that is filtered out of the main reports by default:
+  total bot visits, the bot share of total traffic, the busiest bot user
+  agents, and a bot-only visit trend. Mirrors the Livewire BotTraffic widget.
+
+  @since 1.2.0
+-->
+<script setup lang="ts">
+import { computed, reactive, watch } from 'vue';
+import { Card, Table, Loading } from '@artisanpack-ui/vue';
+
+import { useAnalyticsApi } from '../composables/useAnalyticsApi';
+
+import type { TableColumn } from '@artisanpack-ui/vue';
+import type { BotStatsData, DateRangePreset } from '../../types';
+
+const props = withDefaults( defineProps<{
+    /** Date range preset to query. Defaults to '30d'. */
+    period?: DateRangePreset;
+    /** Optional site ID filter. */
+    siteId?: number;
+    /** Maximum number of bot user agents to display. */
+    limit?: number;
+    /** Current bot-inclusion state of the main dashboard charts. */
+    includeBots?: boolean;
+}>(), {
+    period: '30d',
+    siteId: undefined,
+    limit: 10,
+    includeBots: false,
+} );
+
+const emit = defineEmits<{
+    includeBotsChange: [includeBots: boolean];
+}>();
+
+const params = reactive( {
+    period: props.period,
+    site_id: props.siteId,
+    limit: props.limit,
+} );
+
+const { data, loading, error, refresh } = useAnalyticsApi<BotStatsData>( {
+    endpoint: 'bots',
+    params,
+} );
+
+watch(
+    () => [ props.period, props.siteId, props.limit ],
+    () => {
+        params.period = props.period;
+        params.site_id = props.siteId;
+        params.limit = props.limit;
+        refresh();
+    },
+);
+
+const columns: TableColumn[] = [
+    { key: 'user_agent', label: 'Bot user agent' },
+    { key: 'visits', label: 'Visits' },
+];
+
+const numberFormatter = new Intl.NumberFormat();
+
+const botVisits = computed( () => data.value?.bot_visits ?? 0 );
+const botPercentage = computed( () => data.value?.bot_percentage ?? 0 );
+const trend = computed( () => data.value?.trend ?? [] );
+const trendMax = computed( () => Math.max( 1, ...trend.value.map( ( point ) => point.visits ) ) );
+const topAgents = computed( () => {
+    const raw = Number( props.limit );
+    const clampedLimit = Number.isFinite( raw ) ? Math.max( 0, Math.floor( raw ) ) : 0;
+
+    return ( data.value?.top_agents ?? [] ).slice( 0, clampedLimit );
+} );
+
+function handleIncludeBotsChange( event: Event ): void {
+    emit( 'includeBotsChange', ( event.target as HTMLInputElement ).checked );
+}
+</script>
+
+<template>
+    <Card title="Bot Traffic">
+        <p class="text-sm text-base-content/60 mb-4">
+            Traffic identified as bots and excluded from your reports by default.
+        </p>
+
+        <label class="flex items-center gap-2 text-sm cursor-pointer select-none mb-4">
+            <input
+                type="checkbox"
+                class="toggle toggle-sm"
+                :checked="props.includeBots"
+                aria-label="Include bot traffic in dashboard charts"
+                @change="handleIncludeBotsChange"
+            />
+            <span>Include bot traffic in dashboard charts</span>
+        </label>
+
+        <div v-if="loading && ! data" class="flex justify-center py-8">
+            <Loading size="lg" />
+        </div>
+        <p v-else-if="error && ! data" class="text-error text-center py-4">
+            {{ error }}
+        </p>
+        <div v-else class="space-y-6">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div class="rounded-box bg-base-200 p-4">
+                    <div class="text-xs uppercase tracking-wide text-base-content/50">
+                        Bot visits
+                    </div>
+                    <div class="text-2xl font-bold font-mono">
+                        {{ numberFormatter.format( botVisits ) }}
+                    </div>
+                </div>
+                <div class="rounded-box bg-base-200 p-4">
+                    <div class="text-xs uppercase tracking-wide text-base-content/50">
+                        % of total traffic
+                    </div>
+                    <div class="text-2xl font-bold font-mono">
+                        {{ botPercentage.toFixed( 1 ) }}%
+                    </div>
+                </div>
+            </div>
+
+            <div v-if="trend.length > 0">
+                <div class="text-xs uppercase tracking-wide text-base-content/50 mb-2">
+                    Bot traffic trend
+                </div>
+                <div
+                    class="flex items-end gap-px h-16"
+                    role="img"
+                    aria-label="Bot visits over time for the selected date range."
+                >
+                    <div
+                        v-for="( point, index ) in trend"
+                        :key="`${point.date}-${index}`"
+                        class="flex-1 bg-primary/60 rounded-t min-h-[2px]"
+                        :style="{ height: `${Math.max( 2, Math.round( ( point.visits / trendMax ) * 100 ) )}%` }"
+                        :title="`${point.date}: ${numberFormatter.format( point.visits )}`"
+                    />
+                </div>
+            </div>
+
+            <Table
+                :columns="columns"
+                :rows="topAgents"
+                striped
+                :empty-message="'No bot traffic detected for this period.'"
+            />
+        </div>
+    </Card>
+</template>

--- a/resources/js/vue/components/BotTraffic.vue
+++ b/resources/js/vue/components/BotTraffic.vue
@@ -36,10 +36,16 @@ const emit = defineEmits<{
     includeBotsChange: [includeBots: boolean];
 }>();
 
+const normalizedLimit = computed( () => {
+    const raw = Number( props.limit );
+
+    return Number.isFinite( raw ) ? Math.max( 0, Math.floor( raw ) ) : 0;
+} );
+
 const params = reactive( {
     period: props.period,
     site_id: props.siteId,
-    limit: props.limit,
+    limit: normalizedLimit.value,
 } );
 
 const { data, loading, error, refresh } = useAnalyticsApi<BotStatsData>( {
@@ -52,7 +58,7 @@ watch(
     () => {
         params.period = props.period;
         params.site_id = props.siteId;
-        params.limit = props.limit;
+        params.limit = normalizedLimit.value;
         refresh();
     },
 );
@@ -68,12 +74,7 @@ const botVisits = computed( () => data.value?.bot_visits ?? 0 );
 const botPercentage = computed( () => data.value?.bot_percentage ?? 0 );
 const trend = computed( () => data.value?.trend ?? [] );
 const trendMax = computed( () => Math.max( 1, ...trend.value.map( ( point ) => point.visits ) ) );
-const topAgents = computed( () => {
-    const raw = Number( props.limit );
-    const clampedLimit = Number.isFinite( raw ) ? Math.max( 0, Math.floor( raw ) ) : 0;
-
-    return ( data.value?.top_agents ?? [] ).slice( 0, clampedLimit );
-} );
+const topAgents = computed( () => ( data.value?.top_agents ?? [] ).slice( 0, normalizedLimit.value ) );
 
 function handleIncludeBotsChange( event: Event ): void {
     emit( 'includeBotsChange', ( event.target as HTMLInputElement ).checked );

--- a/resources/js/vue/components/BotTraffic.vue
+++ b/resources/js/vue/components/BotTraffic.vue
@@ -39,7 +39,7 @@ const emit = defineEmits<{
 const normalizedLimit = computed( () => {
     const raw = Number( props.limit );
 
-    return Number.isFinite( raw ) ? Math.max( 0, Math.floor( raw ) ) : 0;
+    return Number.isFinite( raw ) ? Math.min( 100, Math.max( 1, Math.floor( raw ) ) ) : 10;
 } );
 
 const params = reactive( {

--- a/resources/js/vue/index.ts
+++ b/resources/js/vue/index.ts
@@ -15,6 +15,7 @@ export { default as VisitorsChart } from './components/VisitorsChart.vue';
 export { default as TopPages } from './components/TopPages.vue';
 export { default as TrafficSources } from './components/TrafficSources.vue';
 export { default as RealtimeVisitors } from './components/RealtimeVisitors.vue';
+export { default as BotTraffic } from './components/BotTraffic.vue';
 
 // Components (consent)
 export { default as ConsentBanner } from './components/ConsentBanner.vue';

--- a/resources/views/livewire/analytics-dashboard.blade.php
+++ b/resources/views/livewire/analytics-dashboard.blade.php
@@ -295,5 +295,14 @@
 				</x-artisanpack-card>
 			</div>
 		@endif
+
+		{{-- Bots Tab --}}
+		@if ( $activeTab === 'bots' )
+			<livewire:artisanpack-analytics::widgets.bot-traffic
+				:date-range-preset="$dateRangePreset"
+				:site-id="$siteId"
+				:limit="10"
+			/>
+		@endif
 	</div>
 </div>

--- a/resources/views/livewire/widgets/bot-traffic.blade.php
+++ b/resources/views/livewire/widgets/bot-traffic.blade.php
@@ -90,7 +90,7 @@
 						</thead>
 						<tbody>
 							@foreach ( $topAgents as $agent )
-								<tr class="hover:bg-base-200/50" wire:key="bot-agent-{{ $loop->index }}">
+								<tr class="hover:bg-base-200/50" wire:key="bot-agent-{{ md5( $agent['user_agent'] ) }}">
 									<td class="max-w-md truncate" title="{{ $agent['user_agent'] }}">
 										<span class="font-mono text-xs">{{ $agent['user_agent'] }}</span>
 									</td>

--- a/resources/views/livewire/widgets/bot-traffic.blade.php
+++ b/resources/views/livewire/widgets/bot-traffic.blade.php
@@ -1,0 +1,108 @@
+<div>
+	{{-- Loading State --}}
+	@if ( $isLoading )
+		<x-artisanpack-card>
+			<div class="h-4 bg-base-300 rounded w-1/4 mb-4 animate-pulse"></div>
+			<div class="grid grid-cols-2 gap-4 mb-4">
+				<div class="h-16 bg-base-300 rounded animate-pulse"></div>
+				<div class="h-16 bg-base-300 rounded animate-pulse"></div>
+			</div>
+			@foreach ( range( 1, 5 ) as $i )
+				<div class="flex justify-between py-2 animate-pulse">
+					<div class="h-4 bg-base-300 rounded w-2/3"></div>
+					<div class="h-4 bg-base-300 rounded w-16"></div>
+				</div>
+			@endforeach
+		</x-artisanpack-card>
+	@else
+		<x-artisanpack-card :title="__( 'Bot Traffic' )">
+			<x-slot:menu>
+				<x-artisanpack-button
+					wire:click="refreshData"
+					class="btn-ghost btn-xs"
+					icon="o-arrow-path"
+					spinner
+					:tooltip="__( 'Refresh' )"
+				/>
+			</x-slot:menu>
+
+			<p class="text-sm text-base-content/60 mb-4">
+				{{ __( 'Traffic identified as bots and excluded from your reports by default.' ) }}
+			</p>
+
+			{{-- Summary stats --}}
+			<div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+				<div class="rounded-box bg-base-200 p-4">
+					<div class="text-xs uppercase tracking-wide text-base-content/50">
+						{{ __( 'Bot visits' ) }}
+					</div>
+					<div class="text-2xl font-bold font-mono">
+						{{ number_format( $botVisits ) }}
+					</div>
+				</div>
+				<div class="rounded-box bg-base-200 p-4">
+					<div class="text-xs uppercase tracking-wide text-base-content/50">
+						{{ __( '% of total traffic' ) }}
+					</div>
+					<div class="text-2xl font-bold font-mono">
+						{{ number_format( $botPercentage, 1 ) }}%
+					</div>
+				</div>
+			</div>
+
+			{{-- Trend sparkline --}}
+			@if ( ! empty( $trend ) )
+				@php( $trendMax = $this->getTrendMax() )
+				<div class="mb-6">
+					<div class="text-xs uppercase tracking-wide text-base-content/50 mb-2">
+						{{ __( 'Bot traffic trend' ) }}
+					</div>
+					<div
+						class="flex items-end gap-px h-16"
+						role="img"
+						aria-label="{{ __( 'Bot visits over time for the selected date range.' ) }}"
+					>
+						@foreach ( $trend as $point )
+							<div
+								class="flex-1 bg-primary/60 rounded-t min-h-[2px]"
+								style="height: {{ max( 2, (int) round( ( $point['visits'] / $trendMax ) * 100 ) ) }}%"
+								title="{{ $point['date'] }}: {{ number_format( $point['visits'] ) }}"
+							></div>
+						@endforeach
+					</div>
+				</div>
+			@endif
+
+			{{-- Top bot user agents --}}
+			@if ( $topAgents->isEmpty() )
+				<div class="flex flex-col items-center justify-center py-8 text-base-content/50">
+					<x-artisanpack-icon name="o-bug-ant" class="w-12 h-12 mb-2" />
+					<p>{{ __( 'No bot traffic detected for this period' ) }}</p>
+				</div>
+			@else
+				<div class="overflow-x-auto">
+					<table class="table table-sm">
+						<thead>
+							<tr>
+								<th>{{ __( 'Bot user agent' ) }}</th>
+								<th class="text-right">{{ __( 'Visits' ) }}</th>
+							</tr>
+						</thead>
+						<tbody>
+							@foreach ( $topAgents as $agent )
+								<tr class="hover:bg-base-200/50" wire:key="bot-agent-{{ $loop->index }}">
+									<td class="max-w-md truncate" title="{{ $agent['user_agent'] }}">
+										<span class="font-mono text-xs">{{ $agent['user_agent'] }}</span>
+									</td>
+									<td class="text-right font-mono">
+										{{ number_format( $agent['visits'] ) }}
+									</td>
+								</tr>
+							@endforeach
+						</tbody>
+					</table>
+				</div>
+			@endif
+		</x-artisanpack-card>
+	@endif
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -91,6 +91,9 @@ Route::middleware( config( 'artisanpack.analytics.dashboard_middleware', [ 'auth
 
 	Route::get( '/realtime', [ AnalyticsQueryController::class, 'realtime' ] )
 		->name( 'analytics.realtime' );
+
+	Route::get( '/bots', [ AnalyticsQueryController::class, 'bots' ] )
+		->name( 'analytics.bots' );
 } );
 
 /*
@@ -151,6 +154,9 @@ Route::middleware( [ 'analytics.api-key' ] )->prefix( 'v1' )->group( function ()
 
 	Route::get( '/realtime', [ AnalyticsQueryController::class, 'realtime' ] )
 		->name( 'analytics.api.realtime' );
+
+	Route::get( '/bots', [ AnalyticsQueryController::class, 'bots' ] )
+		->name( 'analytics.api.bots' );
 
 	/*
 	|--------------------------------------------------------------------------

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -519,6 +519,24 @@ class Analytics implements AnalyticsQueryInterface, AnalyticsServiceInterface
     }
 
     /**
+     * Get the top bot user agents by visit count.
+     *
+     * Uses the first provider that supports queries.
+     *
+     * @param  DateRange  $range  The date range to query.
+     * @param  int  $limit  Maximum number of user agents to return.
+     * @param  array<string, mixed>  $filters  Optional filters to apply (site/tenant scoping).
+     *
+     * @return Collection<int, array{user_agent: string, visits: int}>
+     *
+     * @since 1.2.0
+     */
+    public function getTopBotAgents( DateRange $range, int $limit = 10, array $filters = [] ): Collection
+    {
+        return $this->queryWithProvider( fn ( AnalyticsQueryInterface $p ) => $p->getTopBotAgents( $range, $limit, $filters ), collect() );
+    }
+
+    /**
      * Get device breakdown.
      *
      * Uses the first provider that supports queries.

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -615,6 +615,7 @@ class AnalyticsServiceProvider extends ServiceProvider
         \Livewire\Livewire::component( 'artisanpack-analytics::widgets.top-pages', Http\Livewire\Widgets\TopPages::class );
         \Livewire\Livewire::component( 'artisanpack-analytics::widgets.traffic-sources', Http\Livewire\Widgets\TrafficSources::class );
         \Livewire\Livewire::component( 'artisanpack-analytics::widgets.realtime-visitors', Http\Livewire\Widgets\RealtimeVisitors::class );
+        \Livewire\Livewire::component( 'artisanpack-analytics::widgets.bot-traffic', Http\Livewire\Widgets\BotTraffic::class );
     }
 
     /**

--- a/src/Contracts/AnalyticsQueryInterface.php
+++ b/src/Contracts/AnalyticsQueryInterface.php
@@ -166,5 +166,21 @@ interface AnalyticsQueryInterface
 	 *
 	 * @since 1.0.0
 	 */
-	public function getRealTimeVisitors( int $minutes = 5, array $filters = []): int;
+	public function getRealTimeVisitors( int $minutes = 5, array $filters = [] ): int;
+
+	/**
+	 * Get the top bot user agents by visit count.
+	 *
+	 * Returns confirmed bot visitors grouped by user agent within the date
+	 * range, ordered by the number of matching visitors.
+	 *
+	 * @param DateRange            $range   The date range to query.
+	 * @param int                  $limit   Maximum number of user agents to return.
+	 * @param array<string, mixed> $filters Optional filters to apply (site/tenant scoping).
+	 *
+	 * @return Collection<int, array{user_agent: string, visits: int}>
+	 *
+	 * @since 1.2.0
+	 */
+	public function getTopBotAgents( DateRange $range, int $limit = 10, array $filters = []): Collection;
 }

--- a/src/Http/Controllers/AnalyticsQueryController.php
+++ b/src/Http/Controllers/AnalyticsQueryController.php
@@ -216,6 +216,34 @@ class AnalyticsQueryController extends Controller
 	}
 
 	/**
+	 * Get bot-traffic statistics.
+	 *
+	 * GET /api/analytics/bots
+	 *
+	 * @param Request $request The HTTP request.
+	 *
+	 * @return JsonResponse
+	 *
+	 * @since 1.2.0
+	 */
+	public function bots( Request $request ): JsonResponse
+	{
+		$range       = $this->getDateRange( $request );
+		$limit       = $this->getLimit( $request );
+		$granularity = $request->query( 'granularity', 'day' );
+		$granularity = in_array( $granularity, [ 'hour', 'day', 'week', 'month' ], true ) ? $granularity : 'day';
+		$filters     = $this->getFilters( $request );
+
+		$stats = $this->analyticsQuery->getBotStats( $range, $limit, $granularity, $filters );
+
+		return response()->json( [
+			'success' => true,
+			'data'    => $stats,
+			'range'   => $range->toArray(),
+		] );
+	}
+
+	/**
 	 * Get visitor data (API-key authenticated).
 	 *
 	 * GET /api/analytics/v1/visitors

--- a/src/Http/Livewire/AnalyticsDashboard.php
+++ b/src/Http/Livewire/AnalyticsDashboard.php
@@ -186,6 +186,10 @@ class AnalyticsDashboard extends Component
 				'label' => __( 'Audience' ),
 				'icon'  => 'users',
 			],
+			'bots' => [
+				'label' => __( 'Bots' ),
+				'icon'  => 'bug-ant',
+			],
 		];
 	}
 

--- a/src/Http/Livewire/Widgets/BotTraffic.php
+++ b/src/Http/Livewire/Widgets/BotTraffic.php
@@ -1,0 +1,149 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Livewire\Widgets;
+
+use ArtisanPackUI\Analytics\Http\Livewire\Concerns\WithAnalyticsWidget;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\On;
+use Livewire\Component;
+
+/**
+ * Bot Traffic Widget.
+ *
+ * Surfaces the bot traffic that is filtered out of the main dashboard by
+ * default: total bot visits, the bot share of total traffic, the busiest
+ * bot user agents, and a bot-only visit trend.
+ *
+ * @since   1.2.0
+ *
+ * @package ArtisanPackUI\Analytics\Http\Livewire\Widgets
+ */
+class BotTraffic extends Component
+{
+	use WithAnalyticsWidget;
+
+	/**
+	 * Total bot visits for the current range.
+	 */
+	public int $botVisits = 0;
+
+	/**
+	 * Total visits (human and bot) for the current range.
+	 */
+	public int $totalVisits = 0;
+
+	/**
+	 * Bot share of total traffic as a percentage.
+	 */
+	public float $botPercentage = 0.0;
+
+	/**
+	 * The top bot user agents.
+	 *
+	 * @var Collection<int, array{user_agent: string, visits: int}>
+	 */
+	public Collection $topAgents;
+
+	/**
+	 * The bot-only visit trend.
+	 *
+	 * @var array<int, array{date: string, visits: int}>
+	 */
+	public array $trend = [];
+
+	/**
+	 * Maximum number of bot user agents to display.
+	 */
+	public int $limit = 10;
+
+	/**
+	 * Mount the component.
+	 *
+	 * @param string|null $dateRangePreset The initial date range.
+	 * @param int|null    $siteId          Site ID filter.
+	 * @param int         $limit           Maximum bot user agents to show.
+	 *
+	 * @since 1.2.0
+	 */
+	public function mount(
+		?string $dateRangePreset = null,
+		?int $siteId = null,
+		int $limit = 10,
+	): void {
+		$this->topAgents = collect();
+		$this->initializeWidget( $dateRangePreset, $siteId );
+		$this->limit = $limit;
+		$this->loadBotStats();
+	}
+
+	/**
+	 * Load the bot traffic statistics.
+	 *
+	 * @since 1.2.0
+	 */
+	public function loadBotStats(): void
+	{
+		$this->isLoading = true;
+
+		$stats = $this->getAnalyticsQuery()->getBotStats(
+			$this->getDateRange(),
+			$this->limit,
+			'day',
+			$this->getFilters(),
+		);
+
+		$this->botVisits     = $stats['bot_visits'];
+		$this->totalVisits   = $stats['total_visits'];
+		$this->botPercentage = $stats['bot_percentage'];
+		$this->topAgents     = collect( $stats['top_agents'] );
+		$this->trend         = $stats['trend'];
+
+		$this->isLoading = false;
+	}
+
+	/**
+	 * Refresh the widget data.
+	 *
+	 * @since 1.2.0
+	 */
+	#[On( 'refresh-analytics-widgets' )]
+	public function refreshData(): void
+	{
+		$this->loadBotStats();
+	}
+
+	/**
+	 * Get the maximum visit count across the trend points.
+	 *
+	 * Used to scale the sparkline bars. Returns at least 1 to avoid
+	 * division by zero.
+	 *
+	 * @since 1.2.0
+	 */
+	public function getTrendMax(): int
+	{
+		$max = 0;
+
+		foreach ( $this->trend as $point ) {
+			if ( $point['visits'] > $max ) {
+				$max = $point['visits'];
+			}
+		}
+
+		return max( 1, $max );
+	}
+
+	/**
+	 * Get the view for the component.
+	 *
+	 * @return \Illuminate\Contracts\View\View The component view.
+	 *
+	 * @since 1.2.0
+	 */
+	public function render(): \Illuminate\Contracts\View\View
+	{
+		return view( 'artisanpack-analytics::livewire.widgets.bot-traffic' );
+	}
+}

--- a/src/Http/Livewire/Widgets/BotTraffic.php
+++ b/src/Http/Livewire/Widgets/BotTraffic.php
@@ -74,7 +74,7 @@ class BotTraffic extends Component
 	): void {
 		$this->topAgents = collect();
 		$this->initializeWidget( $dateRangePreset, $siteId );
-		$this->limit = $limit;
+		$this->limit = max( 1, min( $limit, 100 ) );
 		$this->loadBotStats();
 	}
 

--- a/src/Providers/AbstractAnalyticsProvider.php
+++ b/src/Providers/AbstractAnalyticsProvider.php
@@ -317,6 +317,24 @@ abstract class AbstractAnalyticsProvider implements AnalyticsProviderInterface, 
     }
 
     /**
+     * Get the top bot user agents by visit count.
+     *
+     * Default implementation returns empty collection. Override in subclasses.
+     *
+     * @param  DateRange  $range  The date range to query.
+     * @param  int  $limit  Maximum number of user agents to return.
+     * @param  array<string, mixed>  $filters  Optional filters to apply (site/tenant scoping).
+     *
+     * @return Collection<int, array{user_agent: string, visits: int}>
+     *
+     * @since 1.2.0
+     */
+    public function getTopBotAgents( DateRange $range, int $limit = 10, array $filters = [] ): Collection
+    {
+        return collect();
+    }
+
+    /**
      * Get device breakdown.
      *
      * Default implementation returns empty collection. Override in subclasses.

--- a/src/Providers/LocalAnalyticsProvider.php
+++ b/src/Providers/LocalAnalyticsProvider.php
@@ -533,6 +533,45 @@ class LocalAnalyticsProvider extends AbstractAnalyticsProvider
     }
 
     /**
+     * Get the top bot user agents by visit count.
+     *
+     * Groups confirmed bot visitors seen within the date range by user agent
+     * and returns the busiest agents first. The `only` bot mode is forced so
+     * the result always reflects bot traffic regardless of caller filters.
+     *
+     * @param  DateRange  $range  The date range to query.
+     * @param  int  $limit  Maximum number of user agents to return.
+     * @param  array<string, mixed>  $filters  Optional filters to apply (site/tenant scoping).
+     *
+     * @return Collection<int, array{user_agent: string, visits: int}>
+     *
+     * @since 1.2.0
+     */
+    public function getTopBotAgents( DateRange $range, int $limit = 10, array $filters = [] ): Collection
+    {
+        return $this->safeQuery(
+            function () use ( $range, $limit, $filters ) {
+                return $this->applyFilters( Visitor::query(), array_merge( $filters, ['bots' => 'only'] ) )
+                    ->whereBetween( 'last_seen_at', [$range->startDate, $range->endDate] )
+                    ->whereNotNull( 'user_agent' )
+                    ->select( [
+                        'user_agent',
+                        DB::raw( 'COUNT(*) as visits' ),
+                    ] )
+                    ->groupBy( 'user_agent' )
+                    ->orderByDesc( 'visits' )
+                    ->limit( $limit )
+                    ->get()
+                    ->map( fn ( $row ) => [
+                        'user_agent' => (string) $row->user_agent,
+                        'visits'     => (int) $row->visits,
+                    ] );
+            },
+            collect(),
+        );
+    }
+
+    /**
      * Get statistics summary for a date range.
      *
      * @param  DateRange  $range  The date range to query.

--- a/src/Providers/LocalAnalyticsProvider.php
+++ b/src/Providers/LocalAnalyticsProvider.php
@@ -535,9 +535,10 @@ class LocalAnalyticsProvider extends AbstractAnalyticsProvider
     /**
      * Get the top bot user agents by visit count.
      *
-     * Groups confirmed bot visitors seen within the date range by user agent
-     * and returns the busiest agents first. The `only` bot mode is forced so
-     * the result always reflects bot traffic regardless of caller filters.
+     * Counts bot page views within the date range grouped by the visitor's
+     * user agent and returns the busiest agents first. The `only` bot mode is
+     * forced so the result always reflects bot traffic regardless of caller
+     * filters.
      *
      * @param  DateRange  $range  The date range to query.
      * @param  int  $limit  Maximum number of user agents to return.
@@ -551,14 +552,15 @@ class LocalAnalyticsProvider extends AbstractAnalyticsProvider
     {
         return $this->safeQuery(
             function () use ( $range, $limit, $filters ) {
-                return $this->applyFilters( Visitor::query(), array_merge( $filters, ['bots' => 'only'] ) )
-                    ->whereBetween( 'last_seen_at', [$range->startDate, $range->endDate] )
-                    ->whereNotNull( 'user_agent' )
+                return $this->applyFilters( PageView::query(), array_merge( $filters, ['bots' => 'only'] ) )
+                    ->join( 'analytics_visitors', 'analytics_page_views.visitor_id', '=', 'analytics_visitors.id' )
+                    ->whereBetween( 'analytics_page_views.created_at', [$range->startDate, $range->endDate] )
+                    ->whereNotNull( 'analytics_visitors.user_agent' )
                     ->select( [
-                        'user_agent',
+                        'analytics_visitors.user_agent as user_agent',
                         DB::raw( 'COUNT(*) as visits' ),
                     ] )
-                    ->groupBy( 'user_agent' )
+                    ->groupBy( 'analytics_visitors.user_agent' )
                     ->orderByDesc( 'visits' )
                     ->limit( $limit )
                     ->get()

--- a/src/Services/AnalyticsQuery.php
+++ b/src/Services/AnalyticsQuery.php
@@ -266,6 +266,78 @@ class AnalyticsQuery
     }
 
     /**
+     * Get the top bot user agents by visit count.
+     *
+     * Always scoped to bot traffic; any incoming bot mode is ignored.
+     *
+     * @param  DateRange  $range  The date range to query.
+     * @param  int  $limit  Maximum number of user agents to return.
+     * @param  array<string, mixed>  $filters  Optional filters to apply (site/tenant scoping).
+     *
+     * @return Collection<int, array{user_agent: string, visits: int}>
+     *
+     * @since 1.2.0
+     */
+    public function getTopBotAgents( DateRange $range, int $limit = 10, array $filters = [] ): Collection
+    {
+        unset( $filters['bots'] );
+        $cacheKey = $this->buildCacheKey( 'top_bot_agents', $range, $filters, $limit );
+
+        return $this->cached( $cacheKey, fn () => $this->provider->getTopBotAgents( $range, $limit, $filters ) );
+    }
+
+    /**
+     * Get an aggregated summary of bot traffic for a date range.
+     *
+     * Combines bot-only visitor counts, the bot share of total traffic, the
+     * busiest bot user agents, and a bot-only visit trend so dashboards can
+     * surface filtered traffic in a single call.
+     *
+     * @param  DateRange  $range  The date range to query.
+     * @param  int  $agentLimit  Maximum number of bot user agents to return.
+     * @param  string  $granularity  Trend grouping granularity ('hour', 'day', 'week', 'month').
+     * @param  array<string, mixed>  $filters  Optional filters to apply (site/tenant scoping).
+     *
+     * @return array{
+     *     bot_visits: int,
+     *     total_visits: int,
+     *     bot_percentage: float,
+     *     top_agents: array<int, array{user_agent: string, visits: int}>,
+     *     trend: array<int, array{date: string, visits: int}>
+     * }
+     *
+     * @since 1.2.0
+     */
+    public function getBotStats( DateRange $range, int $agentLimit = 10, string $granularity = 'day', array $filters = [] ): array
+    {
+        // This method controls bot scoping itself, so discard any caller mode.
+        unset( $filters['bots'] );
+
+        $botVisits   = $this->getVisitors( $range, array_merge( $filters, ['bots' => 'only'] ) );
+        $totalVisits = $this->getVisitors( $range, array_merge( $filters, ['bots' => 'include'] ) );
+
+        $percentage = $totalVisits > 0
+            ? round( ( $botVisits / $totalVisits ) * 100, 1 )
+            : 0.0;
+
+        $trend = $this->getPageViews( $range, $granularity, array_merge( $filters, ['bots' => 'only'] ) )
+            ->map( fn ( array $row ) => [
+                'date'   => $row['date'],
+                'visits' => $row['visitors'],
+            ] )
+            ->values()
+            ->all();
+
+        return [
+            'bot_visits'     => $botVisits,
+            'total_visits'   => $totalVisits,
+            'bot_percentage' => $percentage,
+            'top_agents'     => $this->getTopBotAgents( $range, $agentLimit, $filters )->values()->all(),
+            'trend'          => $trend,
+        ];
+    }
+
+    /**
      * Get traffic sources.
      *
      * @param  DateRange  $range  The date range to query.

--- a/tests/Feature/BotStatsQueryTest.php
+++ b/tests/Feature/BotStatsQueryTest.php
@@ -40,23 +40,27 @@ function botStatsVisitor( bool $isBot, ?string $userAgent = null, ?int $siteId =
 /**
  * Create a page view tied to a visitor id.
  */
-function botStatsPageView( string $visitorId, string $path = '/' ): void
+function botStatsPageView( string $visitorId, string $path = '/', ?int $siteId = null ): string
 {
     PageView::create( [
         'path'       => $path,
         'session_id' => 'session-' . $visitorId,
         'visitor_id' => $visitorId,
+        'site_id'    => $siteId,
         'created_at' => now(),
     ] );
+
+    return $visitorId;
 }
 
-test( 'getTopBotAgents returns only bot agents ordered by visits', function (): void {
+test( 'getTopBotAgents counts bot page views ordered by visit count', function (): void {
     $provider = new LocalAnalyticsProvider;
 
-    botStatsVisitor( true, 'GPTBot/1.0' );
-    botStatsVisitor( true, 'GPTBot/1.0' );
-    botStatsVisitor( true, 'ClaudeBot/1.0' );
-    botStatsVisitor( false, 'Mozilla/5.0 (real human)' );
+    // Two GPTBot page views, one ClaudeBot, plus a human that must be excluded.
+    botStatsPageView( botStatsVisitor( true, 'GPTBot/1.0' ) );
+    botStatsPageView( botStatsVisitor( true, 'GPTBot/1.0' ) );
+    botStatsPageView( botStatsVisitor( true, 'ClaudeBot/1.0' ) );
+    botStatsPageView( botStatsVisitor( false, 'Mozilla/5.0 (real human)' ) );
 
     $agents = $provider->getTopBotAgents( DateRange::today() );
 
@@ -68,8 +72,8 @@ test( 'getTopBotAgents returns only bot agents ordered by visits', function (): 
 test( 'getTopBotAgents ignores bot visitors without a user agent', function (): void {
     $provider = new LocalAnalyticsProvider;
 
-    botStatsVisitor( true, null );
-    botStatsVisitor( true, 'ByteSpider' );
+    botStatsPageView( botStatsVisitor( true, null ) );
+    botStatsPageView( botStatsVisitor( true, 'ByteSpider' ) );
 
     $agents = $provider->getTopBotAgents( DateRange::today() );
 
@@ -80,8 +84,8 @@ test( 'getTopBotAgents ignores bot visitors without a user agent', function (): 
 test( 'getTopBotAgents respects site scoping', function (): void {
     $provider = new LocalAnalyticsProvider;
 
-    botStatsVisitor( true, 'GPTBot', 1 );
-    botStatsVisitor( true, 'ClaudeBot', 2 );
+    botStatsPageView( botStatsVisitor( true, 'GPTBot', 1 ), '/a', 1 );
+    botStatsPageView( botStatsVisitor( true, 'ClaudeBot', 2 ), '/b', 2 );
 
     $agents = $provider->getTopBotAgents( DateRange::today(), 10, [ 'site_id' => 1 ] );
 

--- a/tests/Feature/BotStatsQueryTest.php
+++ b/tests/Feature/BotStatsQueryTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Data\DateRange;
+use ArtisanPackUI\Analytics\Http\Controllers\AnalyticsQueryController;
+use ArtisanPackUI\Analytics\Models\PageView;
+use ArtisanPackUI\Analytics\Models\Visitor;
+use ArtisanPackUI\Analytics\Providers\LocalAnalyticsProvider;
+use ArtisanPackUI\Analytics\Services\AnalyticsQuery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    config()->set( 'artisanpack.analytics.local.queue_processing', false );
+    config()->set( 'artisanpack.analytics.local.enabled', true );
+} );
+
+/**
+ * Create a visitor with the given bot state and user agent, returning its id.
+ */
+function botStatsVisitor( bool $isBot, ?string $userAgent = null, ?int $siteId = null ): string
+{
+    $visitor = Visitor::create( [
+        'fingerprint'   => bin2hex( random_bytes( 16 ) ),
+        'site_id'       => $siteId,
+        'first_seen_at' => now(),
+        'last_seen_at'  => now(),
+        'device_type'   => 'desktop',
+        'user_agent'    => $userAgent,
+        'is_bot'        => $isBot,
+        'bot_score'     => $isBot ? 90 : null,
+    ] );
+
+    return (string) $visitor->id;
+}
+
+/**
+ * Create a page view tied to a visitor id.
+ */
+function botStatsPageView( string $visitorId, string $path = '/' ): void
+{
+    PageView::create( [
+        'path'       => $path,
+        'session_id' => 'session-' . $visitorId,
+        'visitor_id' => $visitorId,
+        'created_at' => now(),
+    ] );
+}
+
+test( 'getTopBotAgents returns only bot agents ordered by visits', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    botStatsVisitor( true, 'GPTBot/1.0' );
+    botStatsVisitor( true, 'GPTBot/1.0' );
+    botStatsVisitor( true, 'ClaudeBot/1.0' );
+    botStatsVisitor( false, 'Mozilla/5.0 (real human)' );
+
+    $agents = $provider->getTopBotAgents( DateRange::today() );
+
+    expect( $agents->pluck( 'user_agent' )->all() )->toBe( [ 'GPTBot/1.0', 'ClaudeBot/1.0' ] );
+    expect( $agents->first() )->toMatchArray( [ 'user_agent' => 'GPTBot/1.0', 'visits' => 2 ] );
+    expect( $agents->pluck( 'user_agent' )->all() )->not->toContain( 'Mozilla/5.0 (real human)' );
+} );
+
+test( 'getTopBotAgents ignores bot visitors without a user agent', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    botStatsVisitor( true, null );
+    botStatsVisitor( true, 'ByteSpider' );
+
+    $agents = $provider->getTopBotAgents( DateRange::today() );
+
+    expect( $agents )->toHaveCount( 1 );
+    expect( $agents->first()['user_agent'] )->toBe( 'ByteSpider' );
+} );
+
+test( 'getTopBotAgents respects site scoping', function (): void {
+    $provider = new LocalAnalyticsProvider;
+
+    botStatsVisitor( true, 'GPTBot', 1 );
+    botStatsVisitor( true, 'ClaudeBot', 2 );
+
+    $agents = $provider->getTopBotAgents( DateRange::today(), 10, [ 'site_id' => 1 ] );
+
+    expect( $agents->pluck( 'user_agent' )->all() )->toBe( [ 'GPTBot' ] );
+} );
+
+test( 'getBotStats summarizes bot visits, percentage, agents and trend', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    // Three human visits, one bot visit => 25% bot share.
+    botStatsPageView( botStatsVisitor( false, 'Human A' ), '/a' );
+    botStatsPageView( botStatsVisitor( false, 'Human B' ), '/b' );
+    botStatsPageView( botStatsVisitor( false, 'Human C' ), '/c' );
+    botStatsPageView( botStatsVisitor( true, 'GPTBot' ), '/bot' );
+
+    $stats = $query->getBotStats( DateRange::today() );
+
+    expect( $stats['bot_visits'] )->toBe( 1 );
+    expect( $stats['total_visits'] )->toBe( 4 );
+    expect( $stats['bot_percentage'] )->toBe( 25.0 );
+    expect( $stats['top_agents'] )->toBe( [ [ 'user_agent' => 'GPTBot', 'visits' => 1 ] ] );
+    expect( $stats['trend'] )->toBeArray();
+} );
+
+test( 'getBotStats returns a zero percentage when there is no traffic', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    $stats = $query->getBotStats( DateRange::today() );
+
+    expect( $stats['bot_visits'] )->toBe( 0 );
+    expect( $stats['total_visits'] )->toBe( 0 );
+    expect( $stats['bot_percentage'] )->toBe( 0.0 );
+    expect( $stats['top_agents'] )->toBe( [] );
+} );
+
+test( 'getBotStats ignores an incoming bot filter mode', function (): void {
+    $query = ( new AnalyticsQuery( new LocalAnalyticsProvider ) )->setCacheEnabled( false );
+
+    botStatsPageView( botStatsVisitor( false, 'Human' ), '/a' );
+    botStatsPageView( botStatsVisitor( true, 'GPTBot' ), '/bot' );
+
+    // Passing bots => only must not change the computed totals.
+    $stats = $query->getBotStats( DateRange::today(), 10, 'day', [ 'bots' => 'only' ] );
+
+    expect( $stats['bot_visits'] )->toBe( 1 );
+    expect( $stats['total_visits'] )->toBe( 2 );
+} );
+
+test( 'bots controller endpoint returns the bot stats envelope', function (): void {
+    botStatsPageView( botStatsVisitor( false, 'Human' ), '/a' );
+    botStatsPageView( botStatsVisitor( true, 'GPTBot' ), '/bot' );
+
+    $controller = new AnalyticsQueryController( app( AnalyticsQuery::class ) );
+    $response   = $controller->bots( Request::create( '/api/analytics/bots', 'GET', [ 'period' => 'today' ] ) );
+
+    expect( $response->getStatusCode() )->toBe( 200 );
+
+    $payload = $response->getData( true );
+
+    expect( $payload['success'] )->toBeTrue();
+    expect( $payload['data'] )->toHaveKeys( [ 'bot_visits', 'total_visits', 'bot_percentage', 'top_agents', 'trend' ] );
+    expect( $payload['data']['bot_visits'] )->toBe( 1 );
+    expect( $payload )->toHaveKey( 'range' );
+} );

--- a/tests/Feature/Livewire/BotTrafficTest.php
+++ b/tests/Feature/Livewire/BotTrafficTest.php
@@ -36,7 +36,7 @@ function botWidgetVisitor( bool $isBot, ?string $userAgent = null ): string
 /**
  * Create a page view tied to a visitor id.
  */
-function botWidgetPageView( string $visitorId, string $path = '/' ): void
+function botWidgetPageView( string $visitorId, string $path = '/' ): string
 {
     PageView::create( [
         'path'       => $path,
@@ -44,6 +44,8 @@ function botWidgetPageView( string $visitorId, string $path = '/' ): void
         'visitor_id' => $visitorId,
         'created_at' => now(),
     ] );
+
+    return $visitorId;
 }
 
 test( 'bot traffic widget can be rendered', function (): void {
@@ -63,9 +65,9 @@ test( 'bot traffic widget loads bot statistics on mount', function (): void {
 } );
 
 test( 'bot traffic widget lists the top bot user agents', function (): void {
-    botWidgetVisitor( true, 'GPTBot' );
-    botWidgetVisitor( true, 'GPTBot' );
-    botWidgetVisitor( true, 'ClaudeBot' );
+    botWidgetPageView( botWidgetVisitor( true, 'GPTBot' ) );
+    botWidgetPageView( botWidgetVisitor( true, 'GPTBot' ) );
+    botWidgetPageView( botWidgetVisitor( true, 'ClaudeBot' ) );
 
     Livewire::test( BotTraffic::class )
         ->assertSee( 'GPTBot' )

--- a/tests/Feature/Livewire/BotTrafficTest.php
+++ b/tests/Feature/Livewire/BotTrafficTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Http\Livewire\Widgets\BotTraffic;
+use ArtisanPackUI\Analytics\Models\PageView;
+use ArtisanPackUI\Analytics\Models\Visitor;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses( RefreshDatabase::class );
+
+beforeEach( function (): void {
+    config()->set( 'artisanpack.analytics.local.queue_processing', false );
+    config()->set( 'artisanpack.analytics.local.enabled', true );
+} );
+
+/**
+ * Create a visitor with the given bot state and user agent, returning its id.
+ */
+function botWidgetVisitor( bool $isBot, ?string $userAgent = null ): string
+{
+    $visitor = Visitor::create( [
+        'fingerprint'   => bin2hex( random_bytes( 16 ) ),
+        'first_seen_at' => now(),
+        'last_seen_at'  => now(),
+        'device_type'   => 'desktop',
+        'user_agent'    => $userAgent,
+        'is_bot'        => $isBot,
+        'bot_score'     => $isBot ? 90 : null,
+    ] );
+
+    return (string) $visitor->id;
+}
+
+/**
+ * Create a page view tied to a visitor id.
+ */
+function botWidgetPageView( string $visitorId, string $path = '/' ): void
+{
+    PageView::create( [
+        'path'       => $path,
+        'session_id' => 'session-' . $visitorId,
+        'visitor_id' => $visitorId,
+        'created_at' => now(),
+    ] );
+}
+
+test( 'bot traffic widget can be rendered', function (): void {
+    Livewire::test( BotTraffic::class )
+        ->assertStatus( 200 );
+} );
+
+test( 'bot traffic widget loads bot statistics on mount', function (): void {
+    botWidgetPageView( botWidgetVisitor( false, 'Human' ), '/a' );
+    botWidgetPageView( botWidgetVisitor( true, 'GPTBot' ), '/bot' );
+
+    Livewire::test( BotTraffic::class )
+        ->assertSet( 'botVisits', 1 )
+        ->assertSet( 'totalVisits', 2 )
+        ->assertSet( 'botPercentage', 50.0 )
+        ->assertSet( 'isLoading', false );
+} );
+
+test( 'bot traffic widget lists the top bot user agents', function (): void {
+    botWidgetVisitor( true, 'GPTBot' );
+    botWidgetVisitor( true, 'GPTBot' );
+    botWidgetVisitor( true, 'ClaudeBot' );
+
+    Livewire::test( BotTraffic::class )
+        ->assertSee( 'GPTBot' )
+        ->assertSee( 'ClaudeBot' );
+} );
+
+test( 'bot traffic widget shows an empty state when there is no bot traffic', function (): void {
+    botWidgetPageView( botWidgetVisitor( false, 'Human' ), '/a' );
+
+    Livewire::test( BotTraffic::class )
+        ->assertSet( 'botVisits', 0 )
+        ->assertSee( 'No bot traffic detected for this period' );
+} );
+
+test( 'bot traffic widget reloads when widgets are refreshed', function (): void {
+    Livewire::test( BotTraffic::class )
+        ->assertSet( 'botVisits', 0 )
+        ->call( 'refreshData' )
+        ->assertStatus( 200 );
+} );


### PR DESCRIPTION
## Description

Adds a **bot traffic** dashboard widget in all three flavors (Livewire, React, Vue), surfacing the traffic that bot filtering removes from reports by default. Each widget shows total bot visits, the bot share of total traffic, the busiest bot user agents, and a bot-only visit trend.

The widgets needed a data source that did not yet exist, so this also adds a small shared backend: a top-bot-user-agents query and an aggregated bot-stats method, exposed via a new `GET /api/analytics/bots` endpoint that the React/Vue components consume.

**Closes:** #27, #44, #45

## Type of Change

- [x] New feature (adds new functionality)

## Related Issue

**Issue:** #20 (parent), #27, #44, #45

## Motivation and Context

Issue #20 introduced multi-layered bot detection but stored bot-flagged traffic without surfacing it. These widgets give users visibility into what is being filtered, in whichever dashboard stack they use.

## Changes Made

- Add `getTopBotAgents()` to `AnalyticsQueryInterface`, `LocalAnalyticsProvider`, `Analytics`, and `AbstractAnalyticsProvider`.
- Add `getBotStats()` to `AnalyticsQuery` (bot visits, % of total, top agents, bot-only trend).
- Add `GET /api/analytics/bots` (`bots()` controller action) in both the session-auth and v1 API-key route groups, plus `BotStatsData`/`BotAgentItem`/`BotTrendPoint` TypeScript types.
- **#27 Livewire:** `BotTraffic` widget + Blade view, registered in the service provider and surfaced as a new "Bots" dashboard tab.
- **#44 React:** `BotTraffic.tsx`, self-fetching via `useAnalyticsApi`, exported from the React barrel.
- **#45 Vue:** `BotTraffic.vue` (`<script setup lang="ts">`), refetches on date-range change, exported from the Vue barrel.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS
- PHP Version: 8.4
- Project Version: 1.2 (dev)

**Tests Performed:**
1. New Pest tests for `getTopBotAgents`, `getBotStats`, and the `bots()` endpoint (12 new tests, all passing).
2. Livewire `BotTraffic` widget feature tests (render, data load, top agents, empty state, refresh).
3. Manual verification of the Livewire widget in the dev app dashboard (Bots tab) with seeded bot visitors — totals, percentage, and top-agents table render correctly; empty state renders when no bot traffic exists.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [ ] Screen reader tested
- [x] ARIA labels checked

**Details:** Trend sparkline exposes `role="img"` with a descriptive `aria-label`; table and controls follow existing dashboard widget patterns.

## Tests Added

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/BotStatsQueryTest.php`, `tests/Feature/Livewire/BotTrafficTest.php`. Related suites (107 tests) still pass; PHP-CS-Fixer clean.

## Documentation

- [x] Inline code documentation added

**Documentation details:** Full PHPDoc on new methods/endpoint; TSDoc on the React/Vue components. Note: React/Vue resources have no local TS/build harness in the package (compiled in consuming apps), so they were validated by pattern parity with existing components rather than a local typecheck.

## Pre-Submission Checklist

- [x] Code passes all tests
- [x] Code has been linted
- [x] Code follows project style guide
- [x] Self-review completed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Bots" dashboard tab with a Bot Traffic card (total bot visits, bot share, optional trend, top bot user agents).
  * New BotTraffic components for React and Vue and a Livewire widget; include/exclude bots checkbox to toggle dashboard charts.
  * New analytics API endpoint to fetch bot stats.

* **Tests**
  * Added feature and widget tests covering bot stats, trends, top agents, empty states, and refresh behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ArtisanPack-UI/analytics/pull/58?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->