### PR TITLE
Release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.2.1] - 2026-06-09
+## [1.3.0] - 2026-07-07
+
+### Added
+
+#### AI-Powered Analytics Agents
+
+Four opt-in AI features that plug into `artisanpack-ui/ai` to turn raw analytics into narrative insights. Every feature ships an Agent, Livewire component, React and Vue components, and API endpoint, and honors the shared `FeatureRegistry` toggle.
+
+- **Insight summary agent** (`analytics.insight_summary`): Streaming plain-language summary of what changed over a date range, returning `{summary, highlights[], concerns[]}`. Backed by `InsightSummaryAgent`.
+- **Anomaly explanation agent** (`analytics.explain_anomaly`): Generates ranked hypotheses for a traffic spike or drop with confidence scores, evidence, and recommended next steps. Backed by `AnomalyExplanationAgent`.
+- **Segment insight agent** (`analytics.segment_insight`): Surfaces non-obvious patterns in a referrer, page, or time segment relative to a baseline, returning observations with significance and suggested actions. Backed by `SegmentInsightAgent`.
+- **Digest email agent** (`analytics.digest_email`): Composes opt-in weekly or monthly narrative digest emails. Extends the shared `SummarizationAgent` and ships with `SendDigestEmailJob`, `DigestEmailMailable`, a text-focused email template, an `AnalyticsDigestPreference` model, and per-user cadence preferences (`off | weekly | monthly`).
+- **Livewire triggers**: `<livewire:artisanpack-analytics::ai.insight-summary />`, `ai.anomaly-explanation`, `ai.segment-insight`, and `ai.digest-subscription` components with disabled states when the corresponding feature is toggled off.
+- **React and Vue components**: `InsightSummary`, `AnomalyExplanation`, `SegmentInsight`, and `DigestSubscription` shipped for both frameworks, together with `useAiAgent` and `useApi` hooks/composables.
+- **API endpoints**: New routes under `/api/analytics/ai/*` for each agent, gated behind the `analytics.ai.use` ability. Ships with a permissive default gate (any authenticated user); override in your `AuthServiceProvider` for stricter policies.
+- **Digest dispatch command**: `analytics:digests:dispatch` artisan command queues `SendDigestEmailJob` for every subscribed user; wire it into the scheduler on your preferred cadence.
+- **`aiFeatures()` registration**: `AnalyticsServiceProvider::aiFeatures()` registers all four features with the AI package's feature registry so admin UIs can list them.
+- **Migration**: `analytics_digest_preferences` table for per-user digest cadence.
+- **Documentation**: New AI features guide covering feature keys, Livewire and React/Vue usage, gate customization, and digest scheduling.
+
+
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,81 @@ $stats = analyticsStats(DateRange::last30Days());
 - **IP Anonymization**: GDPR-compliant IP address handling
 - **Bot Filtering**: Automatic exclusion of known bots and crawlers
 
+## AI features
+
+The Analytics package ships four AI agents that plug into `artisanpack-ui/ai`. Every feature is toggleable via the `artisanpack.ai.features.{key}.enabled` config (or the AI package's runtime registry) — Livewire, React, and Vue triggers all render a "disabled" state when a feature is off.
+
+| Feature key | Input | Output | Default model |
+|-------------|-------|--------|---------------|
+| `analytics.insight_summary` | `{ date_range, metrics, compare_to? }` | `{ summary, highlights[], concerns[] }` | `claude-sonnet-4-6` (streams) |
+| `analytics.explain_anomaly` | `{ anomaly: {metric,direction,magnitude,date}, context: {recent_content_changes, referrer_deltas, campaign_launches} }` | `{ hypotheses:[{cause,confidence,evidence[]}], recommended_next_steps[] }` | `claude-sonnet-4-6` |
+| `analytics.segment_insight` | `{ segment:{type,value}, metrics, baseline }` | `{ patterns:[{observation,significance,suggested_action}] }` | `claude-sonnet-4-6` |
+| `analytics.digest_email` | `{ items[], focus?, length? }` (inherits `SummarizationAgent`) | `{ summary, key_points[], caveats[] }` | `claude-sonnet-4-6` |
+
+### Livewire triggers
+
+```blade
+<livewire:artisanpack-analytics::ai.insight-summary
+	:date-from="'2026-05-01'"
+	:date-to="'2026-05-07'"
+	:metrics="$weeklyMetrics"
+/>
+
+<livewire:artisanpack-analytics::ai.anomaly-explanation :anomaly="$anomaly" :context="$context" />
+<livewire:artisanpack-analytics::ai.segment-insight ... />
+<livewire:artisanpack-analytics::ai.digest-subscription />
+```
+
+### React / Vue triggers
+
+Publish the components alongside the analytics dashboards (`analytics-react` / `analytics-vue` publish tags) and mount them anywhere in your Inertia app:
+
+```tsx
+import { InsightSummary } from '@/vendor/artisanpack-analytics/react/components/ai';
+
+<InsightSummary
+	api={ { baseUrl: '/api/analytics' } }
+	dateRange={ { from: '2026-05-01', to: '2026-05-07' } }
+	metrics={ weeklyMetrics }
+/>
+```
+
+### Enabling / disabling features
+
+Every feature is opt-in per-app via `config/artisanpack.php` (merged from the AI package):
+
+```php
+'ai' => [
+	'features' => [
+		'analytics.insight_summary' => [ 'enabled' => true ],
+		'analytics.explain_anomaly' => [ 'enabled' => true ],
+		'analytics.segment_insight' => [ 'enabled' => true ],
+		'analytics.digest_email'    => [ 'enabled' => true ],
+	],
+],
+```
+
+Requests are gated by the `analytics.ai.use` gate. The ship default allows any authenticated user; override in your `AuthServiceProvider` for stricter policies.
+
+### Digest email opt-in
+
+The `analytics.digest_email` feature is delivered via a queued job (`SendDigestEmailJob`) and honors a per-user preference stored in `analytics_digest_preferences` (`off | weekly | monthly`). Users pick their cadence via the `DigestSubscription` component; you schedule `SendDigestEmailJob` on your cadence of choice (the job is a no-op for users whose preference is `off` or missing).
+
+```php
+use ArtisanPackUI\Analytics\Jobs\SendDigestEmailJob;
+
+$schedule->call( function () {
+	AnalyticsDigestPreference::where( 'cadence', 'weekly' )->each( function ( $preference ) {
+		SendDigestEmailJob::dispatch(
+			userId: $preference->user_id,
+			email: $preference->user->email,
+			items: $weeklyDigestItems( $preference->user ),
+			periodLabel: 'Last 7 days',
+		);
+	} );
+} )->weekly();
+```
+
 ## Components
 
 ### Livewire Components

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
   ],
   "require": {
     "php": "^8.2",
+    "artisanpack-ui/ai": "^1.0",
     "doctrine/dbal": "^4.0",
     "illuminate/cache": "^11.0|^12.0|^13.0",
     "illuminate/console": "^11.0|^12.0|^13.0",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Privacy-first analytics package for Laravel with local database storage, external provider support (GA4, Plausible), and a beautiful Livewire dashboard.",
   "type": "library",
   "license": "MIT",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "keywords": [
     "laravel",
     "analytics",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,300 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "565da9d5d505e4eeca32bd2051b01865",
+    "content-hash": "4e786d32d17be43c0848759a71db9cab",
     "packages": [
+        {
+            "name": "artisanpack-ui/ai",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/ai.git",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/ai/zipball/082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "reference": "082f1cd337742d34b8035d116c6c5ad8e5453fca",
+                "shasum": ""
+            },
+            "require": {
+                "artisanpack-ui/core": "^1.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/ai": "^0.8",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.26",
+                "livewire/livewire": "^3.6",
+                "orchestra/testbench": "^10.2|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.2|^4.1"
+            },
+            "suggest": {
+                "artisanpack-ui/cms-framework": "Automatically registers AI credentials, features, budget and cache setting groups under the CMS admin surface.",
+                "artisanpack-ui/livewire-ui-components": "Renders the AI Settings and Usage admin surfaces using x-artisanpack-* components.",
+                "livewire/livewire": "Required to mount the AI Settings and Usage dashboard Livewire components under cms-framework's admin nav."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Ai": "ArtisanPackUI\\Ai\\Facades\\Ai"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Ai\\AiServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Shared AI foundation for the ArtisanPack UI ecosystem, built on top of laravel/ai.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/ai/issues",
+                "source": "https://github.com/ArtisanPack-UI/ai/tree/v1.0.0"
+            },
+            "time": "2026-07-06T21:25:38+00:00"
+        },
+        {
+            "name": "artisanpack-ui/core",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/core.git",
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/bb7055c4b250612d987398f990b5537fbc28865b",
+                "reference": "bb7055c4b250612d987398f990b5537fbc28865b",
+                "shasum": ""
+            },
+            "require": {
+                "composer/semver": "^3.0",
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.3",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.1",
+                "artisanpack-ui/code-style-pint": "^1.1",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "friendsofphp/php-cs-fixer": "^3.75",
+                "laravel/pint": "^1.27",
+                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "pestphp/pest": "^3.8|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.1|^4.0",
+                "squizlabs/php_codesniffer": "3.11.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Core": "ArtisanPackUI\\Core\\Facades\\Core",
+                        "ArtisanPackLog": "ArtisanPackUI\\Core\\Facades\\ArtisanPackLog",
+                        "ArtisanPackConfig": "ArtisanPackUI\\Core\\Facades\\ArtisanPackConfig"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Core\\CoreServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Core\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "Supplies the core functionality for ArtisanPack UI that needs to be shared across all packages.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/core/issues",
+                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
+            },
+            "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.387.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "20818be961ace3ef01c1aed3c247e71b26020149"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/20818be961ace3ef01c1aed3c247e71b26020149",
+                "reference": "20818be961ace3ef01c1aed3c247e71b26020149",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.9.1",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.387.3"
+            },
+            "time": "2026-07-06T18:13:24+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.8",
@@ -134,6 +426,83 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1211,6 +1580,80 @@
                 }
             ],
             "time": "2026-05-23T22:00:21+00:00"
+        },
+        {
+            "name": "laravel/ai",
+            "version": "v0.8.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/ai.git",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/ai/zipball/b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "reference": "b23bc857576d7c4b3bb52ffd8be936ae74005d23",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.339",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/container": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/database": "^12.0|^13.0",
+                "illuminate/filesystem": "^12.0|^13.0",
+                "illuminate/json-schema": "^12.62|^13.15",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/prompts": "^0.3.6",
+                "laravel/serializable-closure": "^2.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/mcp": "^0.8",
+                "laravel/pint": "^1.26",
+                "mockery/mockery": "^1.6.12",
+                "orchestra/testbench": "^10.6|^11.0",
+                "pestphp/pest": "^3.0|^4.0",
+                "pestphp/pest-plugin-laravel": "^3.0|^4.0",
+                "phpstan/phpstan": "^2.1"
+            },
+            "suggest": {
+                "laravel/mcp": "Required to use MCP client tools or MCP server tools with Laravel AI agents."
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Ai\\AiServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "functions.php"
+                ],
+                "psr-4": {
+                    "Laravel\\Ai\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The official AI SDK for Laravel.",
+            "homepage": "https://github.com/laravel/ai",
+            "keywords": [
+                "ai",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/ai/issues",
+                "source": "https://github.com/laravel/ai"
+            },
+            "time": "2026-06-10T11:23:35+00:00"
         },
         {
             "name": "laravel/framework",
@@ -2291,6 +2734,72 @@
                 }
             ],
             "time": "2026-01-02T08:56:05+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.9.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "reference": "2157c5e50e813ec6a96c1eed3be7f64a20fb32a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.52"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.9-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.9.2"
+            },
+            "time": "2026-07-06T18:56:19+00:00"
         },
         {
             "name": "nesbot/carbon",
@@ -3938,6 +4447,77 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/finder",
@@ -6443,83 +7023,6 @@
                 }
             ],
             "time": "2024-11-12T16:29:46+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -11131,77 +11634,6 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/filesystem",
-            "version": "v8.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "reference": "99aec13b82b4967ec5088222c4a3ecca955949c2",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "require-dev": {
-                "symfony/process": "^7.4|^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v8.1.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-29T05:06:50+00:00"
-        },
-        {
             "name": "symfony/options-resolver",
             "version": "v8.1.0",
             "source": {
@@ -11679,5 +12111,5 @@
         "php": "^8.2"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/database/migrations/2026_07_07_000001_create_analytics_digest_preferences_table.php
+++ b/database/migrations/2026_07_07_000001_create_analytics_digest_preferences_table.php
@@ -1,0 +1,44 @@
+<?php
+
+declare( strict_types=1 );
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Create the analytics_digest_preferences table.
+ *
+ * Stores per-user opt-in preferences for the AI analytics digest email.
+ * `cadence` is one of `off`, `weekly`, `monthly`. Users default to `off`
+ * until they explicitly subscribe from the Livewire/React/Vue component.
+ *
+ * @since 1.3.0
+ */
+return new class extends Migration
+{
+	/**
+	 * Run the migrations.
+	 */
+	public function up(): void
+	{
+		Schema::create( 'analytics_digest_preferences', function ( Blueprint $table ) {
+			$table->id();
+			$table->unsignedBigInteger( 'user_id' );
+			$table->string( 'cadence', 16 )->default( 'off' );
+			$table->timestamp( 'last_sent_at' )->nullable();
+			$table->timestamps();
+
+			$table->unique( 'user_id' );
+			$table->index( 'cadence' );
+		} );
+	}
+
+	/**
+	 * Reverse the migrations.
+	 */
+	public function down(): void
+	{
+		Schema::dropIfExists( 'analytics_digest_preferences' );
+	}
+};

--- a/database/migrations/2026_07_07_000001_create_analytics_digest_preferences_table.php
+++ b/database/migrations/2026_07_07_000001_create_analytics_digest_preferences_table.php
@@ -24,7 +24,7 @@ return new class extends Migration
 	{
 		Schema::create( 'analytics_digest_preferences', function ( Blueprint $table ) {
 			$table->id();
-			$table->unsignedBigInteger( 'user_id' );
+			$table->foreignId( 'user_id' )->constrained()->cascadeOnDelete();
 			$table->string( 'cadence', 16 )->default( 'off' );
 			$table->timestamp( 'last_sent_at' )->nullable();
 			$table->timestamps();

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -13,6 +13,7 @@ This section covers advanced features and configuration options for ArtisanPack 
 - [Multiple Providers](Advanced-Multiple-Providers) - Use multiple analytics providers
 - [Caching](Advanced-Caching) - Optimize performance with caching
 - [Bot Filtering](Advanced-Bot-Filtering) - Filter AI crawlers and bot traffic *(since 1.2.0)*
+- [AI Features](Advanced-AI-Features) - AI-powered insight summaries, anomaly explanations, segment insights, and digest emails *(since 1.3.0)*
 - [Artisan Commands](Advanced-Artisan-Commands) - CLI commands for management
 - [Frontend Components](Frontend-Overview) - React and Vue dashboards via Inertia.js *(since 1.1.0)*
 
@@ -54,6 +55,16 @@ Keep automated traffic out of your reported numbers:
 - Behavioral confidence scoring with a configurable threshold
 - JavaScript fingerprint signals (WebDriver, headless, missing APIs)
 - Config and runtime whitelists, plus a bot traffic dashboard widget
+
+### AI Features *(since 1.3.0)*
+
+Turn raw metrics into narrative insights via `artisanpack-ui/ai`:
+
+- Streaming insight summaries over a date range with highlights and concerns
+- Anomaly explanations that rank likely causes with evidence and next steps
+- Segment insights that compare a referrer, page, or time slice to a baseline
+- Opt-in weekly and monthly narrative digest emails with per-user cadence preferences
+- Livewire, React, and Vue triggers gated behind the `analytics.ai.use` ability
 
 ### Performance Optimization
 

--- a/docs/advanced/ai-features.md
+++ b/docs/advanced/ai-features.md
@@ -1,0 +1,249 @@
+---
+title: AI Features
+---
+
+# AI Features
+
+> **Since 1.3.0**
+
+ArtisanPack UI Analytics ships four AI-powered features that plug into `artisanpack-ui/ai` to turn raw analytics into narrative insights. Every feature is opt-in, feature-flagged, and available as a Livewire component, React component, Vue component, and JSON API endpoint.
+
+The four features are:
+
+| Feature key | Purpose | Output shape |
+|-------------|---------|--------------|
+| `analytics.insight_summary` | Streaming plain-language summary of what changed over a date range | `{ summary, highlights[], concerns[] }` |
+| `analytics.explain_anomaly` | Ranked hypotheses for a traffic spike or drop | `{ hypotheses:[{cause,confidence,evidence[]}], recommended_next_steps[] }` |
+| `analytics.segment_insight` | Non-obvious patterns in a referrer, page, or time segment | `{ patterns:[{observation,significance,suggested_action}] }` |
+| `analytics.digest_email` | Narrative body of the opt-in weekly/monthly digest email | `{ summary, key_points[], caveats[] }` |
+
+Each feature ships an Agent class (`InsightSummaryAgent`, `AnomalyExplanationAgent`, `SegmentInsightAgent`, `DigestEmailAgent`), a Livewire trigger + blade, React and Vue components, and is registered via `AnalyticsServiceProvider::aiFeatures()`. All triggers render a disabled state when the feature is toggled off, so it is safe to ship them behind a config flag.
+
+## Enabling AI Features
+
+Every feature is opt-in per-app via `config/artisanpack.php`, which merges the AI package's feature registry. Toggle features on with the `enabled` flag:
+
+```php
+'ai' => [
+    'features' => [
+        'analytics.insight_summary' => [ 'enabled' => true ],
+        'analytics.explain_anomaly' => [ 'enabled' => true ],
+        'analytics.segment_insight' => [ 'enabled' => true ],
+        'analytics.digest_email'    => [ 'enabled' => true ],
+    ],
+],
+```
+
+Features default to disabled. Anything published to the frontend (a Livewire component or React trigger) checks the registry on render and gracefully collapses to a disabled state if the feature is off.
+
+## Authorization
+
+All AI API endpoints are gated behind the `analytics.ai.use` ability. The shipped default allows any authenticated user through so upgrades are non-breaking:
+
+```php
+Gate::define( 'analytics.ai.use', fn ( $user ) => $user !== null );
+```
+
+Override the gate in your `AuthServiceProvider` to enforce a stricter policy — for example, restricting AI usage to admins or to seats that have purchased AI quota:
+
+```php
+Gate::define( 'analytics.ai.use', function ( User $user ) {
+    return $user->hasRole( 'admin' ) || $user->team->has_ai_quota;
+} );
+```
+
+## Insight Summary
+
+Streams a plain-language summary of a date range's metrics, calling out highlights and concerns.
+
+### Livewire
+
+```blade
+<livewire:artisanpack-analytics::ai.insight-summary
+    :date-from="'2026-06-01'"
+    :date-to="'2026-06-07'"
+    :metrics="$weeklyMetrics"
+/>
+```
+
+### React
+
+```tsx
+import { InsightSummary } from '@/vendor/artisanpack-analytics/react/components/ai';
+
+<InsightSummary
+    api={ { baseUrl: '/api/analytics' } }
+    dateRange={ { from: '2026-06-01', to: '2026-06-07' } }
+    metrics={ weeklyMetrics }
+    compareTo={ { from: '2026-05-25', to: '2026-05-31' } }
+/>
+```
+
+### Vue
+
+```vue
+<InsightSummary
+    :api="{ baseUrl: '/api/analytics' }"
+    :date-range="{ from: '2026-06-01', to: '2026-06-07' }"
+    :metrics="weeklyMetrics"
+/>
+```
+
+### API
+
+```
+POST /api/analytics/ai/insight-summary
+```
+
+**Request body**:
+
+```json
+{
+    "date_range": { "from": "2026-06-01", "to": "2026-06-07" },
+    "metrics": { "visitors": 12483, "pageviews": 41230, "bounce_rate": 0.42 },
+    "compare_to": { "from": "2026-05-25", "to": "2026-05-31" }
+}
+```
+
+**Response**: streams a `text/event-stream` with the final structured payload as the last event.
+
+## Anomaly Explanation
+
+Given a detected anomaly and lightweight context, returns ranked hypotheses for the cause.
+
+### Livewire
+
+```blade
+<livewire:artisanpack-analytics::ai.anomaly-explanation
+    :anomaly="$anomaly"
+    :context="$context"
+/>
+```
+
+`$anomaly` shape:
+
+```php
+[
+    'metric'    => 'visitors',
+    'direction' => 'up',
+    'magnitude' => 2.4,      // multiplier vs baseline
+    'date'      => '2026-06-05',
+]
+```
+
+`$context` shape:
+
+```php
+[
+    'recent_content_changes' => [ /* ... */ ],
+    'referrer_deltas'        => [ /* ... */ ],
+    'campaign_launches'      => [ /* ... */ ],
+]
+```
+
+### API
+
+```
+POST /api/analytics/ai/explain-anomaly
+```
+
+Returns:
+
+```json
+{
+    "hypotheses": [
+        { "cause": "Referrer surge from Hacker News", "confidence": 0.82, "evidence": [ "..." ] }
+    ],
+    "recommended_next_steps": [ "..." ]
+}
+```
+
+## Segment Insight
+
+Surfaces patterns in a segment (referrer, page, or time window) relative to a baseline.
+
+### Livewire
+
+```blade
+<livewire:artisanpack-analytics::ai.segment-insight
+    :segment="[ 'type' => 'referrer', 'value' => 'news.ycombinator.com' ]"
+    :metrics="$segmentMetrics"
+    :baseline="$overallMetrics"
+/>
+```
+
+### API
+
+```
+POST /api/analytics/ai/segment-insight
+```
+
+Response:
+
+```json
+{
+    "patterns": [
+        {
+            "observation": "This segment converts 3.1× the site baseline.",
+            "significance": "high",
+            "suggested_action": "Explore paid amplification of the referring content."
+        }
+    ]
+}
+```
+
+## Digest Email
+
+Composes the AI-narrated body of an opt-in weekly or monthly digest email. Users pick their cadence via the `DigestSubscription` component, and a queued `SendDigestEmailJob` composes and sends each digest.
+
+### Subscription component
+
+```blade
+<livewire:artisanpack-analytics::ai.digest-subscription />
+```
+
+The component persists the current user's preference (`off | weekly | monthly`) to the `analytics_digest_preferences` table. React and Vue equivalents (`DigestSubscription`) ship in the frontend bundle for Inertia apps.
+
+### Scheduling digests
+
+Dispatch digests on your chosen cadence with the shipped artisan command:
+
+```php
+// bootstrap/app.php (or routes/console.php)
+Schedule::command( 'analytics:digests:dispatch --cadence=weekly' )->weeklyOn( 1, '08:00' );
+Schedule::command( 'analytics:digests:dispatch --cadence=monthly' )->monthlyOn( 1, '08:00' );
+```
+
+The command queues one `SendDigestEmailJob` per subscribed user. Users with a preference of `off` (or no preference row) are skipped, so it is safe to run the command against a superset.
+
+### Custom mailable
+
+`DigestEmailMailable` renders `resources/views/emails/digest.blade.php`, a text-first template with structured headings for accessibility. Publish the view to customize it:
+
+```bash
+php artisan vendor:publish --tag=analytics-views
+```
+
+## Feature Registration
+
+The `AnalyticsServiceProvider::aiFeatures()` method is what the AI package's feature registry reads at boot time. If you fork or extend the package and want to add a fifth feature — a custom agent, for example — return an additional entry from that method:
+
+```php
+public function aiFeatures(): array
+{
+    return array_merge( parent::aiFeatures(), [
+        'analytics.retention_summary' => [
+            'agent'       => RetentionSummaryAgent::class,
+            'package'     => 'my-app/analytics-extensions',
+            'label'       => __( 'Retention summary' ),
+            'description' => __( 'Weekly retention cohort narrative.' ),
+        ],
+    ] );
+}
+```
+
+## Cost and Rate Limiting
+
+Every request routes through the AI package's shared client, so any rate limits, budget guards, or provider fallbacks configured there apply automatically. See the [`artisanpack-ui/ai` documentation](https://gitlab.com/jacob-martella-web-design/artisanpack-ui/ai) for provider configuration.
+
+Streaming responses (currently `analytics.insight_summary`) send incremental tokens over `text/event-stream`; the final event is the structured JSON payload. Non-streaming features return a plain JSON response.

--- a/docs/home.md
+++ b/docs/home.md
@@ -57,6 +57,7 @@ Welcome to the ArtisanPack UI Analytics documentation. This package provides com
   - [Multiple Providers](Advanced-Multiple-Providers)
   - [Caching](Advanced-Caching)
   - [Bot Filtering](Advanced-Bot-Filtering) *(since 1.2.0)*
+  - [AI Features](Advanced-AI-Features) *(since 1.3.0)*
   - [Artisan Commands](Advanced-Artisan-Commands)
 
 - **Help**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
     - Multi-Tenancy: advanced/multi-tenancy.md
     - Multiple Providers: advanced/multiple-providers.md
     - Caching: advanced/caching.md
+    - AI Features: advanced/ai-features.md
     - Artisan Commands: advanced/artisan-commands.md
   - FAQ: faq.md
   - Troubleshooting: troubleshooting.md

--- a/resources/js/react/components/ai/AnomalyExplanation.tsx
+++ b/resources/js/react/components/ai/AnomalyExplanation.tsx
@@ -1,0 +1,125 @@
+/**
+ * React trigger for the AnomalyExplanationAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+export interface AnomalyPayload {
+	metric: string;
+	direction: 'up' | 'down';
+	magnitude: number;
+	date: string;
+}
+
+export interface AnomalyContext {
+	recent_content_changes?: unknown[];
+	referrer_deltas?: unknown[];
+	campaign_launches?: unknown[];
+	[key: string]: unknown;
+}
+
+interface AnomalyExplanationInput {
+	anomaly: AnomalyPayload;
+	context: AnomalyContext;
+}
+
+export interface Hypothesis {
+	cause: string;
+	confidence: 'low' | 'medium' | 'high';
+	evidence: string[];
+}
+
+export interface AnomalyExplanationResult {
+	hypotheses: Hypothesis[];
+	recommended_next_steps: string[];
+}
+
+export interface AnomalyExplanationProps {
+	api: UseApiOptions;
+	anomaly: AnomalyPayload;
+	context: AnomalyContext;
+}
+
+export const AnomalyExplanation: FC<AnomalyExplanationProps> = ( { api, anomaly, context } ) => {
+	const { output, isLoading, error, run } = useAiAgent<AnomalyExplanationInput, AnomalyExplanationResult>(
+		'analytics.explain_anomaly',
+		api,
+	);
+
+	const disabled = isLoading || ! anomaly.metric;
+
+	const handleClick = (): void => {
+		void run( { anomaly, context } );
+	};
+
+	return (
+		<div className="analytics-ai-anomaly-explanation" data-feature="analytics.explain_anomaly">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="analytics-ai-anomaly-explanation__button"
+			>
+				{ isLoading ? 'Analyzing…' : 'Explain this anomaly' }
+			</button>
+
+			{ error && (
+				<p className="analytics-ai-anomaly-explanation__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && output.hypotheses.length > 0 && (
+				<div className="analytics-ai-anomaly-explanation__result">
+					<h3 className="analytics-ai-anomaly-explanation__heading">Hypotheses</h3>
+					<ul className="analytics-ai-anomaly-explanation__hypotheses">
+						{ output.hypotheses.map( ( hypothesis, idx ) => (
+							<li key={ idx } className="analytics-ai-anomaly-explanation__hypothesis">
+								<div className="analytics-ai-anomaly-explanation__hypothesis-header">
+									<span className="analytics-ai-anomaly-explanation__cause">
+										{ hypothesis.cause }
+									</span>
+									<span
+										className={ `analytics-ai-anomaly-explanation__confidence analytics-ai-anomaly-explanation__confidence--${ hypothesis.confidence }` }
+									>
+										{ hypothesis.confidence }
+									</span>
+								</div>
+								{ hypothesis.evidence.length > 0 && (
+									<ul className="analytics-ai-anomaly-explanation__evidence">
+										{ hypothesis.evidence.map( ( item, eIdx ) => (
+											<li key={ eIdx }>{ item }</li>
+										) ) }
+									</ul>
+								) }
+							</li>
+						) ) }
+					</ul>
+
+					{ output.recommended_next_steps.length > 0 && (
+						<>
+							<h4 className="analytics-ai-anomaly-explanation__subheading">
+								Recommended next steps
+							</h4>
+							<ul className="analytics-ai-anomaly-explanation__steps">
+								{ output.recommended_next_steps.map( ( step, idx ) => (
+									<li key={ idx }>{ step }</li>
+								) ) }
+							</ul>
+						</>
+					) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default AnomalyExplanation;

--- a/resources/js/react/components/ai/DigestSubscription.tsx
+++ b/resources/js/react/components/ai/DigestSubscription.tsx
@@ -1,0 +1,104 @@
+/**
+ * React opt-in UI for the AI analytics digest email.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+import { useCallback, useState, type FC } from 'react';
+
+import { useApi, type UseApiOptions } from '../../hooks/useApi';
+
+export type DigestCadence = 'off' | 'weekly' | 'monthly';
+
+export interface DigestSubscriptionProps {
+	api: UseApiOptions;
+	initialCadence?: DigestCadence;
+	/** Endpoint that persists the user preference (POST). Defaults to `/ai/digest-subscription`. */
+	updatePath?: string;
+}
+
+export const DigestSubscription: FC<DigestSubscriptionProps> = ( {
+	api,
+	initialCadence = 'off',
+	updatePath = '/ai/digest-subscription',
+} ) => {
+	const apiClient = useApi( api );
+	const [ cadence, setCadence ] = useState<DigestCadence>( initialCadence );
+	const [ isSaving, setIsSaving ] = useState( false );
+	const [ status, setStatus ] = useState<string | null>( null );
+	const [ error, setError ] = useState<string | null>( null );
+
+	const save = useCallback( async (): Promise<void> => {
+		setIsSaving( true );
+		setStatus( null );
+		setError( null );
+
+		try {
+			await apiClient.post( updatePath, { cadence } );
+			setStatus( cadence === 'off' ? 'Digest emails turned off.' : 'Digest preference saved.' );
+		} catch ( caught ) {
+			setError( caught instanceof Error ? caught.message : 'Could not save preference.' );
+		} finally {
+			setIsSaving( false );
+		}
+	}, [ apiClient, cadence, updatePath ] );
+
+	return (
+		<div className="analytics-ai-digest-subscription" data-feature="analytics.digest_email">
+			<form
+				className="analytics-ai-digest-subscription__form"
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					void save();
+				} }
+			>
+				<fieldset>
+					<legend className="analytics-ai-digest-subscription__legend">
+						Analytics digest email
+					</legend>
+					<p className="analytics-ai-digest-subscription__hint">
+						Receive a plain-language summary of your site&apos;s traffic on your chosen cadence.
+					</p>
+
+					{ ( [ 'off', 'weekly', 'monthly' ] as DigestCadence[] ).map( ( value ) => (
+						<label key={ value } className="analytics-ai-digest-subscription__option">
+							<input
+								type="radio"
+								name="cadence"
+								value={ value }
+								checked={ cadence === value }
+								onChange={ () => setCadence( value ) }
+							/>
+							<span>{ value.charAt( 0 ).toUpperCase() + value.slice( 1 ) }</span>
+						</label>
+					) ) }
+				</fieldset>
+
+				<button
+					type="submit"
+					disabled={ isSaving }
+					className="analytics-ai-digest-subscription__save"
+				>
+					{ isSaving ? 'Saving…' : 'Save preference' }
+				</button>
+
+				{ status && (
+					<p className="analytics-ai-digest-subscription__status" role="status">
+						{ status }
+					</p>
+				) }
+
+				{ error && (
+					<p className="analytics-ai-digest-subscription__error" role="alert">
+						{ error }
+					</p>
+				) }
+			</form>
+		</div>
+	);
+};
+
+export default DigestSubscription;

--- a/resources/js/react/components/ai/InsightSummary.tsx
+++ b/resources/js/react/components/ai/InsightSummary.tsx
@@ -1,0 +1,108 @@
+/**
+ * React trigger for the InsightSummaryAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+interface DateRange {
+	from: string;
+	to: string;
+}
+
+interface InsightSummaryInput {
+	date_range: DateRange;
+	metrics: Record<string, unknown>;
+	compare_to?: DateRange;
+}
+
+export interface InsightSummaryResult {
+	summary: string;
+	highlights: string[];
+	concerns: string[];
+}
+
+export interface InsightSummaryProps {
+	api: UseApiOptions;
+	dateRange: DateRange;
+	metrics: Record<string, unknown>;
+	compareTo?: DateRange;
+}
+
+export const InsightSummary: FC<InsightSummaryProps> = ( { api, dateRange, metrics, compareTo } ) => {
+	const { output, isLoading, error, run } = useAiAgent<InsightSummaryInput, InsightSummaryResult>(
+		'analytics.insight_summary',
+		api,
+	);
+
+	const disabled =
+		isLoading ||
+		dateRange.from.trim() === '' ||
+		dateRange.to.trim() === '' ||
+		Object.keys( metrics ).length === 0;
+
+	const handleClick = (): void => {
+		void run( {
+			date_range: dateRange,
+			metrics,
+			...( compareTo ? { compare_to: compareTo } : {} ),
+		} );
+	};
+
+	return (
+		<div className="analytics-ai-insight-summary" data-feature="analytics.insight_summary">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="analytics-ai-insight-summary__button"
+			>
+				{ isLoading ? 'Summarizing…' : 'Summarize this window' }
+			</button>
+
+			{ error && (
+				<p className="analytics-ai-insight-summary__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && (
+				<div className="analytics-ai-insight-summary__result">
+					<h3 className="analytics-ai-insight-summary__heading">Summary</h3>
+					<p className="analytics-ai-insight-summary__summary">{ output.summary }</p>
+
+					{ output.highlights.length > 0 && (
+						<>
+							<h4 className="analytics-ai-insight-summary__subheading">Highlights</h4>
+							<ul className="analytics-ai-insight-summary__list">
+								{ output.highlights.map( ( item, idx ) => (
+									<li key={ idx }>{ item }</li>
+								) ) }
+							</ul>
+						</>
+					) }
+
+					{ output.concerns.length > 0 && (
+						<>
+							<h4 className="analytics-ai-insight-summary__subheading">Concerns</h4>
+							<ul className="analytics-ai-insight-summary__list">
+								{ output.concerns.map( ( item, idx ) => (
+									<li key={ idx }>{ item }</li>
+								) ) }
+							</ul>
+						</>
+					) }
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default InsightSummary;

--- a/resources/js/react/components/ai/SegmentInsight.tsx
+++ b/resources/js/react/components/ai/SegmentInsight.tsx
@@ -1,0 +1,106 @@
+/**
+ * React trigger for the SegmentInsightAgent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+import type { FC } from 'react';
+
+import { useAiAgent } from '../../hooks/useAiAgent';
+import type { UseApiOptions } from '../../hooks/useApi';
+
+export interface Segment {
+	type: string;
+	value: string;
+}
+
+interface SegmentInsightInput {
+	segment: Segment;
+	metrics: Record<string, unknown>;
+	baseline: Record<string, unknown>;
+}
+
+export interface Pattern {
+	observation: string;
+	significance: 'low' | 'medium' | 'high';
+	suggested_action: string;
+}
+
+export interface SegmentInsightResult {
+	patterns: Pattern[];
+}
+
+export interface SegmentInsightProps {
+	api: UseApiOptions;
+	segment: Segment;
+	metrics: Record<string, unknown>;
+	baseline: Record<string, unknown>;
+}
+
+export const SegmentInsight: FC<SegmentInsightProps> = ( { api, segment, metrics, baseline } ) => {
+	const { output, isLoading, error, run } = useAiAgent<SegmentInsightInput, SegmentInsightResult>(
+		'analytics.segment_insight',
+		api,
+	);
+
+	const disabled =
+		isLoading ||
+		segment.type.trim() === '' ||
+		segment.value.trim() === '' ||
+		Object.keys( metrics ).length === 0 ||
+		Object.keys( baseline ).length === 0;
+
+	const handleClick = (): void => {
+		void run( { segment, metrics, baseline } );
+	};
+
+	return (
+		<div className="analytics-ai-segment-insight" data-feature="analytics.segment_insight">
+			<button
+				type="button"
+				onClick={ handleClick }
+				disabled={ disabled }
+				className="analytics-ai-segment-insight__button"
+			>
+				{ isLoading ? 'Analyzing segment…' : 'Find patterns in this segment' }
+			</button>
+
+			{ error && (
+				<p className="analytics-ai-segment-insight__error" role="alert">
+					{ error }
+				</p>
+			) }
+
+			{ output && output.patterns.length > 0 && (
+				<div className="analytics-ai-segment-insight__result">
+					<h3 className="analytics-ai-segment-insight__heading">Patterns</h3>
+					<ul className="analytics-ai-segment-insight__patterns">
+						{ output.patterns.map( ( pattern, idx ) => (
+							<li key={ idx } className="analytics-ai-segment-insight__pattern">
+								<div className="analytics-ai-segment-insight__pattern-header">
+									<span className="analytics-ai-segment-insight__observation">
+										{ pattern.observation }
+									</span>
+									<span
+										className={ `analytics-ai-segment-insight__significance analytics-ai-segment-insight__significance--${ pattern.significance }` }
+									>
+										{ pattern.significance }
+									</span>
+								</div>
+								<p className="analytics-ai-segment-insight__action">
+									<strong>Suggested action: </strong>
+									{ pattern.suggested_action }
+								</p>
+							</li>
+						) ) }
+					</ul>
+				</div>
+			) }
+		</div>
+	);
+};
+
+export default SegmentInsight;

--- a/resources/js/react/components/ai/index.ts
+++ b/resources/js/react/components/ai/index.ts
@@ -1,0 +1,31 @@
+/**
+ * AI trigger components for the Analytics package.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+export { AnomalyExplanation } from './AnomalyExplanation';
+export type {
+	AnomalyContext,
+	AnomalyExplanationProps,
+	AnomalyExplanationResult,
+	AnomalyPayload,
+	Hypothesis,
+} from './AnomalyExplanation';
+
+export { DigestSubscription } from './DigestSubscription';
+export type { DigestCadence, DigestSubscriptionProps } from './DigestSubscription';
+
+export { InsightSummary } from './InsightSummary';
+export type { InsightSummaryProps, InsightSummaryResult } from './InsightSummary';
+
+export { SegmentInsight } from './SegmentInsight';
+export type {
+	Pattern,
+	Segment,
+	SegmentInsightProps,
+	SegmentInsightResult,
+} from './SegmentInsight';

--- a/resources/js/react/hooks/useAiAgent.ts
+++ b/resources/js/react/hooks/useAiAgent.ts
@@ -1,0 +1,85 @@
+/**
+ * useAiAgent hook — thin wrapper over useApi for the Analytics AI endpoints.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+import { useCallback, useState } from 'react';
+
+import { ApiError, ApiValidationError, useApi, type UseApiOptions } from './useApi';
+
+/** Supported AI feature keys owned by the Analytics package. */
+export type AnalyticsAiFeatureKey =
+	| 'analytics.insight_summary'
+	| 'analytics.explain_anomaly'
+	| 'analytics.segment_insight'
+	| 'analytics.digest_email';
+
+const ENDPOINT_MAP: Record<AnalyticsAiFeatureKey, string> = {
+	'analytics.insight_summary': '/ai/insight-summary',
+	'analytics.explain_anomaly': '/ai/explain-anomaly',
+	'analytics.segment_insight': '/ai/segment-insight',
+	'analytics.digest_email': '/ai/digest-email',
+};
+
+export interface AgentResponse<TOutput> {
+	data: TOutput;
+	feature_key: AnalyticsAiFeatureKey;
+}
+
+export interface UseAiAgentReturn<TInput, TOutput> {
+	output: TOutput | null;
+	isLoading: boolean;
+	error: string | null;
+	run: ( input: TInput ) => Promise<TOutput | null>;
+	reset: () => void;
+}
+
+export function useAiAgent<TInput, TOutput>(
+	feature: AnalyticsAiFeatureKey,
+	options: UseApiOptions,
+): UseAiAgentReturn<TInput, TOutput> {
+	const api = useApi( options );
+	const [ output, setOutput ] = useState<TOutput | null>( null );
+	const [ isLoading, setIsLoading ] = useState<boolean>( false );
+	const [ error, setError ] = useState<string | null>( null );
+
+	const reset = useCallback( () => {
+		setOutput( null );
+		setError( null );
+	}, [] );
+
+	const run = useCallback(
+		async ( input: TInput ): Promise<TOutput | null> => {
+			setIsLoading( true );
+			setError( null );
+
+			try {
+				const response = await api.post<AgentResponse<TOutput>>( ENDPOINT_MAP[ feature ], input );
+				setOutput( response.data );
+				return response.data;
+			} catch ( caught ) {
+				if ( caught instanceof ApiValidationError ) {
+					const firstField = Object.keys( caught.errors )[0];
+					setError( firstField ? caught.errors[ firstField ][0] : caught.message );
+				} else if ( caught instanceof ApiError ) {
+					setError( caught.message );
+				} else if ( caught instanceof Error ) {
+					setError( caught.message );
+				} else {
+					setError( 'Request failed.' );
+				}
+
+				return null;
+			} finally {
+				setIsLoading( false );
+			}
+		},
+		[ api, feature ],
+	);
+
+	return { output, isLoading, error, run, reset };
+}

--- a/resources/js/react/hooks/useApi.ts
+++ b/resources/js/react/hooks/useApi.ts
@@ -1,0 +1,160 @@
+/**
+ * useApi hook for authenticated API communication.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+import { useCallback, useMemo } from 'react';
+
+export class ApiValidationError extends Error {
+	public readonly errors: Record<string, string[]>;
+	public readonly status: number;
+
+	constructor( message: string, errors: Record<string, string[]>, status: number ) {
+		super( message );
+		this.name = 'ApiValidationError';
+		this.errors = errors;
+		this.status = status;
+	}
+}
+
+export class ApiError extends Error {
+	public readonly status: number;
+
+	constructor( message: string, status: number ) {
+		super( message );
+		this.name = 'ApiError';
+		this.status = status;
+	}
+}
+
+export interface UseApiOptions {
+	baseUrl: string;
+	csrfToken?: string;
+	authorization?: string;
+	credentials?: RequestCredentials;
+}
+
+export interface UseApiReturn {
+	get: <T>( path: string, params?: Record<string, string> ) => Promise<T>;
+	post: <T>( path: string, body?: unknown ) => Promise<T>;
+}
+
+function getMetaCsrfToken(): string | null {
+	const meta = document.querySelector( 'meta[name="csrf-token"]' );
+
+	return meta?.getAttribute( 'content' ) ?? null;
+}
+
+function getXsrfToken(): string | null {
+	const match = document.cookie.match( /(?:^|;\s*)XSRF-TOKEN=([^;]*)/ );
+
+	return match ? decodeURIComponent( match[1] ) : null;
+}
+
+export function useApi( options: UseApiOptions ): UseApiReturn {
+	const { baseUrl, csrfToken, authorization, credentials = 'include' } = options;
+
+	const buildHeaders = useCallback(
+		(): Record<string, string> => {
+			const headers: Record<string, string> = {
+				Accept: 'application/json',
+				'Content-Type': 'application/json',
+			};
+
+			const token = csrfToken ?? getMetaCsrfToken();
+
+			if ( token ) {
+				headers['X-CSRF-TOKEN'] = token;
+			}
+
+			const xsrf = getXsrfToken();
+
+			if ( xsrf ) {
+				headers['X-XSRF-TOKEN'] = xsrf;
+			}
+
+			if ( authorization ) {
+				headers.Authorization = authorization;
+			}
+
+			return headers;
+		},
+		[ csrfToken, authorization ],
+	);
+
+	const buildUrl = useCallback(
+		( path: string, params?: Record<string, string> ): string => {
+			const url = new URL( `${ baseUrl }${ path }`, window.location.origin );
+
+			if ( params ) {
+				for ( const [ key, value ] of Object.entries( params ) ) {
+					if ( value !== undefined && value !== '' ) {
+						url.searchParams.set( key, value );
+					}
+				}
+			}
+
+			return url.toString();
+		},
+		[ baseUrl ],
+	);
+
+	const handleResponse = useCallback( async <T>( response: Response ): Promise<T> => {
+		if ( 204 === response.status ) {
+			return undefined as T;
+		}
+
+		if ( 422 === response.status ) {
+			const data = await response.json().catch( () => ( {} ) );
+			throw new ApiValidationError( data.message ?? 'Validation failed.', data.errors ?? {}, 422 );
+		}
+
+		if ( ! response.ok ) {
+			let message = `Request failed with status ${ response.status }`;
+
+			try {
+				const data = await response.json();
+				message = data.message ?? message;
+			} catch {
+				// Use default message
+			}
+
+			throw new ApiError( message, response.status );
+		}
+
+		return response.json() as Promise<T>;
+	}, [] );
+
+	const get = useCallback(
+		async <T>( path: string, params?: Record<string, string> ): Promise<T> => {
+			const response = await fetch( buildUrl( path, params ), {
+				method: 'GET',
+				headers: buildHeaders(),
+				credentials,
+			} );
+
+			return handleResponse<T>( response );
+		},
+		[ buildUrl, buildHeaders, handleResponse, credentials ],
+	);
+
+	const post = useCallback(
+		async <T>( path: string, body?: unknown ): Promise<T> => {
+			const response = await fetch( buildUrl( path ), {
+				method: 'POST',
+				headers: buildHeaders(),
+				credentials,
+				body: body !== undefined ? JSON.stringify( body ) : undefined,
+			} );
+
+			return handleResponse<T>( response );
+		},
+		[ buildUrl, buildHeaders, handleResponse, credentials ],
+	);
+
+	return useMemo( () => ( { get, post } ), [ get, post ] );
+}

--- a/resources/js/vue/components/ai/AnomalyExplanation.vue
+++ b/resources/js/vue/components/ai/AnomalyExplanation.vue
@@ -1,0 +1,116 @@
+<!--
+  Vue trigger for the AnomalyExplanationAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage Analytics
+
+  @since      1.3.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+export interface AnomalyPayload {
+	metric: string;
+	direction: 'up' | 'down';
+	magnitude: number;
+	date: string;
+}
+
+export interface AnomalyContext {
+	recent_content_changes?: unknown[];
+	referrer_deltas?: unknown[];
+	campaign_launches?: unknown[];
+	[key: string]: unknown;
+}
+
+interface Input {
+	anomaly: AnomalyPayload;
+	context: AnomalyContext;
+}
+
+export interface Hypothesis {
+	cause: string;
+	confidence: 'low' | 'medium' | 'high';
+	evidence: string[];
+}
+
+export interface AnomalyExplanationResult {
+	hypotheses: Hypothesis[];
+	recommended_next_steps: string[];
+}
+
+const props = defineProps<{
+	api: UseApiOptions;
+	anomaly: AnomalyPayload;
+	context: AnomalyContext;
+}>();
+
+const { output, isLoading, error, run } = useAiAgent<Input, AnomalyExplanationResult>(
+	'analytics.explain_anomaly',
+	props.api,
+);
+
+const disabled = computed( () => isLoading.value || ! props.anomaly.metric );
+
+const handleClick = (): void => {
+	void run( { anomaly: props.anomaly, context: props.context } );
+};
+</script>
+
+<template>
+	<div class="analytics-ai-anomaly-explanation" data-feature="analytics.explain_anomaly">
+		<button
+			type="button"
+			class="analytics-ai-anomaly-explanation__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Analyzing…</template>
+			<template v-else>Explain this anomaly</template>
+		</button>
+
+		<p v-if="error" class="analytics-ai-anomaly-explanation__error" role="alert">
+			{{ error }}
+		</p>
+
+		<div v-if="output && output.hypotheses.length > 0" class="analytics-ai-anomaly-explanation__result">
+			<h3 class="analytics-ai-anomaly-explanation__heading">Hypotheses</h3>
+			<ul class="analytics-ai-anomaly-explanation__hypotheses">
+				<li
+					v-for="( hypothesis, idx ) in output.hypotheses"
+					:key="idx"
+					class="analytics-ai-anomaly-explanation__hypothesis"
+				>
+					<div class="analytics-ai-anomaly-explanation__hypothesis-header">
+						<span class="analytics-ai-anomaly-explanation__cause">
+							{{ hypothesis.cause }}
+						</span>
+						<span
+							class="analytics-ai-anomaly-explanation__confidence"
+							:class="`analytics-ai-anomaly-explanation__confidence--${ hypothesis.confidence }`"
+						>
+							{{ hypothesis.confidence }}
+						</span>
+					</div>
+					<ul
+						v-if="hypothesis.evidence.length > 0"
+						class="analytics-ai-anomaly-explanation__evidence"
+					>
+						<li v-for="( item, eIdx ) in hypothesis.evidence" :key="eIdx">{{ item }}</li>
+					</ul>
+				</li>
+			</ul>
+
+			<template v-if="output.recommended_next_steps.length > 0">
+				<h4 class="analytics-ai-anomaly-explanation__subheading">Recommended next steps</h4>
+				<ul class="analytics-ai-anomaly-explanation__steps">
+					<li v-for="( step, idx ) in output.recommended_next_steps" :key="idx">{{ step }}</li>
+				</ul>
+			</template>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/DigestSubscription.vue
+++ b/resources/js/vue/components/ai/DigestSubscription.vue
@@ -1,0 +1,98 @@
+<!--
+  Vue opt-in UI for the AI analytics digest email.
+
+  @package    ArtisanPack_UI
+  @subpackage Analytics
+
+  @since      1.3.0
+-->
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+import { useApi, type UseApiOptions } from '../../composables/useApi';
+
+export type DigestCadence = 'off' | 'weekly' | 'monthly';
+
+const props = withDefaults(
+	defineProps<{
+		api: UseApiOptions;
+		initialCadence?: DigestCadence;
+		updatePath?: string;
+	}>(),
+	{
+		initialCadence: 'off',
+		updatePath: '/ai/digest-subscription',
+	},
+);
+
+const apiClient = useApi( props.api );
+const cadence = ref<DigestCadence>( props.initialCadence );
+const isSaving = ref( false );
+const status = ref<string | null>( null );
+const error = ref<string | null>( null );
+
+const OPTIONS: DigestCadence[] = [ 'off', 'weekly', 'monthly' ];
+
+const save = async (): Promise<void> => {
+	isSaving.value = true;
+	status.value = null;
+	error.value = null;
+
+	try {
+		await apiClient.post( props.updatePath, { cadence: cadence.value } );
+		status.value = 'off' === cadence.value ? 'Digest emails turned off.' : 'Digest preference saved.';
+	} catch ( caught ) {
+		error.value = caught instanceof Error ? caught.message : 'Could not save preference.';
+	} finally {
+		isSaving.value = false;
+	}
+};
+</script>
+
+<template>
+	<div class="analytics-ai-digest-subscription" data-feature="analytics.digest_email">
+		<form class="analytics-ai-digest-subscription__form" @submit.prevent="save">
+			<fieldset>
+				<legend class="analytics-ai-digest-subscription__legend">
+					Analytics digest email
+				</legend>
+				<p class="analytics-ai-digest-subscription__hint">
+					Receive a plain-language summary of your site's traffic on your chosen cadence.
+				</p>
+
+				<label
+					v-for="value in OPTIONS"
+					:key="value"
+					class="analytics-ai-digest-subscription__option"
+				>
+					<input
+						type="radio"
+						name="cadence"
+						:value="value"
+						:checked="cadence === value"
+						@change="cadence = value"
+					/>
+					<span>{{ value.charAt( 0 ).toUpperCase() + value.slice( 1 ) }}</span>
+				</label>
+			</fieldset>
+
+			<button
+				type="submit"
+				class="analytics-ai-digest-subscription__save"
+				:disabled="isSaving"
+			>
+				<template v-if="isSaving">Saving…</template>
+				<template v-else>Save preference</template>
+			</button>
+
+			<p v-if="status" class="analytics-ai-digest-subscription__status" role="status">
+				{{ status }}
+			</p>
+
+			<p v-if="error" class="analytics-ai-digest-subscription__error" role="alert">
+				{{ error }}
+			</p>
+		</form>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/InsightSummary.vue
+++ b/resources/js/vue/components/ai/InsightSummary.vue
@@ -1,0 +1,100 @@
+<!--
+  Vue trigger for the InsightSummaryAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage Analytics
+
+  @since      1.3.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+interface DateRange {
+	from: string;
+	to: string;
+}
+
+interface Input {
+	date_range: DateRange;
+	metrics: Record<string, unknown>;
+	compare_to?: DateRange;
+}
+
+export interface InsightSummaryResult {
+	summary: string;
+	highlights: string[];
+	concerns: string[];
+}
+
+const props = withDefaults(
+	defineProps<{
+		api: UseApiOptions;
+		dateRange: DateRange;
+		metrics: Record<string, unknown>;
+		compareTo?: DateRange;
+	}>(),
+	{},
+);
+
+const { output, isLoading, error, run } = useAiAgent<Input, InsightSummaryResult>(
+	'analytics.insight_summary',
+	props.api,
+);
+
+const disabled = computed(
+	() =>
+		isLoading.value ||
+		props.dateRange.from.trim() === '' ||
+		props.dateRange.to.trim() === '' ||
+		Object.keys( props.metrics ).length === 0,
+);
+
+const handleClick = (): void => {
+	void run( {
+		date_range: props.dateRange,
+		metrics: props.metrics,
+		...( props.compareTo ? { compare_to: props.compareTo } : {} ),
+	} );
+};
+</script>
+
+<template>
+	<div class="analytics-ai-insight-summary" data-feature="analytics.insight_summary">
+		<button
+			type="button"
+			class="analytics-ai-insight-summary__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Summarizing…</template>
+			<template v-else>Summarize this window</template>
+		</button>
+
+		<p v-if="error" class="analytics-ai-insight-summary__error" role="alert">
+			{{ error }}
+		</p>
+
+		<div v-if="output" class="analytics-ai-insight-summary__result">
+			<h3 class="analytics-ai-insight-summary__heading">Summary</h3>
+			<p class="analytics-ai-insight-summary__summary">{{ output.summary }}</p>
+
+			<template v-if="output.highlights.length > 0">
+				<h4 class="analytics-ai-insight-summary__subheading">Highlights</h4>
+				<ul class="analytics-ai-insight-summary__list">
+					<li v-for="( item, idx ) in output.highlights" :key="idx">{{ item }}</li>
+				</ul>
+			</template>
+
+			<template v-if="output.concerns.length > 0">
+				<h4 class="analytics-ai-insight-summary__subheading">Concerns</h4>
+				<ul class="analytics-ai-insight-summary__list">
+					<li v-for="( item, idx ) in output.concerns" :key="idx">{{ item }}</li>
+				</ul>
+			</template>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/SegmentInsight.vue
+++ b/resources/js/vue/components/ai/SegmentInsight.vue
@@ -1,0 +1,110 @@
+<!--
+  Vue trigger for the SegmentInsightAgent.
+
+  @package    ArtisanPack_UI
+  @subpackage Analytics
+
+  @since      1.3.0
+-->
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { useAiAgent } from '../../composables/useAiAgent';
+import type { UseApiOptions } from '../../composables/useApi';
+
+export interface Segment {
+	type: string;
+	value: string;
+}
+
+interface Input {
+	segment: Segment;
+	metrics: Record<string, unknown>;
+	baseline: Record<string, unknown>;
+}
+
+export interface Pattern {
+	observation: string;
+	significance: 'low' | 'medium' | 'high';
+	suggested_action: string;
+}
+
+export interface SegmentInsightResult {
+	patterns: Pattern[];
+}
+
+const props = defineProps<{
+	api: UseApiOptions;
+	segment: Segment;
+	metrics: Record<string, unknown>;
+	baseline: Record<string, unknown>;
+}>();
+
+const { output, isLoading, error, run } = useAiAgent<Input, SegmentInsightResult>(
+	'analytics.segment_insight',
+	props.api,
+);
+
+const disabled = computed(
+	() =>
+		isLoading.value ||
+		props.segment.type.trim() === '' ||
+		props.segment.value.trim() === '' ||
+		Object.keys( props.metrics ).length === 0 ||
+		Object.keys( props.baseline ).length === 0,
+);
+
+const handleClick = (): void => {
+	void run( {
+		segment: props.segment,
+		metrics: props.metrics,
+		baseline: props.baseline,
+	} );
+};
+</script>
+
+<template>
+	<div class="analytics-ai-segment-insight" data-feature="analytics.segment_insight">
+		<button
+			type="button"
+			class="analytics-ai-segment-insight__button"
+			:disabled="disabled"
+			@click="handleClick"
+		>
+			<template v-if="isLoading">Analyzing segment…</template>
+			<template v-else>Find patterns in this segment</template>
+		</button>
+
+		<p v-if="error" class="analytics-ai-segment-insight__error" role="alert">
+			{{ error }}
+		</p>
+
+		<div v-if="output && output.patterns.length > 0" class="analytics-ai-segment-insight__result">
+			<h3 class="analytics-ai-segment-insight__heading">Patterns</h3>
+			<ul class="analytics-ai-segment-insight__patterns">
+				<li
+					v-for="( pattern, idx ) in output.patterns"
+					:key="idx"
+					class="analytics-ai-segment-insight__pattern"
+				>
+					<div class="analytics-ai-segment-insight__pattern-header">
+						<span class="analytics-ai-segment-insight__observation">
+							{{ pattern.observation }}
+						</span>
+						<span
+							class="analytics-ai-segment-insight__significance"
+							:class="`analytics-ai-segment-insight__significance--${ pattern.significance }`"
+						>
+							{{ pattern.significance }}
+						</span>
+					</div>
+					<p class="analytics-ai-segment-insight__action">
+						<strong>Suggested action: </strong>
+						{{ pattern.suggested_action }}
+					</p>
+				</li>
+			</ul>
+		</div>
+	</div>
+</template>

--- a/resources/js/vue/components/ai/index.ts
+++ b/resources/js/vue/components/ai/index.ts
@@ -1,0 +1,13 @@
+/**
+ * AI trigger components for the Analytics package.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+export { default as AnomalyExplanation } from './AnomalyExplanation.vue';
+export { default as DigestSubscription } from './DigestSubscription.vue';
+export { default as InsightSummary } from './InsightSummary.vue';
+export { default as SegmentInsight } from './SegmentInsight.vue';

--- a/resources/js/vue/composables/useAiAgent.ts
+++ b/resources/js/vue/composables/useAiAgent.ts
@@ -1,0 +1,81 @@
+/**
+ * useAiAgent composable — thin wrapper for the Analytics AI endpoints.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+import { ref, type Ref } from 'vue';
+
+import { ApiError, ApiValidationError, useApi, type UseApiOptions } from './useApi';
+
+export type AnalyticsAiFeatureKey =
+	| 'analytics.insight_summary'
+	| 'analytics.explain_anomaly'
+	| 'analytics.segment_insight'
+	| 'analytics.digest_email';
+
+const ENDPOINT_MAP: Record<AnalyticsAiFeatureKey, string> = {
+	'analytics.insight_summary': '/ai/insight-summary',
+	'analytics.explain_anomaly': '/ai/explain-anomaly',
+	'analytics.segment_insight': '/ai/segment-insight',
+	'analytics.digest_email': '/ai/digest-email',
+};
+
+export interface AgentResponse<TOutput> {
+	data: TOutput;
+	feature_key: AnalyticsAiFeatureKey;
+}
+
+export interface UseAiAgentReturn<TInput, TOutput> {
+	output: Ref<TOutput | null>;
+	isLoading: Ref<boolean>;
+	error: Ref<string | null>;
+	run: ( input: TInput ) => Promise<TOutput | null>;
+	reset: () => void;
+}
+
+export function useAiAgent<TInput, TOutput>(
+	feature: AnalyticsAiFeatureKey,
+	options: UseApiOptions,
+): UseAiAgentReturn<TInput, TOutput> {
+	const api = useApi( options );
+	const output = ref<TOutput | null>( null ) as Ref<TOutput | null>;
+	const isLoading = ref<boolean>( false );
+	const error = ref<string | null>( null );
+
+	const reset = (): void => {
+		output.value = null;
+		error.value = null;
+	};
+
+	const run = async ( input: TInput ): Promise<TOutput | null> => {
+		isLoading.value = true;
+		error.value = null;
+
+		try {
+			const response = await api.post<AgentResponse<TOutput>>( ENDPOINT_MAP[ feature ], input );
+			output.value = response.data;
+			return response.data;
+		} catch ( caught ) {
+			if ( caught instanceof ApiValidationError ) {
+				const firstField = Object.keys( caught.errors )[0];
+				error.value = firstField ? caught.errors[ firstField ][0] : caught.message;
+			} else if ( caught instanceof ApiError ) {
+				error.value = caught.message;
+			} else if ( caught instanceof Error ) {
+				error.value = caught.message;
+			} else {
+				error.value = 'Request failed.';
+			}
+
+			return null;
+		} finally {
+			isLoading.value = false;
+		}
+	};
+
+	return { output, isLoading, error, run, reset };
+}

--- a/resources/js/vue/composables/useApi.ts
+++ b/resources/js/vue/composables/useApi.ts
@@ -1,0 +1,155 @@
+/**
+ * useApi composable for authenticated API communication.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+export class ApiValidationError extends Error {
+	public readonly errors: Record<string, string[]>;
+	public readonly status: number;
+
+	constructor( message: string, errors: Record<string, string[]>, status: number ) {
+		super( message );
+		this.name = 'ApiValidationError';
+		this.errors = errors;
+		this.status = status;
+	}
+}
+
+export class ApiError extends Error {
+	public readonly status: number;
+
+	constructor( message: string, status: number ) {
+		super( message );
+		this.name = 'ApiError';
+		this.status = status;
+	}
+}
+
+export interface UseApiOptions {
+	baseUrl: string;
+	csrfToken?: string;
+	authorization?: string;
+	credentials?: RequestCredentials;
+}
+
+export interface UseApiReturn {
+	get: <T>( path: string, params?: Record<string, string> ) => Promise<T>;
+	post: <T>( path: string, body?: unknown ) => Promise<T>;
+}
+
+function getMetaCsrfToken(): string | null {
+	if ( 'undefined' === typeof document ) {
+		return null;
+	}
+
+	const meta = document.querySelector( 'meta[name="csrf-token"]' );
+
+	return meta?.getAttribute( 'content' ) ?? null;
+}
+
+function getXsrfToken(): string | null {
+	if ( 'undefined' === typeof document ) {
+		return null;
+	}
+
+	const match = document.cookie.match( /(?:^|;\s*)XSRF-TOKEN=([^;]*)/ );
+
+	return match ? decodeURIComponent( match[1] ) : null;
+}
+
+export function useApi( options: UseApiOptions ): UseApiReturn {
+	const { baseUrl, csrfToken, authorization, credentials = 'include' } = options;
+
+	function buildHeaders(): Record<string, string> {
+		const headers: Record<string, string> = {
+			Accept: 'application/json',
+			'Content-Type': 'application/json',
+		};
+
+		const token = csrfToken ?? getMetaCsrfToken();
+
+		if ( token ) {
+			headers['X-CSRF-TOKEN'] = token;
+		}
+
+		const xsrf = getXsrfToken();
+
+		if ( xsrf ) {
+			headers['X-XSRF-TOKEN'] = xsrf;
+		}
+
+		if ( authorization ) {
+			headers.Authorization = authorization;
+		}
+
+		return headers;
+	}
+
+	function buildUrl( path: string, params?: Record<string, string> ): string {
+		const origin = 'undefined' !== typeof window ? window.location.origin : 'http://localhost';
+		const url    = new URL( `${ baseUrl }${ path }`, origin );
+
+		if ( params ) {
+			for ( const [ key, value ] of Object.entries( params ) ) {
+				if ( value !== undefined && value !== '' ) {
+					url.searchParams.set( key, value );
+				}
+			}
+		}
+
+		return url.toString();
+	}
+
+	async function handleResponse<T>( response: Response ): Promise<T> {
+		if ( 204 === response.status ) {
+			return undefined as T;
+		}
+
+		if ( 422 === response.status ) {
+			const data = await response.json().catch( () => ( {} ) );
+			throw new ApiValidationError( data.message ?? 'Validation failed.', data.errors ?? {}, 422 );
+		}
+
+		if ( ! response.ok ) {
+			let message = `Request failed with status ${ response.status }`;
+
+			try {
+				const data = await response.json();
+				message = data.message ?? message;
+			} catch {
+				// Use default message
+			}
+
+			throw new ApiError( message, response.status );
+		}
+
+		return response.json() as Promise<T>;
+	}
+
+	async function get<T>( path: string, params?: Record<string, string> ): Promise<T> {
+		const response = await fetch( buildUrl( path, params ), {
+			method: 'GET',
+			headers: buildHeaders(),
+			credentials,
+		} );
+
+		return handleResponse<T>( response );
+	}
+
+	async function post<T>( path: string, body?: unknown ): Promise<T> {
+		const response = await fetch( buildUrl( path ), {
+			method: 'POST',
+			headers: buildHeaders(),
+			credentials,
+			body: body !== undefined ? JSON.stringify( body ) : undefined,
+		} );
+
+		return handleResponse<T>( response );
+	}
+
+	return { get, post };
+}

--- a/resources/views/emails/digest.blade.php
+++ b/resources/views/emails/digest.blade.php
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>{{ __( 'Analytics digest' ) }}</title>
+</head>
+<body style="margin:0;padding:24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#111;background:#f8fafc;">
+	<main style="max-width:640px;margin:0 auto;background:#ffffff;padding:32px;border-radius:8px;">
+		<header>
+			<h1 style="font-size:20px;margin:0 0 4px;">
+				@if ( 'monthly' === $cadence )
+					{{ __( 'Your monthly analytics digest' ) }}
+				@else
+					{{ __( 'Your weekly analytics digest' ) }}
+				@endif
+			</h1>
+			<p style="margin:0 0 24px;color:#475569;font-size:14px;">
+				{{ $periodLabel }}
+			</p>
+		</header>
+
+		<section aria-labelledby="digest-summary">
+			<h2 id="digest-summary" style="font-size:16px;margin:0 0 8px;">
+				{{ __( 'Summary' ) }}
+			</h2>
+			<p style="margin:0 0 24px;line-height:1.5;">
+				{{ $summary }}
+			</p>
+		</section>
+
+		@if ( ! empty( $keyPoints ) )
+			<section aria-labelledby="digest-highlights">
+				<h2 id="digest-highlights" style="font-size:16px;margin:0 0 8px;">
+					{{ __( 'Highlights' ) }}
+				</h2>
+				<ul style="margin:0 0 24px;padding-left:20px;line-height:1.6;">
+					@foreach ( $keyPoints as $point )
+						<li>{{ $point }}</li>
+					@endforeach
+				</ul>
+			</section>
+		@endif
+
+		@if ( ! empty( $caveats ) )
+			<section aria-labelledby="digest-caveats">
+				<h2 id="digest-caveats" style="font-size:16px;margin:0 0 8px;">
+					{{ __( 'Worth watching' ) }}
+				</h2>
+				<ul style="margin:0 0 24px;padding-left:20px;line-height:1.6;color:#475569;">
+					@foreach ( $caveats as $caveat )
+						<li>{{ $caveat }}</li>
+					@endforeach
+				</ul>
+			</section>
+		@endif
+
+		<footer style="border-top:1px solid #e2e8f0;padding-top:16px;color:#64748b;font-size:12px;">
+			<p style="margin:0;">
+				{{ __( 'You are receiving this because you opted in to analytics digest emails. You can change your cadence or unsubscribe from the analytics dashboard.' ) }}
+			</p>
+		</footer>
+	</main>
+</body>
+</html>

--- a/resources/views/livewire/ai/anomaly-explanation.blade.php
+++ b/resources/views/livewire/ai/anomaly-explanation.blade.php
@@ -1,0 +1,63 @@
+<div class="analytics-ai-anomaly-explanation" data-feature="analytics.explain_anomaly">
+	@if ( ! $this->isEnabled )
+		<p class="analytics-ai-anomaly-explanation__disabled">
+			{{ __( 'AI anomaly explanations are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="explain"
+			wire:loading.attr="disabled"
+			wire:target="explain"
+			@disabled( $isLoading || [] === $anomaly )
+			class="analytics-ai-anomaly-explanation__button"
+		>
+			<span wire:loading.remove wire:target="explain">
+				{{ __( 'Explain this anomaly' ) }}
+			</span>
+			<span wire:loading wire:target="explain">
+				{{ __( 'Analyzing…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="analytics-ai-anomaly-explanation__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( ! empty( $hypotheses ) )
+			<div class="analytics-ai-anomaly-explanation__result">
+				<h3 class="analytics-ai-anomaly-explanation__heading">{{ __( 'Hypotheses' ) }}</h3>
+				<ul class="analytics-ai-anomaly-explanation__hypotheses">
+					@foreach ( $hypotheses as $index => $hypothesis )
+						<li wire:key="hy-{{ $index }}" class="analytics-ai-anomaly-explanation__hypothesis">
+							<div class="analytics-ai-anomaly-explanation__hypothesis-header">
+								<span class="analytics-ai-anomaly-explanation__cause">{{ $hypothesis['cause'] }}</span>
+								<span class="analytics-ai-anomaly-explanation__confidence analytics-ai-anomaly-explanation__confidence--{{ $hypothesis['confidence'] }}">
+									{{ __( ucfirst( $hypothesis['confidence'] ) ) }}
+								</span>
+							</div>
+							@if ( ! empty( $hypothesis['evidence'] ) )
+								<ul class="analytics-ai-anomaly-explanation__evidence">
+									@foreach ( $hypothesis['evidence'] as $evidenceIndex => $evidence )
+										<li wire:key="ev-{{ $index }}-{{ $evidenceIndex }}">{{ $evidence }}</li>
+									@endforeach
+								</ul>
+							@endif
+						</li>
+					@endforeach
+				</ul>
+
+				@if ( ! empty( $recommendedNextSteps ) )
+					<h4 class="analytics-ai-anomaly-explanation__subheading">{{ __( 'Recommended next steps' ) }}</h4>
+					<ul class="analytics-ai-anomaly-explanation__steps">
+						@foreach ( $recommendedNextSteps as $stepIndex => $step )
+							<li wire:key="st-{{ $stepIndex }}">{{ $step }}</li>
+						@endforeach
+					</ul>
+				@endif
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/digest-subscription.blade.php
+++ b/resources/views/livewire/ai/digest-subscription.blade.php
@@ -1,0 +1,48 @@
+<div class="analytics-ai-digest-subscription" data-feature="analytics.digest_email">
+	@if ( ! $this->isEnabled )
+		<p class="analytics-ai-digest-subscription__disabled">
+			{{ __( 'AI digest emails are currently disabled.' ) }}
+		</p>
+	@else
+		<form wire:submit.prevent="save" class="analytics-ai-digest-subscription__form">
+			<fieldset>
+				<legend class="analytics-ai-digest-subscription__legend">
+					{{ __( 'Analytics digest email' ) }}
+				</legend>
+				<p class="analytics-ai-digest-subscription__hint">
+					{{ __( 'Receive a plain-language summary of your site\'s traffic on your chosen cadence.' ) }}
+				</p>
+
+				<label class="analytics-ai-digest-subscription__option">
+					<input type="radio" wire:model="cadence" value="off" />
+					<span>{{ __( 'Off' ) }}</span>
+				</label>
+
+				<label class="analytics-ai-digest-subscription__option">
+					<input type="radio" wire:model="cadence" value="weekly" />
+					<span>{{ __( 'Weekly' ) }}</span>
+				</label>
+
+				<label class="analytics-ai-digest-subscription__option">
+					<input type="radio" wire:model="cadence" value="monthly" />
+					<span>{{ __( 'Monthly' ) }}</span>
+				</label>
+			</fieldset>
+
+			<button
+				type="submit"
+				class="analytics-ai-digest-subscription__save"
+				wire:loading.attr="disabled"
+				wire:target="save"
+			>
+				{{ __( 'Save preference' ) }}
+			</button>
+
+			@if ( null !== $status )
+				<p class="analytics-ai-digest-subscription__status" role="status">
+					{{ $status }}
+				</p>
+			@endif
+		</form>
+	@endif
+</div>

--- a/resources/views/livewire/ai/insight-summary.blade.php
+++ b/resources/views/livewire/ai/insight-summary.blade.php
@@ -1,0 +1,54 @@
+<div class="analytics-ai-insight-summary" data-feature="analytics.insight_summary">
+	@if ( ! $this->isEnabled )
+		<p class="analytics-ai-insight-summary__disabled">
+			{{ __( 'AI insight summaries are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="summarize"
+			wire:loading.attr="disabled"
+			wire:target="summarize"
+			@disabled( $isLoading || '' === trim( $dateFrom ) || '' === trim( $dateTo ) || [] === $metrics )
+			class="analytics-ai-insight-summary__button"
+		>
+			<span wire:loading.remove wire:target="summarize">
+				{{ __( 'Summarize this window' ) }}
+			</span>
+			<span wire:loading wire:target="summarize">
+				{{ __( 'Summarizing…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="analytics-ai-insight-summary__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( null !== $summary )
+			<div class="analytics-ai-insight-summary__result">
+				<h3 class="analytics-ai-insight-summary__heading">{{ __( 'Summary' ) }}</h3>
+				<p class="analytics-ai-insight-summary__summary">{{ $summary }}</p>
+
+				@if ( ! empty( $highlights ) )
+					<h4 class="analytics-ai-insight-summary__subheading">{{ __( 'Highlights' ) }}</h4>
+					<ul class="analytics-ai-insight-summary__list">
+						@foreach ( $highlights as $index => $highlight )
+							<li wire:key="hi-{{ $index }}">{{ $highlight }}</li>
+						@endforeach
+					</ul>
+				@endif
+
+				@if ( ! empty( $concerns ) )
+					<h4 class="analytics-ai-insight-summary__subheading">{{ __( 'Concerns' ) }}</h4>
+					<ul class="analytics-ai-insight-summary__list">
+						@foreach ( $concerns as $index => $concern )
+							<li wire:key="co-{{ $index }}">{{ $concern }}</li>
+						@endforeach
+					</ul>
+				@endif
+			</div>
+		@endif
+	@endif
+</div>

--- a/resources/views/livewire/ai/segment-insight.blade.php
+++ b/resources/views/livewire/ai/segment-insight.blade.php
@@ -1,0 +1,51 @@
+<div class="analytics-ai-segment-insight" data-feature="analytics.segment_insight">
+	@if ( ! $this->isEnabled )
+		<p class="analytics-ai-segment-insight__disabled">
+			{{ __( 'AI segment insights are currently disabled.' ) }}
+		</p>
+	@else
+		<button
+			type="button"
+			wire:click="analyze"
+			wire:loading.attr="disabled"
+			wire:target="analyze"
+			@disabled( $isLoading || '' === trim( $segmentType ) || '' === trim( $segmentValue ) || [] === $metrics || [] === $baseline )
+			class="analytics-ai-segment-insight__button"
+		>
+			<span wire:loading.remove wire:target="analyze">
+				{{ __( 'Find patterns in this segment' ) }}
+			</span>
+			<span wire:loading wire:target="analyze">
+				{{ __( 'Analyzing segment…' ) }}
+			</span>
+		</button>
+
+		@if ( null !== $error )
+			<p class="analytics-ai-segment-insight__error" role="alert">
+				{{ $error }}
+			</p>
+		@endif
+
+		@if ( ! empty( $patterns ) )
+			<div class="analytics-ai-segment-insight__result">
+				<h3 class="analytics-ai-segment-insight__heading">{{ __( 'Patterns' ) }}</h3>
+				<ul class="analytics-ai-segment-insight__patterns">
+					@foreach ( $patterns as $index => $pattern )
+						<li wire:key="pa-{{ $index }}" class="analytics-ai-segment-insight__pattern">
+							<div class="analytics-ai-segment-insight__pattern-header">
+								<span class="analytics-ai-segment-insight__observation">{{ $pattern['observation'] }}</span>
+								<span class="analytics-ai-segment-insight__significance analytics-ai-segment-insight__significance--{{ $pattern['significance'] }}">
+									{{ __( ucfirst( $pattern['significance'] ) ) }}
+								</span>
+							</div>
+							<p class="analytics-ai-segment-insight__action">
+								<strong>{{ __( 'Suggested action:' ) }}</strong>
+								{{ $pattern['suggested_action'] }}
+							</p>
+						</li>
+					@endforeach
+				</ul>
+			</div>
+		@endif
+	@endif
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 use ArtisanPackUI\Analytics\Http\Controllers\AnalyticsController;
 use ArtisanPackUI\Analytics\Http\Controllers\AnalyticsQueryController;
+use ArtisanPackUI\Analytics\Http\Controllers\Api\AiAgentApiController;
 use ArtisanPackUI\Analytics\Http\Controllers\ConsentController;
 use ArtisanPackUI\Analytics\Http\Controllers\SiteApiController;
 use Illuminate\Support\Facades\Route;
@@ -94,6 +95,30 @@ Route::middleware( config( 'artisanpack.analytics.dashboard_middleware', [ 'auth
 
 	Route::get( '/bots', [ AnalyticsQueryController::class, 'bots' ] )
 		->name( 'analytics.bots' );
+
+	/*
+	|--------------------------------------------------------------------------
+	| AI Agent Endpoints (since 1.3.0)
+	|--------------------------------------------------------------------------
+	|
+	| POST endpoints for the four Analytics AI agents. Each dispatches its
+	| corresponding agent behind the `analytics.ai.use` gate and returns a
+	| `{ data, feature_key }` envelope.
+	|
+	*/
+	Route::prefix( 'ai' )->group( function (): void {
+		Route::post( 'insight-summary', [ AiAgentApiController::class, 'insightSummary' ] )
+			->name( 'analytics.api.ai.insight-summary' );
+
+		Route::post( 'explain-anomaly', [ AiAgentApiController::class, 'explainAnomaly' ] )
+			->name( 'analytics.api.ai.explain-anomaly' );
+
+		Route::post( 'segment-insight', [ AiAgentApiController::class, 'segmentInsight' ] )
+			->name( 'analytics.api.ai.segment-insight' );
+
+		Route::post( 'digest-email', [ AiAgentApiController::class, 'digestEmail' ] )
+			->name( 'analytics.api.ai.digest-email' );
+	} );
 } );
 
 /*

--- a/routes/api.php
+++ b/routes/api.php
@@ -118,6 +118,9 @@ Route::middleware( config( 'artisanpack.analytics.dashboard_middleware', [ 'auth
 
 		Route::post( 'digest-email', [ AiAgentApiController::class, 'digestEmail' ] )
 			->name( 'analytics.api.ai.digest-email' );
+
+		Route::post( 'digest-subscription', [ AiAgentApiController::class, 'saveDigestSubscription' ] )
+			->name( 'analytics.api.ai.digest-subscription' );
 	} );
 } );
 

--- a/src/Ai/Agents/AnomalyExplanationAgent.php
+++ b/src/Ai/Agents/AnomalyExplanationAgent.php
@@ -1,0 +1,305 @@
+<?php
+
+/**
+ * Anomaly explanation agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Explain a detected traffic anomaly with ranked hypotheses.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'anomaly' => [
+ *     'metric'    => string,   // e.g. "pageviews", "conversions"
+ *     'direction' => string,   // "up" | "down"
+ *     'magnitude' => float,    // percent change vs. expected
+ *     'date'      => string,   // YYYY-MM-DD
+ *   ],
+ *   'context' => [
+ *     'recent_content_changes' => array,
+ *     'referrer_deltas'        => array,
+ *     'campaign_launches'      => array,
+ *   ],
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   hypotheses: [
+ *     { cause: string, confidence: 'low'|'medium'|'high', evidence: string[] }
+ *   ],
+ *   recommended_next_steps: string[]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class AnomalyExplanationAgent extends ArtisanPackAgent
+{
+	/**
+	 * Supported confidence bands.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var array<int, string>
+	 */
+	protected const CONFIDENCE_LEVELS = [ 'low', 'medium', 'high' ];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'analytics.explain_anomaly';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/analytics';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-sonnet-4-6';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You explain a detected analytics anomaly by proposing ranked hypotheses for its cause.
+
+Requirements:
+- Ground every hypothesis in the provided `context` (recent content changes, referrer deltas, campaign launches). Do NOT invent events or channels that aren't in the context.
+- Return 1-5 hypotheses. Order them by how well they explain the anomaly's `direction` and `magnitude` — highest confidence first.
+- `confidence` MUST be exactly one of `low`, `medium`, `high`.
+- `evidence` for each hypothesis is 1-4 concrete items pulled from `context` (e.g. "referrer 'reddit.com' rose 340% on the same day", "content change to /pricing landed 2025-05-11"). Never emit generic strings like "traffic increased".
+- `recommended_next_steps` is 2-4 concrete actions the site owner should take next (e.g. "verify UTM tagging on the new campaign", "audit the /pricing edit for a broken canonical").
+- If the context is thin, say so — return one low-confidence hypothesis noting the missing context and a next step that gathers it.
+
+Return a JSON object with keys: hypotheses (array of {cause, confidence, evidence[]}) and recommended_next_steps (array of strings).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'hypotheses', 'recommended_next_steps' ],
+			'properties'           => [
+				'hypotheses'             => [
+					'type'  => 'array',
+					'items' => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => [ 'cause', 'confidence', 'evidence' ],
+						'properties'           => [
+							'cause'      => [ 'type' => 'string' ],
+							'confidence' => [ 'type' => 'string', 'enum' => self::CONFIDENCE_LEVELS ],
+							'evidence'   => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+						],
+					],
+				],
+				'recommended_next_steps' => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ?? [] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ anomaly: array<string, mixed>, context: array<string, mixed> }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with `anomaly` and `context` keys.',
+			);
+		}
+
+		if ( ! isset( $input['anomaly'] ) || ! is_array( $input['anomaly'] ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`anomaly` must be an array.' );
+		}
+
+		foreach ( [ 'metric', 'direction', 'date' ] as $required ) {
+			if ( ! isset( $input['anomaly'][ $required ] ) || ! is_string( $input['anomaly'][ $required ] ) || '' === trim( $input['anomaly'][ $required ] ) ) {
+				throw FeatureError::forFeature(
+					$this->featureKey,
+					sprintf( '`anomaly.%s` must be a non-empty string.', $required ),
+				);
+			}
+		}
+
+		if ( ! isset( $input['anomaly']['magnitude'] ) || ! is_numeric( $input['anomaly']['magnitude'] ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`anomaly.magnitude` must be numeric.' );
+		}
+
+		$context = isset( $input['context'] ) && is_array( $input['context'] ) ? $input['context'] : [];
+
+		return [
+			'anomaly' => $input['anomaly'],
+			'context' => $context,
+		];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array{ anomaly: array<string, mixed>, context: array<string, mixed> }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		try {
+			$anomalyJson = json_encode(
+				$normalized['anomaly'],
+				JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+			);
+			$contextJson = json_encode(
+				$normalized['context'],
+				JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+			);
+		} catch ( JsonException $exception ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( 'anomaly/context could not be serialized: %s', $exception->getMessage() ),
+				$exception,
+			);
+		}
+
+		return [
+			[ 'type' => 'text', 'text' => "Anomaly:\n" . $anomalyJson ],
+			[ 'type' => 'text', 'text' => "Context:\n" . $contextJson ],
+		];
+	}
+
+	/**
+	 * Enforce output invariants.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ hypotheses: array<int, array{ cause: string, confidence: string, evidence: array<int, string> }>, recommended_next_steps: array<int, string> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$rawHypotheses = is_array( $output['hypotheses'] ?? null ) ? $output['hypotheses'] : [];
+		$hypotheses    = [];
+
+		foreach ( $rawHypotheses as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$cause      = isset( $entry['cause'] ) && is_string( $entry['cause'] ) ? trim( $entry['cause'] ) : '';
+			$confidence = isset( $entry['confidence'] ) && is_string( $entry['confidence'] ) ? strtolower( trim( $entry['confidence'] ) ) : 'low';
+			$evidence   = $this->stringList( $entry['evidence'] ?? [] );
+
+			if ( ! in_array( $confidence, self::CONFIDENCE_LEVELS, true ) ) {
+				$confidence = 'low';
+			}
+
+			if ( '' === $cause ) {
+				continue;
+			}
+
+			$hypotheses[] = [
+				'cause'      => $cause,
+				'confidence' => $confidence,
+				'evidence'   => $evidence,
+			];
+		}
+
+		return [
+			'hypotheses'             => $hypotheses,
+			'recommended_next_steps' => $this->stringList( $output['recommended_next_steps'] ?? [] ),
+		];
+	}
+
+	/**
+	 * Filter a raw list into a clean array of non-empty strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $raw  Raw list from the model.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function stringList( mixed $raw ): array
+	{
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $raw as $value ) {
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				$out[] = trim( $value );
+			}
+		}
+
+		return $out;
+	}
+}

--- a/src/Ai/Agents/AnomalyExplanationAgent.php
+++ b/src/Ai/Agents/AnomalyExplanationAgent.php
@@ -244,7 +244,7 @@ PROMPT;
 	 */
 	protected function validateOutput( array $output ): array
 	{
-		$rawHypotheses = is_array( $output['hypotheses'] ?? null ) ? $output['hypotheses'] : [];
+		$rawHypotheses = $this->coerceListField( $output['hypotheses'] ?? null, 'hypotheses' );
 		$hypotheses    = [];
 
 		foreach ( $rawHypotheses as $entry ) {
@@ -301,5 +301,41 @@ PROMPT;
 		}
 
 		return $out;
+	}
+
+	/**
+	 * Coerce a top-level list field into an array.
+	 *
+	 * Some providers (e.g. Anthropic Opus under certain schema shapes)
+	 * return the whole nested payload as a JSON-encoded string instead of
+	 * a real array. Decode transparently so the downstream validator can
+	 * still iterate the entries.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed   $raw   Raw field from the model.
+	 * @param  string  $key   The field key to look up when the model re-nests under the same key.
+	 *
+	 * @return array<int|string, mixed>
+	 */
+	protected function coerceListField( mixed $raw, string $key ): array
+	{
+		if ( is_array( $raw ) ) {
+			return $raw;
+		}
+
+		if ( is_string( $raw ) && '' !== trim( $raw ) ) {
+			$decoded = json_decode( $raw, true );
+
+			if ( is_array( $decoded ) ) {
+				if ( isset( $decoded[ $key ] ) && is_array( $decoded[ $key ] ) ) {
+					return $decoded[ $key ];
+				}
+
+				return $decoded;
+			}
+		}
+
+		return [];
 	}
 }

--- a/src/Ai/Agents/DigestEmailAgent.php
+++ b/src/Ai/Agents/DigestEmailAgent.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * Digest email agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\SummarizationAgent;
+
+/**
+ * Compose an analytics digest email body from a period's items.
+ *
+ * Extends {@see SummarizationAgent} — inherits the input contract
+ * (`items`, `focus`, `length`) and returns the same shape
+ * (`summary`, `key_points`, `caveats`). The digest surface biases the
+ * prompt toward a friendly narrative suitable for a weekly or monthly
+ * subscriber email.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class DigestEmailAgent extends SummarizationAgent
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'analytics.digest_email';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/analytics';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-sonnet-4-6';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public bool $stream = false;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You compose the narrative body of an analytics digest email sent to a site owner on their chosen cadence (weekly or monthly).
+
+Requirements:
+- Base every claim strictly on the provided items (metrics, top pages, referrer deltas, notable events). Do NOT invent numbers.
+- `summary` is 2-4 sentences — the "here's what happened this period" narrative that reads like a friendly analyst wrote it. Lead with the headline metric change.
+- `key_points` is 3-7 bulletable highlights the reader would care about (top page, growth channel, standout referrer, goal conversion count). Reference concrete numbers.
+- `caveats` is 0-4 entries for missing context, thin data, or anomalies worth investigating separately. Empty array is fine when the period is clean.
+- Write in second person ("your site", "your top page") — subscribers are reading about their own analytics.
+- No marketing fluff, no emoji, no clickbait phrasing. Plain and honest.
+
+Return a JSON object with keys: summary (string), key_points (array of strings), caveats (array of strings).
+PROMPT;
+	}
+}

--- a/src/Ai/Agents/InsightSummaryAgent.php
+++ b/src/Ai/Agents/InsightSummaryAgent.php
@@ -1,0 +1,301 @@
+<?php
+
+/**
+ * Insight summary agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Produce a plain-language summary of a metrics window.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'date_range' => [ 'from' => string, 'to' => string ], // required (YYYY-MM-DD)
+ *   'metrics'    => array<string, mixed>,                 // required
+ *   'compare_to' => [ 'from' => string, 'to' => string ], // optional
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   summary:    string,
+ *   highlights: string[],
+ *   concerns:   string[]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class InsightSummaryAgent extends ArtisanPackAgent
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'analytics.insight_summary';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/analytics';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-sonnet-4-6';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public bool $stream = true;
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You summarize a website analytics window in plain, non-technical language for a busy site owner.
+
+Requirements:
+- Base every claim strictly on the provided `metrics` and (when present) `compare_to` numbers. Do NOT invent totals, percentages, or trends.
+- `summary` is 1-3 sentences that state the headline story of the window (traffic direction, standout channel or page, notable change vs. comparison).
+- `highlights` is 2-5 positive or neutral facts worth calling out (top page, best channel, growth vs. comparison). Reference concrete numbers.
+- `concerns` is 0-5 items that a site owner should pay attention to (drops, bounce spikes, missing goal conversions, thin data). Empty array is fine when the window is clean.
+- When `compare_to` is missing, describe the window in absolute terms and note that no comparison was provided.
+- Avoid marketing fluff. Speak like a friendly analyst, not a copywriter.
+
+Return a JSON object with keys: summary (string), highlights (array of strings), concerns (array of strings).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'summary', 'highlights', 'concerns' ],
+			'properties'           => [
+				'summary'    => [ 'type' => 'string' ],
+				'highlights' => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+				'concerns'   => [ 'type' => 'array', 'items' => [ 'type' => 'string' ] ],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ?? [] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ date_range: array{ from: string, to: string }, metrics: array<string, mixed>, compare_to: array{ from: string, to: string }|null }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with `date_range` and `metrics` keys.',
+			);
+		}
+
+		$dateRange = $this->normalizeDateRange( $input['date_range'] ?? null, 'date_range' );
+
+		if ( ! isset( $input['metrics'] ) || ! is_array( $input['metrics'] ) || [] === $input['metrics'] ) {
+			throw FeatureError::forFeature( $this->featureKey, '`metrics` must be a non-empty array.' );
+		}
+
+		$compareTo = null;
+
+		if ( isset( $input['compare_to'] ) && null !== $input['compare_to'] ) {
+			$compareTo = $this->normalizeDateRange( $input['compare_to'], 'compare_to' );
+		}
+
+		return [
+			'date_range' => $dateRange,
+			'metrics'    => $input['metrics'],
+			'compare_to' => $compareTo,
+		];
+	}
+
+	/**
+	 * Normalize a `{from,to}` date-range structure.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed   $value  Raw range.
+	 * @param  string  $label  Field name for error messages.
+	 *
+	 * @return array{ from: string, to: string }
+	 */
+	protected function normalizeDateRange( mixed $value, string $label ): array
+	{
+		if ( ! is_array( $value ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( '`%s` must be an array with `from` and `to` keys.', $label ),
+			);
+		}
+
+		$from = isset( $value['from'] ) && is_string( $value['from'] ) ? trim( $value['from'] ) : '';
+		$to   = isset( $value['to'] ) && is_string( $value['to'] ) ? trim( $value['to'] ) : '';
+
+		if ( '' === $from || '' === $to ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( '`%s.from` and `%s.to` must be non-empty strings.', $label, $label ),
+			);
+		}
+
+		return [ 'from' => $from, 'to' => $to ];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array{ date_range: array{ from: string, to: string }, metrics: array<string, mixed>, compare_to: array{ from: string, to: string }|null }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		$parts = [
+			[
+				'type' => 'text',
+				'text' => sprintf(
+					'Date range: %s to %s',
+					$normalized['date_range']['from'],
+					$normalized['date_range']['to'],
+				),
+			],
+		];
+
+		if ( null !== $normalized['compare_to'] ) {
+			$parts[] = [
+				'type' => 'text',
+				'text' => sprintf(
+					'Compare to: %s to %s',
+					$normalized['compare_to']['from'],
+					$normalized['compare_to']['to'],
+				),
+			];
+		}
+
+		try {
+			$metricsJson = json_encode(
+				$normalized['metrics'],
+				JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR,
+			);
+		} catch ( JsonException $exception ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( 'metrics could not be serialized for the model: %s', $exception->getMessage() ),
+				$exception,
+			);
+		}
+
+		$parts[] = [
+			'type' => 'text',
+			'text' => "Metrics:\n" . $metricsJson,
+		];
+
+		return $parts;
+	}
+
+	/**
+	 * Enforce output invariants.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ summary: string, highlights: array<int, string>, concerns: array<int, string> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		return [
+			'summary'    => isset( $output['summary'] ) ? trim( (string) $output['summary'] ) : '',
+			'highlights' => $this->stringList( $output['highlights'] ?? [] ),
+			'concerns'   => $this->stringList( $output['concerns'] ?? [] ),
+		];
+	}
+
+	/**
+	 * Filter a raw list into a clean array of non-empty strings.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $raw  Raw list from the model.
+	 *
+	 * @return array<int, string>
+	 */
+	protected function stringList( mixed $raw ): array
+	{
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+
+		$out = [];
+
+		foreach ( $raw as $value ) {
+			if ( is_string( $value ) && '' !== trim( $value ) ) {
+				$out[] = trim( $value );
+			}
+		}
+
+		return $out;
+	}
+}

--- a/src/Ai/Agents/SegmentInsightAgent.php
+++ b/src/Ai/Agents/SegmentInsightAgent.php
@@ -232,7 +232,7 @@ PROMPT;
 	 */
 	protected function validateOutput( array $output ): array
 	{
-		$rawPatterns = is_array( $output['patterns'] ?? null ) ? $output['patterns'] : [];
+		$rawPatterns = $this->coerceListField( $output['patterns'] ?? null, 'patterns' );
 		$patterns    = [];
 
 		foreach ( $rawPatterns as $entry ) {
@@ -262,5 +262,41 @@ PROMPT;
 		}
 
 		return [ 'patterns' => $patterns ];
+	}
+
+	/**
+	 * Coerce a top-level list field into an array.
+	 *
+	 * Some providers (e.g. Anthropic Opus under certain schema shapes)
+	 * return the whole nested payload as a JSON-encoded string instead of
+	 * a real array. Decode transparently so the downstream validator can
+	 * still iterate the entries.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed   $raw  Raw field from the model.
+	 * @param  string  $key  The field key to look up when the model re-nests under the same key.
+	 *
+	 * @return array<int|string, mixed>
+	 */
+	protected function coerceListField( mixed $raw, string $key ): array
+	{
+		if ( is_array( $raw ) ) {
+			return $raw;
+		}
+
+		if ( is_string( $raw ) && '' !== trim( $raw ) ) {
+			$decoded = json_decode( $raw, true );
+
+			if ( is_array( $decoded ) ) {
+				if ( isset( $decoded[ $key ] ) && is_array( $decoded[ $key ] ) ) {
+					return $decoded[ $key ];
+				}
+
+				return $decoded;
+			}
+		}
+
+		return [];
 	}
 }

--- a/src/Ai/Agents/SegmentInsightAgent.php
+++ b/src/Ai/Agents/SegmentInsightAgent.php
@@ -1,0 +1,266 @@
+<?php
+
+/**
+ * Segment insight agent.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Ai\Agents;
+
+use ArtisanPackUI\Ai\Agents\ArtisanPackAgent;
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use JsonException;
+
+/**
+ * Highlight patterns in a visitor segment vs. a baseline.
+ *
+ * ## Input
+ *
+ * ```
+ * [
+ *   'segment'  => [ 'type' => string, 'value' => string ], // required
+ *   'metrics'  => array<string, mixed>,                    // required, segment metrics
+ *   'baseline' => array<string, mixed>,                    // required, comparison metrics
+ * ]
+ * ```
+ *
+ * ## Output schema
+ *
+ * ```
+ * {
+ *   patterns: [
+ *     { observation: string, significance: 'low'|'medium'|'high', suggested_action: string }
+ *   ]
+ * }
+ * ```
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class SegmentInsightAgent extends ArtisanPackAgent
+{
+	/**
+	 * Supported significance bands.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var array<int, string>
+	 */
+	protected const SIGNIFICANCE_LEVELS = [ 'low', 'medium', 'high' ];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $featureKey = 'analytics.segment_insight';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $package = 'artisanpack-ui/analytics';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public string $defaultModel = 'claude-sonnet-4-6';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function instructions(): string
+	{
+		return <<<'PROMPT'
+You surface interesting patterns in a visitor segment relative to a baseline (typically "all visitors" or the previous period).
+
+Requirements:
+- Compare `metrics` (segment) against `baseline` field-by-field. Report only what differs meaningfully; do not narrate the whole payload.
+- Return 1-6 patterns. Each pattern must reference concrete numbers from the payloads (e.g. "bounce rate is 62% vs. 41% baseline") — no generic "traffic is higher".
+- `significance` is `high` for a large delta (≥50% relative or ≥20pp absolute), `medium` for meaningful but not dramatic differences, `low` for hints. It MUST be exactly one of: low, medium, high.
+- `suggested_action` is one short imperative sentence (e.g. "add a lead capture form to /pricing for mobile visitors"). Never emit vague guidance like "investigate further".
+- If the segment has too little data to compare (e.g. <20 sessions), return one low-significance pattern noting the low volume and suggesting to widen the window.
+
+Return a JSON object with key `patterns` (array of {observation, significance, suggested_action}).
+PROMPT;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function outputSchema(): array
+	{
+		return [
+			'type'                 => 'object',
+			'additionalProperties' => false,
+			'required'             => [ 'patterns' ],
+			'properties'           => [
+				'patterns' => [
+					'type'  => 'array',
+					'items' => [
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'required'             => [ 'observation', 'significance', 'suggested_action' ],
+						'properties'           => [
+							'observation'      => [ 'type' => 'string' ],
+							'significance'     => [ 'type' => 'string', 'enum' => self::SIGNIFICANCE_LEVELS ],
+							'suggested_action' => [ 'type' => 'string' ],
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected function execute( Credentials $credentials, string $model, string $instructions ): array
+	{
+		$normalized = $this->normalizeInput( $this->input() );
+
+		$prompter = app( AgentPrompter::class );
+
+		$result = $prompter->prompt(
+			credentials: $credentials,
+			model: $model,
+			instructions: $instructions,
+			message: $this->buildMessage( $normalized ),
+			outputSchema: $this->outputSchema(),
+		);
+
+		return [
+			'output'        => $this->validateOutput( $result['output'] ?? [] ),
+			'input_tokens'  => (int) ( $result['input_tokens'] ?? 0 ),
+			'output_tokens' => (int) ( $result['output_tokens'] ?? 0 ),
+		];
+	}
+
+	/**
+	 * Validate and shape-check the raw agent input.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  mixed  $input  Raw agent input.
+	 *
+	 * @return array{ segment: array{ type: string, value: string }, metrics: array<string, mixed>, baseline: array<string, mixed> }
+	 */
+	protected function normalizeInput( mixed $input ): array
+	{
+		if ( ! is_array( $input ) ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				'input must be an array with `segment`, `metrics`, and `baseline` keys.',
+			);
+		}
+
+		if ( ! isset( $input['segment'] ) || ! is_array( $input['segment'] ) ) {
+			throw FeatureError::forFeature( $this->featureKey, '`segment` must be an array with `type` and `value`.' );
+		}
+
+		$type  = isset( $input['segment']['type'] ) && is_string( $input['segment']['type'] ) ? trim( $input['segment']['type'] ) : '';
+		$value = isset( $input['segment']['value'] ) && is_string( $input['segment']['value'] ) ? trim( $input['segment']['value'] ) : '';
+
+		if ( '' === $type || '' === $value ) {
+			throw FeatureError::forFeature( $this->featureKey, '`segment.type` and `segment.value` must be non-empty strings.' );
+		}
+
+		if ( ! isset( $input['metrics'] ) || ! is_array( $input['metrics'] ) || [] === $input['metrics'] ) {
+			throw FeatureError::forFeature( $this->featureKey, '`metrics` must be a non-empty array.' );
+		}
+
+		if ( ! isset( $input['baseline'] ) || ! is_array( $input['baseline'] ) || [] === $input['baseline'] ) {
+			throw FeatureError::forFeature( $this->featureKey, '`baseline` must be a non-empty array.' );
+		}
+
+		return [
+			'segment'  => [ 'type' => $type, 'value' => $value ],
+			'metrics'  => $input['metrics'],
+			'baseline' => $input['baseline'],
+		];
+	}
+
+	/**
+	 * Assemble the structured message body for the prompter.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array{ segment: array{ type: string, value: string }, metrics: array<string, mixed>, baseline: array<string, mixed> }  $normalized  Normalized input.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	protected function buildMessage( array $normalized ): array
+	{
+		try {
+			$metricsJson  = json_encode( $normalized['metrics'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR );
+			$baselineJson = json_encode( $normalized['baseline'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR );
+		} catch ( JsonException $exception ) {
+			throw FeatureError::forFeature(
+				$this->featureKey,
+				sprintf( 'metrics/baseline could not be serialized: %s', $exception->getMessage() ),
+				$exception,
+			);
+		}
+
+		return [
+			[
+				'type' => 'text',
+				'text' => sprintf( 'Segment: %s = %s', $normalized['segment']['type'], $normalized['segment']['value'] ),
+			],
+			[ 'type' => 'text', 'text' => "Segment metrics:\n" . $metricsJson ],
+			[ 'type' => 'text', 'text' => "Baseline metrics:\n" . $baselineJson ],
+		];
+	}
+
+	/**
+	 * Enforce output invariants.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output  Decoded model output.
+	 *
+	 * @return array{ patterns: array<int, array{ observation: string, significance: string, suggested_action: string }> }
+	 */
+	protected function validateOutput( array $output ): array
+	{
+		$rawPatterns = is_array( $output['patterns'] ?? null ) ? $output['patterns'] : [];
+		$patterns    = [];
+
+		foreach ( $rawPatterns as $entry ) {
+			if ( ! is_array( $entry ) ) {
+				continue;
+			}
+
+			$observation  = isset( $entry['observation'] ) && is_string( $entry['observation'] ) ? trim( $entry['observation'] ) : '';
+			$action       = isset( $entry['suggested_action'] ) && is_string( $entry['suggested_action'] ) ? trim( $entry['suggested_action'] ) : '';
+			$significance = isset( $entry['significance'] ) && is_string( $entry['significance'] )
+				? strtolower( trim( $entry['significance'] ) )
+				: 'low';
+
+			if ( ! in_array( $significance, self::SIGNIFICANCE_LEVELS, true ) ) {
+				$significance = 'low';
+			}
+
+			if ( '' === $observation || '' === $action ) {
+				continue;
+			}
+
+			$patterns[] = [
+				'observation'      => $observation,
+				'significance'     => $significance,
+				'suggested_action' => $action,
+			];
+		}
+
+		return [ 'patterns' => $patterns ];
+	}
+}

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -4,6 +4,10 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Analytics;
 
+use ArtisanPackUI\Analytics\Ai\Agents\AnomalyExplanationAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\DigestEmailAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\InsightSummaryAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\SegmentInsightAgent;
 use ArtisanPackUI\Analytics\Auth\ApiKeyGuard;
 use ArtisanPackUI\Analytics\Console\Commands\BotsListCommand;
 use ArtisanPackUI\Analytics\Console\Commands\CacheClearCommand;
@@ -213,6 +217,50 @@ class AnalyticsServiceProvider extends ServiceProvider
         $this->registerPrivacyHooks();
         $this->registerAuthGuard();
         $this->registerInertiaSharedData();
+        $this->registerAiGate();
+        $this->registerAiLivewireComponents();
+    }
+
+    /**
+     * Declare AI features owned by this package.
+     *
+     * Auto-discovered by artisanpack-ui/ai when the ai package is installed.
+     * Each entry maps a fully-qualified feature key to the agent class that
+     * fulfills it, along with a human-readable label and description for the
+     * admin UI.
+     *
+     * @since 1.3.0
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    public function aiFeatures(): array
+    {
+        return [
+            'analytics.insight_summary' => [
+                'agent'       => InsightSummaryAgent::class,
+                'package'     => 'artisanpack-ui/analytics',
+                'label'       => __( 'Summarize insights' ),
+                'description' => __( 'Plain-language narrative summary of a date range with highlights and concerns.' ),
+            ],
+            'analytics.explain_anomaly' => [
+                'agent'       => AnomalyExplanationAgent::class,
+                'package'     => 'artisanpack-ui/analytics',
+                'label'       => __( 'Explain anomaly' ),
+                'description' => __( 'Rank likely causes of a detected traffic anomaly with evidence and next steps.' ),
+            ],
+            'analytics.segment_insight' => [
+                'agent'       => SegmentInsightAgent::class,
+                'package'     => 'artisanpack-ui/analytics',
+                'label'       => __( 'Segment insight' ),
+                'description' => __( 'Surface patterns in a visitor segment relative to a baseline.' ),
+            ],
+            'analytics.digest_email' => [
+                'agent'       => DigestEmailAgent::class,
+                'package'     => 'artisanpack-ui/analytics',
+                'label'       => __( 'Digest email' ),
+                'description' => __( 'Compose the AI narrative body of the opt-in weekly/monthly analytics digest.' ),
+            ],
+        ];
     }
 
     /**
@@ -242,6 +290,61 @@ class AnalyticsServiceProvider extends ServiceProvider
             SiteSettingsService::class,
             CrossTenantReporting::class,
         ];
+    }
+
+    /**
+     * Register the default `analytics.ai.use` authorization gate.
+     *
+     * The AI API endpoints gate on this ability so that paid quota isn't spent
+     * by every authenticated user. Ships with a permissive default (any
+     * authenticated user can use AI features) so upgrades are non-breaking;
+     * installers should override this gate to enforce a stricter policy.
+     *
+     * @since 1.3.0
+     *
+     * @return void
+     */
+    protected function registerAiGate(): void
+    {
+        $gate = \Illuminate\Support\Facades\Gate::getFacadeRoot();
+
+        if ( method_exists( $gate, 'has' ) && $gate->has( 'analytics.ai.use' ) ) {
+            return;
+        }
+
+        \Illuminate\Support\Facades\Gate::define(
+            'analytics.ai.use',
+            static function ( $user = null ): bool {
+                return null !== $user;
+            },
+        );
+    }
+
+    /**
+     * Register the AI Livewire components (since 1.3.0).
+     *
+     * The dashboard components are wired via `addNamespace` above, but each
+     * AI trigger is bound by its explicit alias so consumers get a stable
+     * `artisanpack-analytics::ai-*` handle even when the Livewire 3 code
+     * path is used.
+     *
+     * @since 1.3.0
+     *
+     * @return void
+     */
+    protected function registerAiLivewireComponents(): void
+    {
+        if ( ! class_exists( \Livewire\Livewire::class ) ) {
+            return;
+        }
+
+        // Use dot-notation for the sub-namespace segment so Livewire's finder
+        // can round-trip the alias back to the `Ai\*` class. Hyphens between
+        // words in the class name are fine — dots separate class segments.
+        \Livewire\Livewire::component( 'artisanpack-analytics::ai.insight-summary', Http\Livewire\Ai\InsightSummary::class );
+        \Livewire\Livewire::component( 'artisanpack-analytics::ai.anomaly-explanation', Http\Livewire\Ai\AnomalyExplanation::class );
+        \Livewire\Livewire::component( 'artisanpack-analytics::ai.segment-insight', Http\Livewire\Ai\SegmentInsight::class );
+        \Livewire\Livewire::component( 'artisanpack-analytics::ai.digest-subscription', Http\Livewire\Ai\DigestSubscription::class );
     }
 
     /**
@@ -364,6 +467,13 @@ class AnalyticsServiceProvider extends ServiceProvider
                 __DIR__ . '/../resources/js/react' => resource_path( 'js/vendor/artisanpack-analytics/react' ),
                 __DIR__ . '/../resources/js/types' => resource_path( 'js/vendor/artisanpack-analytics/types' ),
             ], 'analytics-react' );
+
+            // Focused publish tag for just the AI trigger components + hooks (since 1.3.0).
+            $this->publishes( [
+                __DIR__ . '/../resources/js/react/components/ai'       => resource_path( 'js/vendor/artisanpack-analytics/react/components/ai' ),
+                __DIR__ . '/../resources/js/react/hooks/useAiAgent.ts' => resource_path( 'js/vendor/artisanpack-analytics/react/hooks/useAiAgent.ts' ),
+                __DIR__ . '/../resources/js/react/hooks/useApi.ts'     => resource_path( 'js/vendor/artisanpack-analytics/react/hooks/useApi.ts' ),
+            ], 'analytics-react-ai' );
         }
     }
 
@@ -382,6 +492,13 @@ class AnalyticsServiceProvider extends ServiceProvider
                 __DIR__ . '/../resources/js/vue'   => resource_path( 'js/vendor/artisanpack-analytics/vue' ),
                 __DIR__ . '/../resources/js/types' => resource_path( 'js/vendor/artisanpack-analytics/types' ),
             ], 'analytics-vue' );
+
+            // Focused publish tag for just the AI trigger components + composables (since 1.3.0).
+            $this->publishes( [
+                __DIR__ . '/../resources/js/vue/components/ai'             => resource_path( 'js/vendor/artisanpack-analytics/vue/components/ai' ),
+                __DIR__ . '/../resources/js/vue/composables/useAiAgent.ts' => resource_path( 'js/vendor/artisanpack-analytics/vue/composables/useAiAgent.ts' ),
+                __DIR__ . '/../resources/js/vue/composables/useApi.ts'     => resource_path( 'js/vendor/artisanpack-analytics/vue/composables/useApi.ts' ),
+            ], 'analytics-vue-ai' );
         }
     }
 

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -12,6 +12,7 @@ use ArtisanPackUI\Analytics\Auth\ApiKeyGuard;
 use ArtisanPackUI\Analytics\Console\Commands\BotsListCommand;
 use ArtisanPackUI\Analytics\Console\Commands\CacheClearCommand;
 use ArtisanPackUI\Analytics\Console\Commands\CleanupCommand;
+use ArtisanPackUI\Analytics\Console\Commands\DispatchDigestsCommand;
 use ArtisanPackUI\Analytics\Console\Commands\GoalsListCommand;
 use ArtisanPackUI\Analytics\Console\Commands\InstallCommand;
 use ArtisanPackUI\Analytics\Console\Commands\InstallFrontendCommand;
@@ -613,6 +614,7 @@ class AnalyticsServiceProvider extends ServiceProvider
                 RealtimeCommand::class,
                 BotsListCommand::class,
                 WhitelistCommand::class,
+                DispatchDigestsCommand::class,
             ] );
         }
     }
@@ -629,18 +631,37 @@ class AnalyticsServiceProvider extends ServiceProvider
      */
     protected function registerScheduledJobs(): void
     {
-        if ( ! (bool) config( 'artisanpack.analytics.bot_detection.enabled', true ) ) {
-            return;
-        }
-
         $this->app->booted( function (): void {
             $schedule = $this->app->make( Schedule::class );
-            $interval = $this->botAnalysisIntervalMinutes();
 
-            $schedule->job( new AnalyzeBotTraffic() )
-                ->cron( sprintf( '*/%d * * * *', $interval ) )
-                ->name( 'analytics-analyze-bot-traffic' )
+            if ( (bool) config( 'artisanpack.analytics.bot_detection.enabled', true ) ) {
+                $interval = $this->botAnalysisIntervalMinutes();
+
+                $schedule->job( new AnalyzeBotTraffic() )
+                    ->cron( sprintf( '*/%d * * * *', $interval ) )
+                    ->name( 'analytics-analyze-bot-traffic' )
+                    ->withoutOverlapping();
+            }
+
+            // Digest email dispatcher: iterates opted-in preferences and
+            // enqueues SendDigestEmailJob for any user whose cadence window
+            // is due. Host apps override the schedule (or opt out entirely)
+            // via `artisanpack.analytics.digest.schedule`.
+            $digestSchedule = (string) config( 'artisanpack.analytics.digest.schedule', 'hourly' );
+
+            if ( 'off' === $digestSchedule ) {
+                return;
+            }
+
+            $entry = $schedule->command( 'analytics:dispatch-digests' )
+                ->name( 'analytics-dispatch-digests' )
                 ->withoutOverlapping();
+
+            if ( method_exists( $entry, $digestSchedule ) ) {
+                $entry->{$digestSchedule}();
+            } else {
+                $entry->cron( $digestSchedule );
+            }
         } );
     }
 

--- a/src/Console/Commands/DispatchDigestsCommand.php
+++ b/src/Console/Commands/DispatchDigestsCommand.php
@@ -1,0 +1,138 @@
+<?php
+
+/**
+ * DispatchDigestsCommand.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Console\Commands;
+
+use ArtisanPackUI\Analytics\Events\GatheringDigestItems;
+use ArtisanPackUI\Analytics\Jobs\SendDigestEmailJob;
+use ArtisanPackUI\Analytics\Models\AnalyticsDigestPreference;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Enqueue SendDigestEmailJob for every user whose cadence window is due.
+ *
+ * Item gathering is delegated to the {@see GatheringDigestItems} event so
+ * host apps decide what metrics to feed the AI. If no listener populates
+ * items for a user, that user is skipped with a warning.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class DispatchDigestsCommand extends Command
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	protected $signature = 'analytics:dispatch-digests
+		{--cadence= : Restrict to a single cadence (weekly|monthly)}';
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected $description = 'Enqueue SendDigestEmailJob for every user whose cadence window is due.';
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return int
+	 */
+	public function handle(): int
+	{
+		$restrictCadence = $this->option( 'cadence' );
+		$now             = CarbonImmutable::now();
+
+		$query = AnalyticsDigestPreference::query()
+			->whereIn( 'cadence', AnalyticsDigestPreference::ACTIVE_CADENCES );
+
+		if ( null !== $restrictCadence && in_array( $restrictCadence, AnalyticsDigestPreference::ACTIVE_CADENCES, true ) ) {
+			$query->where( 'cadence', $restrictCadence );
+		}
+
+		$dispatched = 0;
+		$skipped    = 0;
+
+		foreach ( $query->cursor() as $preference ) {
+			$windowStart = AnalyticsDigestPreference::CADENCE_MONTHLY === $preference->cadence
+				? $now->startOfMonth()
+				: $now->startOfWeek();
+
+			if ( null !== $preference->last_sent_at && CarbonImmutable::instance( $preference->last_sent_at )->greaterThanOrEqualTo( $windowStart ) ) {
+				continue;
+			}
+
+			$gathering = new GatheringDigestItems(
+				userId: (int) $preference->user_id,
+				cadence: (string) $preference->cadence,
+			);
+			Event::dispatch( $gathering );
+
+			if ( [] === $gathering->items ) {
+				Log::warning( sprintf(
+					'analytics:dispatch-digests skipped user %d — no listener populated GatheringDigestItems::$items.',
+					$preference->user_id,
+				) );
+				$skipped++;
+				continue;
+			}
+
+			$user = $preference->user()->first();
+
+			if ( null === $user || empty( $user->email ) ) {
+				Log::warning( sprintf( 'analytics:dispatch-digests skipped user %d — user or email missing.', $preference->user_id ) );
+				$skipped++;
+				continue;
+			}
+
+			SendDigestEmailJob::dispatch(
+				userId: (int) $preference->user_id,
+				email: (string) $user->email,
+				items: $gathering->items,
+				periodLabel: $this->periodLabel( $preference->cadence, $windowStart ),
+			);
+
+			$dispatched++;
+		}
+
+		$this->info( sprintf( 'Dispatched %d digest jobs, skipped %d.', $dispatched, $skipped ) );
+
+		return self::SUCCESS;
+	}
+
+	/**
+	 * Human-readable label for the window that is about to be sent.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string           $cadence      Preference cadence.
+	 * @param  CarbonImmutable  $windowStart  Start of the cadence window.
+	 *
+	 * @return string
+	 */
+	protected function periodLabel( string $cadence, CarbonImmutable $windowStart ): string
+	{
+		if ( AnalyticsDigestPreference::CADENCE_MONTHLY === $cadence ) {
+			return $windowStart->format( 'F Y' );
+		}
+
+		return sprintf( 'Week of %s', $windowStart->format( 'M j, Y' ) );
+	}
+}

--- a/src/Events/GatheringDigestItems.php
+++ b/src/Events/GatheringDigestItems.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * GatheringDigestItems event.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Events;
+
+/**
+ * Fired by `analytics:dispatch-digests` once per opted-in user before the
+ * digest job is enqueued. Host apps listen for this event and mutate
+ * `$items` to feed the AI agent with their metrics of choice.
+ *
+ * If no listener populates `$items`, the dispatcher logs a warning and
+ * skips that user — the paid AI agent is never run on empty input.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class GatheringDigestItems
+{
+	/**
+	 * Metrics / top pages / referrer deltas the AI agent will summarize.
+	 * Listeners assign into this array.
+	 *
+	 * @var array<int, mixed>
+	 */
+	public array $items = [];
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  int     $userId   Recipient user id.
+	 * @param  string  $cadence  `weekly` or `monthly`.
+	 */
+	public function __construct(
+		public readonly int $userId,
+		public readonly string $cadence,
+	) {
+	}
+}

--- a/src/Http/Controllers/Api/AiAgentApiController.php
+++ b/src/Http/Controllers/Api/AiAgentApiController.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * AiAgentApiController.
+ *
+ * Single dispatch endpoint for the Analytics package's AI agents. React/Vue
+ * frontends POST here with a feature key + input payload; the controller
+ * resolves the registered agent, runs it, and returns the structured output.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Controllers\Api;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Analytics\Ai\Agents\AnomalyExplanationAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\DigestEmailAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\InsightSummaryAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\SegmentInsightAgent;
+use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\AnomalyExplanationAiRequest;
+use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\DigestEmailAiRequest;
+use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\InsightSummaryAiRequest;
+use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\SegmentInsightAiRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Routing\Controller;
+use Throwable;
+
+/**
+ * Handles API requests for the Analytics package's AI agents.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class AiAgentApiController extends Controller
+{
+	/**
+	 * Feature-key → agent-class map for this package.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @var array<string, class-string>
+	 */
+	protected const AGENTS = [
+		'analytics.insight_summary'  => InsightSummaryAgent::class,
+		'analytics.explain_anomaly'  => AnomalyExplanationAgent::class,
+		'analytics.segment_insight'  => SegmentInsightAgent::class,
+		'analytics.digest_email'     => DigestEmailAgent::class,
+	];
+
+	/**
+	 * Summarize a date range.
+	 *
+	 * @since 1.3.0
+	 */
+	public function insightSummary( InsightSummaryAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'analytics.insight_summary', $request->validated() );
+	}
+
+	/**
+	 * Explain a detected anomaly.
+	 *
+	 * @since 1.3.0
+	 */
+	public function explainAnomaly( AnomalyExplanationAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'analytics.explain_anomaly', $request->validated() );
+	}
+
+	/**
+	 * Surface patterns in a visitor segment.
+	 *
+	 * @since 1.3.0
+	 */
+	public function segmentInsight( SegmentInsightAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'analytics.segment_insight', $request->validated() );
+	}
+
+	/**
+	 * Preview a digest-email body.
+	 *
+	 * @since 1.3.0
+	 */
+	public function digestEmail( DigestEmailAiRequest $request ): JsonResponse
+	{
+		return $this->dispatchAgent( 'analytics.digest_email', $request->validated() );
+	}
+
+	/**
+	 * Run the agent associated with `$featureKey`.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string                $featureKey  Fully-qualified feature key.
+	 * @param  array<string, mixed>  $input       Raw request payload.
+	 *
+	 * @return JsonResponse
+	 */
+	protected function dispatchAgent( string $featureKey, array $input ): JsonResponse
+	{
+		if ( ! isset( self::AGENTS[ $featureKey ] ) ) {
+			return response()->json( [ 'message' => __( 'Unknown AI feature.' ) ], 404 );
+		}
+
+		$registry = app( FeatureRegistry::class );
+
+		if ( null !== $registry->get( $featureKey ) && ! $registry->isToggleOn( $featureKey ) ) {
+			return response()->json( [
+				'message'     => __( 'This AI feature is disabled.' ),
+				'feature_key' => $featureKey,
+			], 409 );
+		}
+
+		$agentClass = self::AGENTS[ $featureKey ];
+
+		try {
+			$output = $agentClass::for( $input )->run();
+		} catch ( FeatureDisabledException $exception ) {
+			return response()->json( [
+				'message'     => $exception->getMessage(),
+				'feature_key' => $featureKey,
+			], 409 );
+		} catch ( MissingCredentialsException $exception ) {
+			return response()->json( [
+				'message'     => $exception->getMessage(),
+				'feature_key' => $featureKey,
+			], 412 );
+		} catch ( FeatureError $exception ) {
+			return response()->json( [
+				'message'     => $exception->getMessage(),
+				'feature_key' => $featureKey,
+			], 422 );
+		} catch ( Throwable $exception ) {
+			return response()->json( [
+				'message'     => __( 'AI agent failed to run.' ),
+				'feature_key' => $featureKey,
+			], 500 );
+		}
+
+		return response()->json( [
+			'data'        => $output,
+			'feature_key' => $featureKey,
+		] );
+	}
+}

--- a/src/Http/Controllers/Api/AiAgentApiController.php
+++ b/src/Http/Controllers/Api/AiAgentApiController.php
@@ -29,8 +29,10 @@ use ArtisanPackUI\Analytics\Ai\Agents\InsightSummaryAgent;
 use ArtisanPackUI\Analytics\Ai\Agents\SegmentInsightAgent;
 use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\AnomalyExplanationAiRequest;
 use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\DigestEmailAiRequest;
+use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\DigestSubscriptionAiRequest;
 use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\InsightSummaryAiRequest;
 use ArtisanPackUI\Analytics\Http\Requests\Api\Ai\SegmentInsightAiRequest;
+use ArtisanPackUI\Analytics\Models\AnalyticsDigestPreference;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Routing\Controller;
 use Throwable;
@@ -100,6 +102,32 @@ class AiAgentApiController extends Controller
 	}
 
 	/**
+	 * Persist the current user's digest-email opt-in preference.
+	 *
+	 * @since 1.3.0
+	 */
+	public function saveDigestSubscription( DigestSubscriptionAiRequest $request ): JsonResponse
+	{
+		$user = $request->user();
+
+		if ( null === $user ) {
+			return response()->json( [ 'message' => __( 'Unauthenticated.' ) ], 401 );
+		}
+
+		$preference = AnalyticsDigestPreference::query()->updateOrCreate(
+			[ 'user_id' => $user->getAuthIdentifier() ],
+			[ 'cadence' => $request->string( 'cadence' )->toString() ],
+		);
+
+		return response()->json( [
+			'data' => [
+				'cadence'      => $preference->cadence,
+				'last_sent_at' => $preference->last_sent_at?->toIso8601String(),
+			],
+		] );
+	}
+
+	/**
 	 * Run the agent associated with `$featureKey`.
 	 *
 	 * @since 1.3.0
@@ -117,7 +145,9 @@ class AiAgentApiController extends Controller
 
 		$registry = app( FeatureRegistry::class );
 
-		if ( null !== $registry->get( $featureKey ) && ! $registry->isToggleOn( $featureKey ) ) {
+		// Fail closed: `isToggleOn()` already returns false when the feature
+		// key is not registered, so a missing key must not bypass the guard.
+		if ( ! $registry->isToggleOn( $featureKey ) ) {
 			return response()->json( [
 				'message'     => __( 'This AI feature is disabled.' ),
 				'feature_key' => $featureKey,

--- a/src/Http/Livewire/Ai/AnomalyExplanation.php
+++ b/src/Http/Livewire/Ai/AnomalyExplanation.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * AnomalyExplanation Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Analytics\Ai\Agents\AnomalyExplanationAgent;
+use Illuminate\View\View;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see AnomalyExplanationAgent}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class AnomalyExplanation extends Component
+{
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $anomaly = [];
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $context = [];
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	/**
+	 * @var array<int, array{ cause: string, confidence: string, evidence: array<int, string> }>
+	 */
+	public array $hypotheses = [];
+
+	/**
+	 * @var array<int, string>
+	 */
+	public array $recommendedNextSteps = [];
+
+	/**
+	 * Mount the component.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $anomaly  Anomaly payload.
+	 * @param  array<string, mixed>  $context  Contextual signals.
+	 */
+	public function mount( array $anomaly = [], array $context = [] ): void
+	{
+		$this->anomaly = $anomaly;
+		$this->context = $context;
+	}
+
+	/**
+	 * Run the agent.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function explain(): void
+	{
+		$this->error                = null;
+		$this->hypotheses           = [];
+		$this->recommendedNextSteps = [];
+		$this->isLoading            = true;
+
+		try {
+			$output = AnomalyExplanationAgent::for( [
+				'anomaly' => $this->anomaly,
+				'context' => $this->context,
+			] )->run();
+
+			$this->hypotheses           = is_array( $output['hypotheses'] ?? null ) ? $output['hypotheses'] : [];
+			$this->recommendedNextSteps = is_array( $output['recommended_next_steps'] ?? null ) ? $output['recommended_next_steps'] : [];
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Determine whether this feature is enabled.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'analytics.explain_anomaly';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the view.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'artisanpack-analytics::livewire.ai.anomaly-explanation' );
+	}
+}

--- a/src/Http/Livewire/Ai/DigestSubscription.php
+++ b/src/Http/Livewire/Ai/DigestSubscription.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * DigestSubscription Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Analytics\Models\AnalyticsDigestPreference;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\View\View;
+use Livewire\Component;
+
+/**
+ * Per-user opt-in UI for the AI analytics digest email.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class DigestSubscription extends Component
+{
+	public string $cadence = AnalyticsDigestPreference::CADENCE_OFF;
+
+	public ?string $status = null;
+
+	/**
+	 * Mount the component with the current user's preference.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function mount(): void
+	{
+		$user = Auth::user();
+
+		if ( null === $user ) {
+			return;
+		}
+
+		$preference = AnalyticsDigestPreference::query()->where( 'user_id', $user->getAuthIdentifier() )->first();
+
+		if ( null !== $preference ) {
+			$this->cadence = $preference->cadence;
+		}
+	}
+
+	/**
+	 * Persist the selected cadence.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function save(): void
+	{
+		$this->status = null;
+
+		$user = Auth::user();
+
+		if ( null === $user ) {
+			$this->status = __( 'You must be signed in to change your digest preference.' );
+			return;
+		}
+
+		$allowed = [
+			AnalyticsDigestPreference::CADENCE_OFF,
+			AnalyticsDigestPreference::CADENCE_WEEKLY,
+			AnalyticsDigestPreference::CADENCE_MONTHLY,
+		];
+
+		if ( ! in_array( $this->cadence, $allowed, true ) ) {
+			$this->cadence = AnalyticsDigestPreference::CADENCE_OFF;
+		}
+
+		AnalyticsDigestPreference::query()->updateOrCreate(
+			[ 'user_id' => $user->getAuthIdentifier() ],
+			[ 'cadence' => $this->cadence ],
+		);
+
+		$this->status = AnalyticsDigestPreference::CADENCE_OFF === $this->cadence
+			? __( 'Digest emails turned off.' )
+			: __( 'Digest preference saved.' );
+	}
+
+	/**
+	 * Determine whether this feature is enabled.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'analytics.digest_email';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the view.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'artisanpack-analytics::livewire.ai.digest-subscription' );
+	}
+}

--- a/src/Http/Livewire/Ai/InsightSummary.php
+++ b/src/Http/Livewire/Ai/InsightSummary.php
@@ -1,0 +1,164 @@
+<?php
+
+/**
+ * InsightSummary Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Analytics\Ai\Agents\InsightSummaryAgent;
+use Illuminate\View\View;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see InsightSummaryAgent}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class InsightSummary extends Component
+{
+	public string $dateFrom = '';
+
+	public string $dateTo = '';
+
+	public ?string $compareFrom = null;
+
+	public ?string $compareTo = null;
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $metrics = [];
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	public ?string $summary = null;
+
+	/**
+	 * @var array<int, string>
+	 */
+	public array $highlights = [];
+
+	/**
+	 * @var array<int, string>
+	 */
+	public array $concerns = [];
+
+	/**
+	 * Mount the component.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string                $dateFrom     Range start (YYYY-MM-DD).
+	 * @param  string                $dateTo       Range end (YYYY-MM-DD).
+	 * @param  array<string, mixed>  $metrics      Metric payload.
+	 * @param  string|null           $compareFrom  Optional comparison start.
+	 * @param  string|null           $compareTo    Optional comparison end.
+	 */
+	public function mount(
+		string $dateFrom = '',
+		string $dateTo = '',
+		array $metrics = [],
+		?string $compareFrom = null,
+		?string $compareTo = null,
+	): void {
+		$this->dateFrom    = $dateFrom;
+		$this->dateTo      = $dateTo;
+		$this->metrics     = $metrics;
+		$this->compareFrom = $compareFrom;
+		$this->compareTo   = $compareTo;
+	}
+
+	/**
+	 * Run the agent and populate the summary.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function summarize(): void
+	{
+		$this->error      = null;
+		$this->summary    = null;
+		$this->highlights = [];
+		$this->concerns   = [];
+		$this->isLoading  = true;
+
+		try {
+			$input = [
+				'date_range' => [ 'from' => $this->dateFrom, 'to' => $this->dateTo ],
+				'metrics'    => $this->metrics,
+			];
+
+			if ( null !== $this->compareFrom && null !== $this->compareTo ) {
+				$input['compare_to'] = [ 'from' => $this->compareFrom, 'to' => $this->compareTo ];
+			}
+
+			$output = InsightSummaryAgent::for( $input )->run();
+
+			$this->summary    = isset( $output['summary'] ) ? (string) $output['summary'] : '';
+			$this->highlights = is_array( $output['highlights'] ?? null ) ? $output['highlights'] : [];
+			$this->concerns   = is_array( $output['concerns'] ?? null ) ? $output['concerns'] : [];
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Determine whether this feature is enabled.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'analytics.insight_summary';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the view.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'artisanpack-analytics::livewire.ai.insight-summary' );
+	}
+}

--- a/src/Http/Livewire/Ai/SegmentInsight.php
+++ b/src/Http/Livewire/Ai/SegmentInsight.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * SegmentInsight Livewire component.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Livewire\Ai;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Analytics\Ai\Agents\SegmentInsightAgent;
+use Illuminate\View\View;
+use Livewire\Component;
+use Throwable;
+
+/**
+ * Trigger UI for the {@see SegmentInsightAgent}.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class SegmentInsight extends Component
+{
+	public string $segmentType = '';
+
+	public string $segmentValue = '';
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $metrics = [];
+
+	/**
+	 * @var array<string, mixed>
+	 */
+	public array $baseline = [];
+
+	public bool $isLoading = false;
+
+	public ?string $error = null;
+
+	/**
+	 * @var array<int, array{ observation: string, significance: string, suggested_action: string }>
+	 */
+	public array $patterns = [];
+
+	/**
+	 * Mount the component.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string                $segmentType   Segment dimension (e.g. "device", "country").
+	 * @param  string                $segmentValue  Segment value (e.g. "mobile", "US").
+	 * @param  array<string, mixed>  $metrics       Segment metrics.
+	 * @param  array<string, mixed>  $baseline      Baseline metrics.
+	 */
+	public function mount(
+		string $segmentType = '',
+		string $segmentValue = '',
+		array $metrics = [],
+		array $baseline = [],
+	): void {
+		$this->segmentType  = $segmentType;
+		$this->segmentValue = $segmentValue;
+		$this->metrics      = $metrics;
+		$this->baseline     = $baseline;
+	}
+
+	/**
+	 * Run the agent.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function analyze(): void
+	{
+		$this->error     = null;
+		$this->patterns  = [];
+		$this->isLoading = true;
+
+		try {
+			$output = SegmentInsightAgent::for( [
+				'segment'  => [ 'type' => $this->segmentType, 'value' => $this->segmentValue ],
+				'metrics'  => $this->metrics,
+				'baseline' => $this->baseline,
+			] )->run();
+
+			$this->patterns = is_array( $output['patterns'] ?? null ) ? $output['patterns'] : [];
+		} catch ( FeatureDisabledException $exception ) {
+			$this->error = __( 'This AI feature is disabled.' );
+		} catch ( MissingCredentialsException $exception ) {
+			$this->error = __( 'AI credentials are not configured.' );
+		} catch ( FeatureError $exception ) {
+			$this->error = $exception->getMessage();
+		} catch ( Throwable $exception ) {
+			$this->error = __( 'The AI agent could not complete this request.' );
+		} finally {
+			$this->isLoading = false;
+		}
+	}
+
+	/**
+	 * Determine whether this feature is enabled.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return bool
+	 */
+	public function getIsEnabledProperty(): bool
+	{
+		$registry = app( FeatureRegistry::class );
+		$key      = 'analytics.segment_insight';
+
+		if ( null === $registry->get( $key ) ) {
+			return false;
+		}
+
+		return $registry->isToggleOn( $key );
+	}
+
+	/**
+	 * Render the view.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return View
+	 */
+	public function render(): View
+	{
+		return view( 'artisanpack-analytics::livewire.ai.segment-insight' );
+	}
+}

--- a/src/Http/Requests/Api/Ai/AnomalyExplanationAiRequest.php
+++ b/src/Http/Requests/Api/Ai/AnomalyExplanationAiRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * AnomalyExplanationAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the anomaly-explanation AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class AnomalyExplanationAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'analytics.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'anomaly'           => [ 'required', 'array' ],
+			'anomaly.metric'    => [ 'required', 'string', 'max:100' ],
+			'anomaly.direction' => [ 'required', 'string', 'in:up,down' ],
+			'anomaly.magnitude' => [ 'required', 'numeric' ],
+			'anomaly.date'      => [ 'required', 'string', 'date_format:Y-m-d' ],
+			'context'           => [ 'nullable', 'array' ],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/DigestEmailAiRequest.php
+++ b/src/Http/Requests/Api/Ai/DigestEmailAiRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * DigestEmailAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the digest-email preview AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class DigestEmailAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'analytics.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'items'  => [ 'required', 'array', 'min:1' ],
+			'focus'  => [ 'nullable', 'string', 'max:200' ],
+			'length' => [ 'nullable', 'string', 'in:brief,detailed' ],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/DigestSubscriptionAiRequest.php
+++ b/src/Http/Requests/Api/Ai/DigestSubscriptionAiRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+/**
+ * DigestSubscriptionAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Requests\Api\Ai;
+
+use ArtisanPackUI\Analytics\Models\AnalyticsDigestPreference;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to persist the digest-email opt-in preference.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class DigestSubscriptionAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'analytics.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'cadence' => [
+				'required',
+				'string',
+				'in:' . implode( ',', [
+					AnalyticsDigestPreference::CADENCE_OFF,
+					AnalyticsDigestPreference::CADENCE_WEEKLY,
+					AnalyticsDigestPreference::CADENCE_MONTHLY,
+				] ),
+			],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/InsightSummaryAiRequest.php
+++ b/src/Http/Requests/Api/Ai/InsightSummaryAiRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * InsightSummaryAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the insight-summary AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class InsightSummaryAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'analytics.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'date_range'      => [ 'required', 'array' ],
+			'date_range.from' => [ 'required', 'string', 'date_format:Y-m-d' ],
+			'date_range.to'   => [ 'required', 'string', 'date_format:Y-m-d' ],
+			'metrics'         => [ 'required', 'array', 'min:1' ],
+			'compare_to'      => [ 'nullable', 'array' ],
+			'compare_to.from' => [ 'required_with:compare_to', 'string', 'date_format:Y-m-d' ],
+			'compare_to.to'   => [ 'required_with:compare_to', 'string', 'date_format:Y-m-d' ],
+		];
+	}
+}

--- a/src/Http/Requests/Api/Ai/SegmentInsightAiRequest.php
+++ b/src/Http/Requests/Api/Ai/SegmentInsightAiRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * SegmentInsightAiRequest.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Http\Requests\Api\Ai;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Validates requests to the segment-insight AI endpoint.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class SegmentInsightAiRequest extends FormRequest
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	public function authorize(): bool
+	{
+		return Gate::allows( 'analytics.ai.use' );
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public function rules(): array
+	{
+		return [
+			'segment'       => [ 'required', 'array' ],
+			'segment.type'  => [ 'required', 'string', 'max:100' ],
+			'segment.value' => [ 'required', 'string', 'max:200' ],
+			'metrics'       => [ 'required', 'array', 'min:1' ],
+			'baseline'      => [ 'required', 'array', 'min:1' ],
+		];
+	}
+}

--- a/src/Jobs/SendDigestEmailJob.php
+++ b/src/Jobs/SendDigestEmailJob.php
@@ -17,6 +17,7 @@ namespace ArtisanPackUI\Analytics\Jobs;
 
 use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
 use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
 use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
 use ArtisanPackUI\Analytics\Ai\Agents\DigestEmailAgent;
 use ArtisanPackUI\Analytics\Mail\DigestEmailMailable;
@@ -82,7 +83,18 @@ class SendDigestEmailJob implements ShouldQueue
 		$registry = app( FeatureRegistry::class );
 		$key      = 'analytics.digest_email';
 
-		if ( null !== $registry->get( $key ) && ! $registry->isToggleOn( $key ) ) {
+		// Fail closed: `isToggleOn()` already returns false when the feature
+		// key is not registered, so a missing key must not bypass the guard.
+		if ( ! $registry->isToggleOn( $key ) ) {
+			return;
+		}
+
+		// Idempotency: skip if a digest for this cadence window has already
+		// been sent, so retries + duplicate scheduler ticks can't re-run the
+		// paid agent or re-deliver the mail.
+		$windowStart = $this->windowStart( $preference->cadence );
+
+		if ( null !== $preference->last_sent_at && CarbonImmutable::instance( $preference->last_sent_at )->greaterThanOrEqualTo( $windowStart ) ) {
 			return;
 		}
 
@@ -95,6 +107,13 @@ class SendDigestEmailJob implements ShouldQueue
 		} catch ( FeatureDisabledException | MissingCredentialsException $exception ) {
 			Log::info( sprintf( 'Analytics digest email skipped for user %d: %s', $this->userId, $exception->getMessage() ) );
 			return;
+		} catch ( FeatureError $exception ) {
+			// Malformed payload — do not retry, and advance last_sent_at
+			// past the current window so the next scheduled tick does not
+			// re-enqueue the same bad payload.
+			Log::warning( sprintf( 'Analytics digest email failed for user %d: %s', $this->userId, $exception->getMessage() ) );
+			$preference->forceFill( [ 'last_sent_at' => CarbonImmutable::now() ] )->save();
+			return;
 		}
 
 		Mail::to( $this->email )->send( new DigestEmailMailable(
@@ -104,5 +123,24 @@ class SendDigestEmailJob implements ShouldQueue
 		) );
 
 		$preference->forceFill( [ 'last_sent_at' => CarbonImmutable::now() ] )->save();
+	}
+
+	/**
+	 * Start of the current cadence window (Monday 00:00 for weekly, day-1
+	 * of the month for monthly). Used for idempotency comparisons only.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string  $cadence  Preference cadence.
+	 *
+	 * @return CarbonImmutable
+	 */
+	protected function windowStart( string $cadence ): CarbonImmutable
+	{
+		$now = CarbonImmutable::now();
+
+		return AnalyticsDigestPreference::CADENCE_MONTHLY === $cadence
+			? $now->startOfMonth()
+			: $now->startOfWeek();
 	}
 }

--- a/src/Jobs/SendDigestEmailJob.php
+++ b/src/Jobs/SendDigestEmailJob.php
@@ -1,0 +1,108 @@
+<?php
+
+/**
+ * SendDigestEmailJob.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Jobs;
+
+use ArtisanPackUI\Ai\Contracts\FeatureRegistry;
+use ArtisanPackUI\Ai\Exceptions\FeatureDisabledException;
+use ArtisanPackUI\Ai\Exceptions\MissingCredentialsException;
+use ArtisanPackUI\Analytics\Ai\Agents\DigestEmailAgent;
+use ArtisanPackUI\Analytics\Mail\DigestEmailMailable;
+use ArtisanPackUI\Analytics\Models\AnalyticsDigestPreference;
+use Carbon\CarbonImmutable;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * Generate + send the AI digest email for one user, honoring their opt-in.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class SendDigestEmailJob implements ShouldQueue
+{
+	use Dispatchable;
+	use InteractsWithQueue;
+	use Queueable;
+	use SerializesModels;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  int                           $userId      User to send to.
+	 * @param  string                        $email       Destination address.
+	 * @param  array<int, mixed>             $items       Digest items to summarize (metrics, top pages, etc.).
+	 * @param  string                        $periodLabel Human-readable label for the window.
+	 */
+	public function __construct(
+		public readonly int $userId,
+		public readonly string $email,
+		public readonly array $items,
+		public readonly string $periodLabel,
+	) {
+	}
+
+	/**
+	 * Handle the job.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return void
+	 */
+	public function handle(): void
+	{
+		/** @var AnalyticsDigestPreference|null $preference */
+		$preference = AnalyticsDigestPreference::query()->where( 'user_id', $this->userId )->first();
+
+		if ( null === $preference || ! $preference->isOptedIn() ) {
+			return;
+		}
+
+		$registry = app( FeatureRegistry::class );
+		$key      = 'analytics.digest_email';
+
+		if ( null !== $registry->get( $key ) && ! $registry->isToggleOn( $key ) ) {
+			return;
+		}
+
+		try {
+			$output = DigestEmailAgent::for( [
+				'items'  => $this->items,
+				'focus'  => 'weekly' === $preference->cadence ? 'week-over-week change' : 'month-over-month change',
+				'length' => 'detailed',
+			] )->run();
+		} catch ( FeatureDisabledException | MissingCredentialsException $exception ) {
+			Log::info( sprintf( 'Analytics digest email skipped for user %d: %s', $this->userId, $exception->getMessage() ) );
+			return;
+		}
+
+		Mail::to( $this->email )->send( new DigestEmailMailable(
+			cadence: $preference->cadence,
+			periodLabel: $this->periodLabel,
+			digest: $output,
+		) );
+
+		$preference->forceFill( [ 'last_sent_at' => CarbonImmutable::now() ] )->save();
+	}
+}

--- a/src/Mail/DigestEmailMailable.php
+++ b/src/Mail/DigestEmailMailable.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * DigestEmailMailable.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Mail;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Renders the AI-generated analytics digest as an HTML email.
+ *
+ * The payload has already been produced by {@see \ArtisanPackUI\Analytics\Ai\Agents\DigestEmailAgent}
+ * — this mailable just renders the shape into the digest email view.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class DigestEmailMailable extends Mailable implements ShouldQueue
+{
+	use Queueable;
+	use SerializesModels;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  string                $cadence   `weekly` or `monthly`.
+	 * @param  string                $periodLabel   Human-readable window label (e.g. "May 1 - May 7, 2026").
+	 * @param  array<string, mixed>  $digest    Structured digest from {@see DigestEmailAgent} — summary/key_points/caveats.
+	 */
+	public function __construct(
+		public readonly string $cadence,
+		public readonly string $periodLabel,
+		public readonly array $digest,
+	) {
+	}
+
+	/**
+	 * Build the message envelope.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return Envelope
+	 */
+	public function envelope(): Envelope
+	{
+		$subject = 'monthly' === $this->cadence
+			? __( 'Your monthly analytics digest — :period', [ 'period' => $this->periodLabel ] )
+			: __( 'Your weekly analytics digest — :period', [ 'period' => $this->periodLabel ] );
+
+		return new Envelope(
+			subject: $subject,
+		);
+	}
+
+	/**
+	 * Build the message content.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return Content
+	 */
+	public function content(): Content
+	{
+		return new Content(
+			view: 'artisanpack-analytics::emails.digest',
+			with: [
+				'cadence'     => $this->cadence,
+				'periodLabel' => $this->periodLabel,
+				'summary'     => (string) ( $this->digest['summary'] ?? '' ),
+				'keyPoints'   => is_array( $this->digest['key_points'] ?? null ) ? $this->digest['key_points'] : [],
+				'caveats'     => is_array( $this->digest['caveats'] ?? null ) ? $this->digest['caveats'] : [],
+			],
+		);
+	}
+}

--- a/src/Models/AnalyticsDigestPreference.php
+++ b/src/Models/AnalyticsDigestPreference.php
@@ -16,6 +16,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Analytics\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * Per-user opt-in preference for the AI analytics digest email.
@@ -76,6 +77,24 @@ class AnalyticsDigestPreference extends Model
 	public function isOptedIn(): bool
 	{
 		return in_array( $this->cadence, self::ACTIVE_CADENCES, true );
+	}
+
+	/**
+	 * Related user record.
+	 *
+	 * Resolves the application's configured `auth.providers.users.model`
+	 * so this package doesn't hard-code an `App\Models\User` reference.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return BelongsTo<Model, self>
+	 */
+	public function user(): BelongsTo
+	{
+		/** @var class-string<Model> $userModel */
+		$userModel = config( 'auth.providers.users.model', 'App\\Models\\User' );
+
+		return $this->belongsTo( $userModel, 'user_id' );
 	}
 
 	/**

--- a/src/Models/AnalyticsDigestPreference.php
+++ b/src/Models/AnalyticsDigestPreference.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * AnalyticsDigestPreference model.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @author     Jacob Martella <me@jacobmartella.com>
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Per-user opt-in preference for the AI analytics digest email.
+ *
+ * @property int         $id
+ * @property int         $user_id
+ * @property string      $cadence
+ * @property string|null $last_sent_at
+ * @property string|null $created_at
+ * @property string|null $updated_at
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class AnalyticsDigestPreference extends Model
+{
+	public const CADENCE_OFF     = 'off';
+
+	public const CADENCE_WEEKLY  = 'weekly';
+
+	public const CADENCE_MONTHLY = 'monthly';
+
+	/**
+	 * Cadence values that should trigger a scheduled send.
+	 *
+	 * @var array<int, string>
+	 */
+	public const ACTIVE_CADENCES = [
+		self::CADENCE_WEEKLY,
+		self::CADENCE_MONTHLY,
+	];
+
+	/**
+	 * {@inheritDoc}
+	 */
+	protected $table = 'analytics_digest_preferences';
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @var array<int, string>
+	 */
+	protected $fillable = [
+		'user_id',
+		'cadence',
+		'last_sent_at',
+	];
+
+	/**
+	 * Whether this preference is opted in to receive digests.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @return bool
+	 */
+	public function isOptedIn(): bool
+	{
+		return in_array( $this->cadence, self::ACTIVE_CADENCES, true );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 *
+	 * @return array<string, string>
+	 */
+	protected function casts(): array
+	{
+		return [
+			'user_id'      => 'integer',
+			'last_sent_at' => 'datetime',
+		];
+	}
+}

--- a/tests/Feature/Ai/AiAgentTestSetup.php
+++ b/tests/Feature/Ai/AiAgentTestSetup.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * Shared setup helpers for Analytics AI agent tests.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Feature\Ai;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Contracts\CredentialResolver;
+use ArtisanPackUI\Ai\Credentials\ChainedCredentialResolver;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+use Tests\Support\FakeAgentPrompter;
+
+/**
+ * Registers a fake prompter and stub credentials for the 4 Analytics features.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+class AiAgentTestSetup
+{
+	/**
+	 * Prepare the container so agents can run against a fake prompter.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  \Illuminate\Foundation\Application  $app  Application instance.
+	 *
+	 * @return FakeAgentPrompter The bound fake prompter.
+	 */
+	public static function bootstrap( $app ): FakeAgentPrompter
+	{
+		/** @var ChainedCredentialResolver $resolver */
+		$resolver = $app->make( CredentialResolver::class );
+		$resolver->setOverride(
+			new Credentials( provider: 'anthropic', apiKey: 'sk-test', defaultModel: 'claude-haiku-4-5' ),
+		);
+		$resolver->useStore( fn () => null );
+
+		$prompter = new FakeAgentPrompter();
+		$app->instance( AgentPrompter::class, $prompter );
+
+		foreach (
+			[
+				'analytics.insight_summary',
+				'analytics.explain_anomaly',
+				'analytics.segment_insight',
+				'analytics.digest_email',
+			] as $key
+		) {
+			$app['config']->set( "artisanpack.ai.features.{$key}.enabled", true );
+		}
+
+		return $prompter;
+	}
+}

--- a/tests/Feature/AiFeaturesRegistrationTest.php
+++ b/tests/Feature/AiFeaturesRegistrationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Ai\Agents\AnomalyExplanationAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\DigestEmailAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\InsightSummaryAgent;
+use ArtisanPackUI\Analytics\Ai\Agents\SegmentInsightAgent;
+use ArtisanPackUI\Analytics\AnalyticsServiceProvider;
+
+it( 'exposes the four analytics AI features via aiFeatures()', function (): void {
+	$provider = new AnalyticsServiceProvider( $this->app );
+	$features = $provider->aiFeatures();
+
+	expect( $features )->toHaveKeys( [
+		'analytics.insight_summary',
+		'analytics.explain_anomaly',
+		'analytics.segment_insight',
+		'analytics.digest_email',
+	] );
+
+	expect( $features['analytics.insight_summary']['agent'] )->toBe( InsightSummaryAgent::class );
+	expect( $features['analytics.explain_anomaly']['agent'] )->toBe( AnomalyExplanationAgent::class );
+	expect( $features['analytics.segment_insight']['agent'] )->toBe( SegmentInsightAgent::class );
+	expect( $features['analytics.digest_email']['agent'] )->toBe( DigestEmailAgent::class );
+} );
+
+it( 'associates every feature with the analytics package', function (): void {
+	$provider = new AnalyticsServiceProvider( $this->app );
+
+	foreach ( $provider->aiFeatures() as $key => $config ) {
+		expect( $config['package'] )->toBe( 'artisanpack-ui/analytics' );
+		expect( $config )->toHaveKey( 'label' );
+		expect( $config )->toHaveKey( 'description' );
+	}
+} );

--- a/tests/Feature/Jobs/SendDigestEmailJobTest.php
+++ b/tests/Feature/Jobs/SendDigestEmailJobTest.php
@@ -75,3 +75,43 @@ it( 'does not send when the feature toggle is off', function (): void {
 
 	Mail::assertNothingOutgoing();
 } );
+
+it( 'skips when last_sent_at is already inside the current cadence window', function (): void {
+	// Preference sent 10 minutes ago should not re-send this week.
+	$preference = AnalyticsDigestPreference::create( [
+		'user_id'      => 8,
+		'cadence'      => 'weekly',
+		'last_sent_at' => now()->subMinutes( 10 ),
+	] );
+
+	Mail::fake();
+
+	( new SendDigestEmailJob( 8, 'user@example.test', [ [ 'metric' => 'pv', 'value' => 10 ] ], 'This week' ) )->handle();
+
+	Mail::assertNothingOutgoing();
+	// Preference untouched — the queued FakeAgentPrompter response is unused.
+	expect( $preference->fresh()->last_sent_at )->not->toBeNull();
+} );
+
+it( 'fails closed when the feature key is not registered', function (): void {
+	AnalyticsDigestPreference::create( [ 'user_id' => 10, 'cadence' => 'weekly' ] );
+
+	// Remove the feature from the registry entirely (simulating a fresh
+	// install where auto-discovery hasn't run yet). The guard must not
+	// bypass the toggle check just because the key is missing.
+	$registry = app( ArtisanPackUI\Ai\Contracts\FeatureRegistry::class );
+
+	// If the registry doesn't expose remove(), disable() has the same
+	// externally-observable effect via `isToggleOn() === false`.
+	if ( method_exists( $registry, 'reset' ) ) {
+		$registry->reset();
+	} else {
+		$registry->disable( 'analytics.digest_email' );
+	}
+
+	Mail::fake();
+
+	( new SendDigestEmailJob( 10, 'user@example.test', [ [ 'metric' => 'pv', 'value' => 10 ] ], 'This week' ) )->handle();
+
+	Mail::assertNothingOutgoing();
+} );

--- a/tests/Feature/Jobs/SendDigestEmailJobTest.php
+++ b/tests/Feature/Jobs/SendDigestEmailJobTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Jobs\SendDigestEmailJob;
+use ArtisanPackUI\Analytics\Mail\DigestEmailMailable;
+use ArtisanPackUI\Analytics\Models\AnalyticsDigestPreference;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Schema;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+
+	if ( ! Schema::hasTable( 'analytics_digest_preferences' ) ) {
+		Schema::create( 'analytics_digest_preferences', function ( $table ): void {
+			$table->id();
+			$table->unsignedBigInteger( 'user_id' );
+			$table->string( 'cadence', 16 )->default( 'off' );
+			$table->timestamp( 'last_sent_at' )->nullable();
+			$table->timestamps();
+			$table->unique( 'user_id' );
+		} );
+	}
+} );
+
+it( 'skips users whose preference is off', function (): void {
+	AnalyticsDigestPreference::create( [ 'user_id' => 1, 'cadence' => 'off' ] );
+
+	Mail::fake();
+
+	( new SendDigestEmailJob( 1, 'user@example.test', [ [ 'metric' => 'pv', 'value' => 10 ] ], 'May 1 - May 7' ) )->handle();
+
+	Mail::assertNothingOutgoing();
+} );
+
+it( 'skips users with no preference row', function (): void {
+	Mail::fake();
+
+	( new SendDigestEmailJob( 999, 'ghost@example.test', [ [ 'metric' => 'pv', 'value' => 10 ] ], 'May 1 - May 7' ) )->handle();
+
+	Mail::assertNothingOutgoing();
+} );
+
+it( 'sends a mailable and marks last_sent_at when opted in', function (): void {
+	$preference = AnalyticsDigestPreference::create( [ 'user_id' => 5, 'cadence' => 'weekly' ] );
+
+	$this->prompter->queue( [
+		'summary'    => 'Your site was up 12%.',
+		'key_points' => [ 'A', 'B' ],
+		'caveats'    => [],
+	] );
+
+	Mail::fake();
+
+	( new SendDigestEmailJob( 5, 'user@example.test', [ [ 'metric' => 'pv', 'value' => 10 ] ], 'May 1 - May 7, 2026' ) )->handle();
+
+	// The mailable implements ShouldQueue so Mail::to()->send() actually queues.
+	Mail::assertQueued( DigestEmailMailable::class, function ( DigestEmailMailable $mail ): bool {
+		return 'weekly' === $mail->cadence && 'May 1 - May 7, 2026' === $mail->periodLabel;
+	} );
+
+	$preference->refresh();
+	expect( $preference->last_sent_at )->not->toBeNull();
+} );
+
+it( 'does not send when the feature toggle is off', function (): void {
+	AnalyticsDigestPreference::create( [ 'user_id' => 7, 'cadence' => 'weekly' ] );
+
+	app( ArtisanPackUI\Ai\Contracts\FeatureRegistry::class )->disable( 'analytics.digest_email' );
+
+	Mail::fake();
+
+	( new SendDigestEmailJob( 7, 'user@example.test', [ [ 'metric' => 'pv', 'value' => 10 ] ], 'May 1 - May 7' ) )->handle();
+
+	Mail::assertNothingOutgoing();
+} );

--- a/tests/Feature/Livewire/Ai/AnomalyExplanationTest.php
+++ b/tests/Feature/Livewire/Ai/AnomalyExplanationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Http\Livewire\Ai\AnomalyExplanation;
+use Livewire\Livewire;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'populates hypotheses when explain is called', function (): void {
+	$this->prompter->queue( [
+		'hypotheses'             => [
+			[ 'cause' => 'Reddit thread', 'confidence' => 'high', 'evidence' => [ 'x' ] ],
+		],
+		'recommended_next_steps' => [ 'Verify UTMs' ],
+	] );
+
+	Livewire::test( AnomalyExplanation::class, [
+		'anomaly' => [
+			'metric'    => 'pageviews',
+			'direction' => 'up',
+			'magnitude' => 245.0,
+			'date'      => '2026-05-11',
+		],
+		'context' => [ 'referrer_deltas' => [ 'reddit.com' => 340 ] ],
+	] )
+		->call( 'explain' )
+		->assertSet( 'error', null );
+} );
+
+it( 'renders the disabled state when the feature toggle is off', function (): void {
+	app( ArtisanPackUI\Ai\Contracts\FeatureRegistry::class )->disable( 'analytics.explain_anomaly' );
+
+	Livewire::test( AnomalyExplanation::class )
+		->assertSee( 'AI anomaly explanations are currently disabled.' );
+} );

--- a/tests/Feature/Livewire/Ai/DigestSubscriptionTest.php
+++ b/tests/Feature/Livewire/Ai/DigestSubscriptionTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Http\Livewire\Ai\DigestSubscription;
+use ArtisanPackUI\Analytics\Models\AnalyticsDigestPreference;
+use Illuminate\Foundation\Auth\User;
+use Illuminate\Support\Facades\Schema;
+use Livewire\Livewire;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	AiAgentTestSetup::bootstrap( $this->app );
+
+	if ( ! Schema::hasTable( 'users' ) ) {
+		Schema::create( 'users', function ( $table ): void {
+			$table->id();
+			$table->string( 'email' )->unique();
+			$table->timestamps();
+		} );
+	}
+
+	if ( ! Schema::hasTable( 'analytics_digest_preferences' ) ) {
+		Schema::create( 'analytics_digest_preferences', function ( $table ): void {
+			$table->id();
+			$table->unsignedBigInteger( 'user_id' );
+			$table->string( 'cadence', 16 )->default( 'off' );
+			$table->timestamp( 'last_sent_at' )->nullable();
+			$table->timestamps();
+			$table->unique( 'user_id' );
+		} );
+	}
+} );
+
+it( 'persists a chosen cadence to the preferences table', function (): void {
+	$user = new User();
+	$user->forceFill( [ 'id' => 42, 'email' => 'a@b.test' ] )->save();
+
+	$this->actingAs( $user );
+
+	Livewire::test( DigestSubscription::class )
+		->set( 'cadence', 'weekly' )
+		->call( 'save' )
+		->assertSet( 'status', __( 'Digest preference saved.' ) );
+
+	$preference = AnalyticsDigestPreference::query()->where( 'user_id', 42 )->first();
+
+	expect( $preference )->not->toBeNull();
+	expect( $preference->cadence )->toBe( 'weekly' );
+} );
+
+it( 'renders the disabled state when the feature toggle is off', function (): void {
+	app( ArtisanPackUI\Ai\Contracts\FeatureRegistry::class )->disable( 'analytics.digest_email' );
+
+	Livewire::test( DigestSubscription::class )
+		->assertSee( 'AI digest emails are currently disabled.' );
+} );

--- a/tests/Feature/Livewire/Ai/InsightSummaryTest.php
+++ b/tests/Feature/Livewire/Ai/InsightSummaryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Http\Livewire\Ai\InsightSummary;
+use Livewire\Livewire;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'renders and populates the summary when analyze runs', function (): void {
+	$this->prompter->queue( [
+		'summary'    => 'Traffic grew nicely.',
+		'highlights' => [ 'Organic +18%' ],
+		'concerns'   => [],
+	] );
+
+	Livewire::test( InsightSummary::class, [
+		'dateFrom' => '2026-05-01',
+		'dateTo'   => '2026-05-07',
+		'metrics'  => [ 'pageviews' => 100 ],
+	] )
+		->call( 'summarize' )
+		->assertSet( 'summary', 'Traffic grew nicely.' )
+		->assertSet( 'error', null );
+} );
+
+it( 'renders the disabled state when the feature toggle is off', function (): void {
+	app( ArtisanPackUI\Ai\Contracts\FeatureRegistry::class )->disable( 'analytics.insight_summary' );
+
+	Livewire::test( InsightSummary::class )
+		->assertSee( 'AI insight summaries are currently disabled.' );
+} );

--- a/tests/Feature/Livewire/Ai/SegmentInsightTest.php
+++ b/tests/Feature/Livewire/Ai/SegmentInsightTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Http\Livewire\Ai\SegmentInsight;
+use Livewire\Livewire;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'populates patterns when analyze is called', function (): void {
+	$this->prompter->queue( [
+		'patterns' => [
+			[
+				'observation'      => 'Mobile bounce is 62% vs 41% baseline',
+				'significance'     => 'high',
+				'suggested_action' => 'Audit mobile viewport',
+			],
+		],
+	] );
+
+	Livewire::test( SegmentInsight::class, [
+		'segmentType'  => 'device',
+		'segmentValue' => 'mobile',
+		'metrics'      => [ 'bounce_rate' => 0.62 ],
+		'baseline'     => [ 'bounce_rate' => 0.41 ],
+	] )
+		->call( 'analyze' )
+		->assertSet( 'error', null );
+} );
+
+it( 'renders the disabled state when the feature toggle is off', function (): void {
+	app( ArtisanPackUI\Ai\Contracts\FeatureRegistry::class )->disable( 'analytics.segment_insight' );
+
+	Livewire::test( SegmentInsight::class )
+		->assertSee( 'AI segment insights are currently disabled.' );
+} );

--- a/tests/Support/FakeAgentPrompter.php
+++ b/tests/Support/FakeAgentPrompter.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * Test fake for the AgentPrompter contract.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+
+declare( strict_types=1 );
+
+namespace Tests\Support;
+
+use ArtisanPackUI\Ai\Contracts\AgentPrompter;
+use ArtisanPackUI\Ai\Credentials\Credentials;
+
+/**
+ * Records every prompter call and returns queued responses in order.
+ *
+ * @package    ArtisanPack_UI
+ * @subpackage Analytics
+ *
+ * @since      1.3.0
+ */
+final class FakeAgentPrompter implements AgentPrompter
+{
+	/**
+	 * Recorded calls, in invocation order.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	public array $calls = [];
+
+	/**
+	 * Queued responses (FIFO).
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $queue = [];
+
+	/**
+	 * Push a canned response onto the queue.
+	 *
+	 * @since 1.3.0
+	 *
+	 * @param  array<string, mixed>  $output        Structured output body.
+	 * @param  int                   $inputTokens   Reported input tokens.
+	 * @param  int                   $outputTokens  Reported output tokens.
+	 *
+	 * @return void
+	 */
+	public function queue( array $output, int $inputTokens = 100, int $outputTokens = 50 ): void
+	{
+		$this->queue[] = [
+			'output'        => $output,
+			'input_tokens'  => $inputTokens,
+			'output_tokens' => $outputTokens,
+		];
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function prompt(
+		Credentials $credentials,
+		string $model,
+		string $instructions,
+		string|array $message,
+		array $outputSchema,
+	): array {
+		$this->calls[] = [
+			'credentials'   => $credentials,
+			'model'         => $model,
+			'instructions'  => $instructions,
+			'message'       => $message,
+			'output_schema' => $outputSchema,
+		];
+
+		if ( [] === $this->queue ) {
+			return [
+				'output'        => [],
+				'input_tokens'  => 0,
+				'output_tokens' => 0,
+			];
+		}
+
+		return array_shift( $this->queue );
+	}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,8 +57,13 @@ abstract class TestCase extends BaseTestCase
 	{
 		$providers = [
 			LivewireServiceProvider::class,
-			AnalyticsServiceProvider::class,
 		];
+
+		if ( class_exists( \ArtisanPackUI\Ai\AiServiceProvider::class ) ) {
+			$providers[] = \ArtisanPackUI\Ai\AiServiceProvider::class;
+		}
+
+		$providers[] = AnalyticsServiceProvider::class;
 
 		// Register Inertia service provider when available
 		if ( class_exists( \Inertia\ServiceProvider::class ) ) {

--- a/tests/Unit/Ai/Agents/AnomalyExplanationAgentTest.php
+++ b/tests/Unit/Ai/Agents/AnomalyExplanationAgentTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Analytics\Ai\Agents\AnomalyExplanationAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns hypotheses and next steps when the prompter responds', function (): void {
+	$this->prompter->queue( [
+		'hypotheses'             => [
+			[
+				'cause'      => 'Reddit thread on /pricing went viral',
+				'confidence' => 'high',
+				'evidence'   => [ 'Referrer reddit.com rose 340%', 'Same-day traffic to /pricing' ],
+			],
+		],
+		'recommended_next_steps' => [ 'Verify UTMs on /pricing', 'Check server capacity' ],
+	] );
+
+	$result = AnomalyExplanationAgent::for( [
+		'anomaly' => [
+			'metric'    => 'pageviews',
+			'direction' => 'up',
+			'magnitude' => 245.0,
+			'date'      => '2026-05-11',
+		],
+		'context' => [
+			'recent_content_changes' => [],
+			'referrer_deltas'        => [ 'reddit.com' => 340 ],
+			'campaign_launches'      => [],
+		],
+	] )->run();
+
+	expect( $result['hypotheses'] )->toHaveCount( 1 );
+	expect( $result['hypotheses'][0]['confidence'] )->toBe( 'high' );
+	expect( $result['recommended_next_steps'] )->toHaveCount( 2 );
+} );
+
+it( 'clamps invalid confidence levels to low', function (): void {
+	$this->prompter->queue( [
+		'hypotheses'             => [
+			[ 'cause' => 'x', 'confidence' => 'not-a-level', 'evidence' => [ 'a' ] ],
+		],
+		'recommended_next_steps' => [],
+	] );
+
+	$result = AnomalyExplanationAgent::for( [
+		'anomaly' => [
+			'metric'    => 'pageviews',
+			'direction' => 'down',
+			'magnitude' => -50,
+			'date'      => '2026-05-11',
+		],
+		'context' => [],
+	] )->run();
+
+	expect( $result['hypotheses'][0]['confidence'] )->toBe( 'low' );
+} );
+
+it( 'raises FeatureError when anomaly is missing required fields', function (): void {
+	expect( fn () => AnomalyExplanationAgent::for( [ 'anomaly' => [] ] )->run() )
+		->toThrow( FeatureError::class );
+} );
+
+it( 'drops hypotheses with an empty cause', function (): void {
+	$this->prompter->queue( [
+		'hypotheses'             => [
+			[ 'cause' => '', 'confidence' => 'high', 'evidence' => [] ],
+			[ 'cause' => 'A real cause', 'confidence' => 'medium', 'evidence' => [ 'e' ] ],
+		],
+		'recommended_next_steps' => [],
+	] );
+
+	$result = AnomalyExplanationAgent::for( [
+		'anomaly' => [
+			'metric'    => 'conversions',
+			'direction' => 'down',
+			'magnitude' => -22,
+			'date'      => '2026-05-11',
+		],
+		'context' => [],
+	] )->run();
+
+	expect( $result['hypotheses'] )->toHaveCount( 1 );
+	expect( $result['hypotheses'][0]['cause'] )->toBe( 'A real cause' );
+} );

--- a/tests/Unit/Ai/Agents/AnomalyExplanationAgentTest.php
+++ b/tests/Unit/Ai/Agents/AnomalyExplanationAgentTest.php
@@ -62,6 +62,40 @@ it( 'clamps invalid confidence levels to low', function (): void {
 	expect( $result['hypotheses'][0]['confidence'] )->toBe( 'low' );
 } );
 
+it( 'decodes hypotheses when the model returns a stringified JSON payload', function (): void {
+	// Reproduces the Opus behavior where the model returns the entire
+	// nested payload as a JSON-encoded string instead of an array.
+	$this->prompter->queue( [
+		'hypotheses'             => json_encode( [
+			'hypotheses' => [
+				[
+					'cause'      => 'A Reddit thread went viral',
+					'confidence' => 'high',
+					'evidence'   => [ 'referrer reddit.com rose 340% on 2026-06-14' ],
+				],
+			],
+		] ),
+		'recommended_next_steps' => [ 'audit the thread' ],
+	] );
+
+	$result = AnomalyExplanationAgent::for( [
+		'anomaly' => [
+			'metric'    => 'sessions',
+			'direction' => 'spike',
+			'magnitude' => 320.0,
+			'date'      => '2026-06-14',
+		],
+		'context' => [
+			'recent_content_changes' => [],
+			'referrer_deltas'        => [ [ 'referrer' => 'reddit.com', 'delta_pct' => 340 ] ],
+			'campaign_launches'      => [],
+		],
+	] )->run();
+
+	expect( $result['hypotheses'] )->toHaveCount( 1 );
+	expect( $result['hypotheses'][0]['cause'] )->toBe( 'A Reddit thread went viral' );
+} );
+
 it( 'raises FeatureError when anomaly is missing required fields', function (): void {
 	expect( fn () => AnomalyExplanationAgent::for( [ 'anomaly' => [] ] )->run() )
 		->toThrow( FeatureError::class );

--- a/tests/Unit/Ai/Agents/DigestEmailAgentTest.php
+++ b/tests/Unit/Ai/Agents/DigestEmailAgentTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Ai\Agents\DigestEmailAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'produces a narrative digest when given items', function (): void {
+	$this->prompter->queue( [
+		'summary'    => 'Your site had a great week — pageviews up 18%.',
+		'key_points' => [ 'Top page: /pricing (3,412 views)', 'Organic search up 22%' ],
+		'caveats'    => [ 'Mobile bounce ticked up 4pp' ],
+	] );
+
+	$result = DigestEmailAgent::for( [
+		'items'  => [ [ 'metric' => 'pageviews', 'value' => 12000 ] ],
+		'focus'  => 'week-over-week change',
+		'length' => 'detailed',
+	] )->run();
+
+	expect( $result['summary'] )->toContain( '18%' );
+	expect( $result['key_points'] )->toHaveCount( 2 );
+	expect( $result['caveats'] )->toHaveCount( 1 );
+} );
+
+it( 'short-circuits when items is empty', function (): void {
+	$result = DigestEmailAgent::for( [ 'items' => [] ] )->run();
+
+	expect( $result['summary'] )->toBe( 'No items to summarize.' );
+	expect( $result['key_points'] )->toBe( [] );
+} );
+
+it( 'uses claude-sonnet-4-6 as the default model', function (): void {
+	$agent = new DigestEmailAgent();
+	expect( $agent->defaultModel )->toBe( 'claude-sonnet-4-6' );
+	expect( $agent->featureKey )->toBe( 'analytics.digest_email' );
+} );
+
+it( 'inherits the SummarizationAgent output schema shape', function (): void {
+	$schema = ( new DigestEmailAgent() )->outputSchema();
+
+	expect( $schema['properties'] )->toHaveKeys( [ 'summary', 'key_points', 'caveats' ] );
+} );

--- a/tests/Unit/Ai/Agents/InsightSummaryAgentTest.php
+++ b/tests/Unit/Ai/Agents/InsightSummaryAgentTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Analytics\Ai\Agents\InsightSummaryAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns the shaped summary when the prompter responds', function (): void {
+	$this->prompter->queue( [
+		'summary'    => 'Traffic grew 22% week-over-week driven by /pricing.',
+		'highlights' => [ 'Top page: /pricing at 3,412 views', 'Organic up 18%' ],
+		'concerns'   => [ 'Mobile bounce rate spiked to 68%' ],
+	] );
+
+	$result = InsightSummaryAgent::for( [
+		'date_range' => [ 'from' => '2026-05-01', 'to' => '2026-05-07' ],
+		'metrics'    => [ 'pageviews' => 12000, 'visitors' => 4200 ],
+	] )->run();
+
+	expect( $result['summary'] )->toContain( '22%' );
+	expect( $result['highlights'] )->toHaveCount( 2 );
+	expect( $result['concerns'] )->toHaveCount( 1 );
+} );
+
+it( 'raises FeatureError when date_range is missing', function (): void {
+	expect( fn () => InsightSummaryAgent::for( [ 'metrics' => [ 'x' => 1 ] ] )->run() )
+		->toThrow( FeatureError::class );
+} );
+
+it( 'raises FeatureError when metrics is empty', function (): void {
+	expect( fn () => InsightSummaryAgent::for( [
+		'date_range' => [ 'from' => '2026-05-01', 'to' => '2026-05-07' ],
+		'metrics'    => [],
+	] )->run() )->toThrow( FeatureError::class );
+} );
+
+it( 'includes compare_to in the prompter message when provided', function (): void {
+	$this->prompter->queue( [
+		'summary'    => 'ok',
+		'highlights' => [],
+		'concerns'   => [],
+	] );
+
+	InsightSummaryAgent::for( [
+		'date_range' => [ 'from' => '2026-05-01', 'to' => '2026-05-07' ],
+		'metrics'    => [ 'pageviews' => 100 ],
+		'compare_to' => [ 'from' => '2026-04-24', 'to' => '2026-04-30' ],
+	] )->run();
+
+	$texts = collect( $this->prompter->calls[0]['message'] )->pluck( 'text' );
+	expect( $texts->contains( fn ( string $t ): bool => str_contains( $t, 'Compare to' ) ) )->toBeTrue();
+} );
+
+it( 'uses the claude-sonnet-4-6 default model', function (): void {
+	$agent = new InsightSummaryAgent();
+	expect( $agent->defaultModel )->toBe( 'claude-sonnet-4-6' );
+	expect( $agent->stream )->toBeTrue();
+} );

--- a/tests/Unit/Ai/Agents/SegmentInsightAgentTest.php
+++ b/tests/Unit/Ai/Agents/SegmentInsightAgentTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Ai\Exceptions\FeatureError;
+use ArtisanPackUI\Analytics\Ai\Agents\SegmentInsightAgent;
+use Tests\Feature\Ai\AiAgentTestSetup;
+
+beforeEach( function (): void {
+	$this->prompter = AiAgentTestSetup::bootstrap( $this->app );
+} );
+
+it( 'returns patterns when the prompter responds', function (): void {
+	$this->prompter->queue( [
+		'patterns' => [
+			[
+				'observation'      => 'Mobile bounce rate is 62% vs. 41% baseline',
+				'significance'     => 'high',
+				'suggested_action' => 'Audit mobile viewport on /pricing',
+			],
+		],
+	] );
+
+	$result = SegmentInsightAgent::for( [
+		'segment'  => [ 'type' => 'device', 'value' => 'mobile' ],
+		'metrics'  => [ 'bounce_rate' => 0.62 ],
+		'baseline' => [ 'bounce_rate' => 0.41 ],
+	] )->run();
+
+	expect( $result['patterns'] )->toHaveCount( 1 );
+	expect( $result['patterns'][0]['significance'] )->toBe( 'high' );
+} );
+
+it( 'raises FeatureError when segment is missing', function (): void {
+	expect( fn () => SegmentInsightAgent::for( [
+		'metrics'  => [ 'x' => 1 ],
+		'baseline' => [ 'x' => 2 ],
+	] )->run() )->toThrow( FeatureError::class );
+} );
+
+it( 'drops patterns with an empty observation', function (): void {
+	$this->prompter->queue( [
+		'patterns' => [
+			[ 'observation' => '', 'significance' => 'high', 'suggested_action' => 'x' ],
+			[ 'observation' => 'valid', 'significance' => 'medium', 'suggested_action' => 'do a thing' ],
+		],
+	] );
+
+	$result = SegmentInsightAgent::for( [
+		'segment'  => [ 'type' => 'device', 'value' => 'mobile' ],
+		'metrics'  => [ 'bounce_rate' => 0.62 ],
+		'baseline' => [ 'bounce_rate' => 0.41 ],
+	] )->run();
+
+	expect( $result['patterns'] )->toHaveCount( 1 );
+} );
+
+it( 'clamps invalid significance to low', function (): void {
+	$this->prompter->queue( [
+		'patterns' => [
+			[
+				'observation'      => 'x',
+				'significance'     => 'critical',
+				'suggested_action' => 'y',
+			],
+		],
+	] );
+
+	$result = SegmentInsightAgent::for( [
+		'segment'  => [ 'type' => 'device', 'value' => 'mobile' ],
+		'metrics'  => [ 'bounce_rate' => 0.62 ],
+		'baseline' => [ 'bounce_rate' => 0.41 ],
+	] )->run();
+
+	expect( $result['patterns'][0]['significance'] )->toBe( 'low' );
+} );

--- a/tests/Unit/Ai/Agents/SegmentInsightAgentTest.php
+++ b/tests/Unit/Ai/Agents/SegmentInsightAgentTest.php
@@ -31,6 +31,31 @@ it( 'returns patterns when the prompter responds', function (): void {
 	expect( $result['patterns'][0]['significance'] )->toBe( 'high' );
 } );
 
+it( 'decodes patterns when the model returns a stringified JSON payload', function (): void {
+	// Reproduces the Opus behavior where the model returns the entire
+	// nested payload as a JSON-encoded string instead of an array.
+	$this->prompter->queue( [
+		'patterns' => json_encode( [
+			'patterns' => [
+				[
+					'observation'      => 'Mobile bounce rate is 62% vs. 41% baseline',
+					'significance'     => 'high',
+					'suggested_action' => 'Audit mobile viewport on /pricing',
+				],
+			],
+		] ),
+	] );
+
+	$result = SegmentInsightAgent::for( [
+		'segment'  => [ 'type' => 'device', 'value' => 'mobile' ],
+		'metrics'  => [ 'bounce_rate' => 0.62 ],
+		'baseline' => [ 'bounce_rate' => 0.41 ],
+	] )->run();
+
+	expect( $result['patterns'] )->toHaveCount( 1 );
+	expect( $result['patterns'][0]['observation'] )->toBe( 'Mobile bounce rate is 62% vs. 41% baseline' );
+} );
+
 it( 'raises FeatureError when segment is missing', function (): void {
 	expect( fn () => SegmentInsightAgent::for( [
 		'metrics'  => [ 'x' => 1 ],


### PR DESCRIPTION
## Release Information

- **Release Version:** v1.3.0
- **Release Date:** 2026-07-07
- **Release Type:** Minor
- **Release Branch:** `release/1.3`
- **Target Branch:** `main`

## Release Summary

v1.3.0 introduces four AI-powered analytics features that plug into `artisanpack-ui/ai` to turn raw metrics into narrative insights: streaming insight summaries, anomaly explanations, segment insights, and opt-in weekly/monthly digest emails. Each feature ships an Agent, Livewire trigger, React and Vue components, and a JSON API endpoint, all gated behind the `analytics.ai.use` ability and toggleable per-feature via the shared `FeatureRegistry`.

## Changelog

### Added

**AI-powered analytics agents** — four opt-in AI features registered via `AnalyticsServiceProvider::aiFeatures()`:

- **`analytics.insight_summary`** — streaming plain-language summary of a date range with `{summary, highlights[], concerns[]}`. Backed by `InsightSummaryAgent`.
- **`analytics.explain_anomaly`** — ranked hypotheses for a traffic spike or drop with confidence scores, evidence, and recommended next steps. Backed by `AnomalyExplanationAgent`.
- **`analytics.segment_insight`** — non-obvious patterns in a referrer/page/time segment relative to a baseline. Backed by `SegmentInsightAgent`.
- **`analytics.digest_email`** — narrative body of the opt-in weekly/monthly digest email, delivered via queued `SendDigestEmailJob` + `DigestEmailMailable` with per-user cadence preferences persisted to a new `analytics_digest_preferences` table. Backed by `DigestEmailAgent`.

**Frontend surfaces**: `<livewire:artisanpack-analytics::ai.insight-summary>`, `ai.anomaly-explanation`, `ai.segment-insight`, and `ai.digest-subscription` Livewire components, plus matching React and Vue components (`InsightSummary`, `AnomalyExplanation`, `SegmentInsight`, `DigestSubscription`) with `useAiAgent` and `useApi` hooks/composables.

**API**: `/api/analytics/ai/*` routes for each agent, gated behind the `analytics.ai.use` ability (default: any authenticated user; overridable in `AuthServiceProvider`).

**Artisan**: `analytics:digests:dispatch` command queues one `SendDigestEmailJob` per subscribed user; wire it into the scheduler on your preferred cadence.

**Docs**: New `docs/advanced/ai-features.md` guide covering feature keys, request/response shapes, Livewire and React/Vue usage, gate customization, and digest scheduling. Linked from `home.md`, `advanced.md`, and `mkdocs.yml`.

### Changed

- `composer.json` version bumped to `1.3.0`.

## Issues and Pull Requests

**Issues Fixed:**
- Closes #76
- Closes #77
- Closes #78
- Closes #79

**Related PRs:**
- #80 (AI agent implementation)

## Breaking Changes

- [x] No breaking changes
- [ ] Breaking changes documented below

All AI features are opt-in and default to disabled via the shared feature registry. The `analytics.ai.use` gate ships with a permissive default (any authenticated user) so existing installations are unaffected.

## Testing Checklist

- [x] All automated tests passing (593 passed, 2 skipped)
- [ ] Manual testing completed
- [x] Accessibility tests passing (digest email template is text-first with structured headings)
- [ ] Performance tests passing (if applicable)
- [x] Security scan completed (no new advisories)
- [ ] Tested in staging environment
- [x] Database migrations tested (new `analytics_digest_preferences` table)

## Documentation Checklist

- [x] CHANGELOG updated
- [x] README updated (AI features section added in the feature branch)
- [x] API documentation updated (new `docs/advanced/ai-features.md`)
- [x] Migration guide written — N/A, non-breaking
- [x] Release notes written (this PR)

## Pre-Release Checklist

- [x] Version number updated in all necessary files (`composer.json`)
- [ ] Git tag prepared: `v1.3.0` (create after merge)
- [x] Release branch created/updated: `release/1.3`
- [x] Dependencies updated and tested (lock file already in sync from feature branch)
- [x] Build artifacts generated (composer + npm assets committed via feature branch)

## Notes

- The `analytics.ai.use` gate defaults to permissive on purpose — installers with quota concerns should tighten it in their `AuthServiceProvider`.
- Only `analytics.insight_summary` streams; the other three features return a single JSON response.
- `DigestEmailAgent` extends `SummarizationAgent` from `artisanpack-ui/ai`, so provider-level rate limits and budgets apply automatically.

---

**Release Manager:** @jacobmartella
