### PR TITLE
refactor: rename ap.analytics.site_selector.query to ap.analytics.siteSelector.query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-20
+
+### Changed
+
+- Renamed hook `ap.analytics.site_selector.query` → `ap.analytics.siteSelector.query` to align with cross-package hooks convention. Old name registered as a deprecation alias. Alias removal deferred to next major.
+- Bumped `artisanpack-ui/hooks` to `^1.3`.
+
+### Notes
+
+- `PrivacyIntegration` still subscribes to legacy `privacy.*` hook names. Those will be updated to `ap.privacy.*` after the privacy package's Wave 1 rename ships; aliases in that package keep the current subscriptions working in the meantime.
+
 ## [1.3.0] - 2026-07-07
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "Privacy-first analytics package for Laravel with local database storage, external provider support (GA4, Plausible), and a beautiful Livewire dashboard.",
   "type": "library",
   "license": "MIT",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "keywords": [
     "laravel",
     "analytics",
@@ -34,6 +34,7 @@
   "require": {
     "php": "^8.2",
     "artisanpack-ui/ai": "^1.0",
+    "artisanpack-ui/hooks": "^1.3",
     "doctrine/dbal": "^4.0",
     "illuminate/cache": "^11.0|^12.0|^13.0",
     "illuminate/console": "^11.0|^12.0|^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4e786d32d17be43c0848759a71db9cab",
+    "content-hash": "b6be0e62a7262da2a3e63eef6c25d51b",
     "packages": [
         {
             "name": "artisanpack-ui/ai",
@@ -146,6 +146,72 @@
                 "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
             },
             "time": "2026-05-24T02:53:50+00:00"
+        },
+        {
+            "name": "artisanpack-ui/hooks",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ArtisanPack-UI/hooks.git",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/hooks/zipball/2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "reference": "2834223f643ee5e12f93edc816a6d2dca66d09aa",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/support": "^11.0|^12.0|^13.0",
+                "php": "^8.2"
+            },
+            "require-dev": {
+                "artisanpack-ui/code-style": "^1.0",
+                "artisanpack-ui/code-style-pint": "^1.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.1",
+                "laravel/pint": "^1.25",
+                "orchestra/testbench": "^10.6",
+                "pestphp/pest": "^3.8",
+                "pestphp/pest-plugin-laravel": "^3.1",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Action": "ArtisanPackUI\\Hooks\\Facades\\Action",
+                        "Filter": "ArtisanPackUI\\Hooks\\Facades\\Filter"
+                    },
+                    "providers": [
+                        "ArtisanPackUI\\Hooks\\Providers\\HooksServiceProvider",
+                        "ArtisanPackUI\\Hooks\\Providers\\BladeDirectiveServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/helpers.php"
+                ],
+                "psr-4": {
+                    "ArtisanPackUI\\Hooks\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jacob Martella",
+                    "email": "me@jacobmartella.com"
+                }
+            ],
+            "description": "WordPress-style actions and filters for Laravel, with Blade directives and helper functions.",
+            "support": {
+                "issues": "https://github.com/ArtisanPack-UI/hooks/issues",
+                "source": "https://github.com/ArtisanPack-UI/hooks/tree/v1.3.0"
+            },
+            "time": "2026-07-20T18:37:59+00:00"
         },
         {
             "name": "aws/aws-crt-php",

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -201,6 +201,8 @@ class AnalyticsServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Support\HookAliases::register();
+
         $this->mergeConfiguration();
         $this->publishConfiguration();
         $this->publishMigrations();

--- a/src/Http/Livewire/SiteSelector.php
+++ b/src/Http/Livewire/SiteSelector.php
@@ -181,7 +181,7 @@ class SiteSelector extends Component
 	{
 		// Use the hooks package if available
 		if ( function_exists( 'applyFilters' ) ) {
-			return applyFilters( 'ap.analytics.site_selector.query', $query, Auth::user() );
+			return applyFilters( 'ap.analytics.siteSelector.query', $query, Auth::user() );
 		}
 
 		return $query;

--- a/src/Services/PrivacyIntegration.php
+++ b/src/Services/PrivacyIntegration.php
@@ -99,6 +99,7 @@ class PrivacyIntegration
 	protected function registerExportHooks(): void
 	{
 		// Filter to add analytics data to privacy export
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addFilter( 'privacy.export-data', function ( array $exportData, string $identifier ) {
 			$analyticsData = $this->exportService->exportVisitorData( $identifier );
 
@@ -110,6 +111,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Filter to provide export formats
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addFilter( 'privacy.export-formats', function ( array $formats ) {
 			$formats['analytics_csv']  = __( 'Analytics Data (CSV)' );
 			$formats['analytics_json'] = __( 'Analytics Data (JSON)' );
@@ -118,6 +120,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Action to handle format-specific exports
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addAction( 'privacy.export-format', function ( string $format, string $identifier ) {
 			if ( 'analytics_csv' === $format ) {
 				return $this->exportService->exportAsCsv( $identifier );
@@ -144,6 +147,7 @@ class PrivacyIntegration
 	protected function registerDeletionHooks(): void
 	{
 		// Action to delete analytics data
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addAction( 'privacy.delete-data', function ( string $identifier ): void {
 			$result = $this->deletionService->deleteVisitorData( $identifier );
 
@@ -155,6 +159,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Action to anonymize analytics data (alternative to deletion)
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addAction( 'privacy.anonymize-data', function ( string $identifier ): void {
 			$result = $this->deletionService->anonymizeVisitorData( $identifier );
 
@@ -166,6 +171,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Filter to check if visitor has data
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addFilter( 'privacy.has-data', function ( bool $hasData, string $identifier ) {
 			if ( $this->deletionService->hasVisitorData( $identifier ) ) {
 				return true;
@@ -175,6 +181,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Filter to get data summary
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addFilter( 'privacy.data-summary', function ( array $summary, string $identifier ) {
 			$analyticsSummary = $this->deletionService->getDataSummary( $identifier );
 
@@ -199,6 +206,7 @@ class PrivacyIntegration
 	protected function registerConsentHooks(): void
 	{
 		// Action when consent is granted via privacy package
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addAction( 'privacy.consent-granted', function ( string $identifier, array $categories ): void {
 			$this->consentService->grantConsent( $identifier, $categories );
 
@@ -208,6 +216,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Action when consent is revoked via privacy package
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addAction( 'privacy.consent-revoked', function ( string $identifier, array $categories ): void {
 			$this->consentService->revokeConsent( $identifier, $categories );
 
@@ -217,6 +226,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Filter to get consent status
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addFilter( 'privacy.consent-status', function ( array $status, string $identifier ) {
 			$analyticsStatus = $this->consentService->getConsentStatus( $identifier );
 
@@ -228,6 +238,7 @@ class PrivacyIntegration
 		}, 10 );
 
 		// Filter to provide available consent categories
+		// TODO(#82 follow-up): rename to 'ap.privacy.*' once privacy #64 rename ships (alias keeps this working meanwhile).
 		addFilter( 'privacy.consent-categories', function ( array $categories ) {
 			$analyticsCategories = config( 'artisanpack.analytics.privacy.consent_categories', [] );
 

--- a/src/Support/HookAliases.php
+++ b/src/Support/HookAliases.php
@@ -1,0 +1,30 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Support;
+
+/**
+ * Registers backwards-compat aliases for renamed hooks.
+ *
+ * @since 1.4.0
+ */
+class HookAliases
+{
+    /**
+     * Register deprecation aliases for renamed analytics hooks.
+     *
+     * Aliases keep existing subscribers firing (with an info log) after
+     * a hook rename. Removed in the next major version.
+     *
+     * @since 1.4.0
+     */
+    public static function register(): void
+    {
+        if ( ! function_exists( 'deprecateHook' ) ) {
+            return;
+        }
+
+        deprecateHook( 'ap.analytics.site_selector.query', 'ap.analytics.siteSelector.query' );
+    }
+}

--- a/tests/Feature/SiteSelectorHookAliasTest.php
+++ b/tests/Feature/SiteSelectorHookAliasTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Support\HookAliases;
+
+test( 'both old and new site selector hook names fire subscribers', function (): void {
+    HookAliases::register();
+
+    $newCalled = false;
+    $oldCalled = false;
+
+    addFilter( 'ap.analytics.siteSelector.query', function ( $query ) use ( &$newCalled ) {
+        $newCalled = true;
+        return $query . ':new';
+    }, 10 );
+
+    addFilter( 'ap.analytics.site_selector.query', function ( $query ) use ( &$oldCalled ) {
+        $oldCalled = true;
+        return $query . ':old';
+    }, 20 );
+
+    $result = applyFilters( 'ap.analytics.siteSelector.query', 'base' );
+
+    expect( $newCalled )->toBeTrue();
+    expect( $oldCalled )->toBeTrue();
+    expect( $result )->toContain( ':new' )->toContain( ':old' );
+} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,6 +59,10 @@ abstract class TestCase extends BaseTestCase
 			LivewireServiceProvider::class,
 		];
 
+		if ( class_exists( \ArtisanPackUI\Hooks\Providers\HooksServiceProvider::class ) ) {
+			$providers[] = \ArtisanPackUI\Hooks\Providers\HooksServiceProvider::class;
+		}
+
 		if ( class_exists( \ArtisanPackUI\Ai\AiServiceProvider::class ) ) {
 			$providers[] = \ArtisanPackUI\Ai\AiServiceProvider::class;
 		}


### PR DESCRIPTION
## Description

Renames `ap.analytics.site_selector.query` → `ap.analytics.siteSelector.query` (snake_case sub-segment → camelCase) to align with the cross-package hooks naming convention. Old name registered as a backwards-compat alias via `HookDeprecations`. Alias removal deferred to next major.

**Closes:** #82

## Type of Change

- [x] Refactoring (code improvement, no behavior change)
- [x] Breaking change (breaks backward compatibility) — mitigated by the deprecation alias

## Related Issue

**Issue:** #82

## Motivation and Context

Cross-package hooks standardization (umbrella hooks#13, Wave 1). snake_case sub-segments violate the new canonical convention.

## Changes Made

- Bumped \`artisanpack-ui/hooks\` requirement to \`^1.3\` (added as explicit \`require\`; was previously only pulled transitively via \`ai\`)
- Renamed fire site in \`src/Http/Livewire/SiteSelector.php\` (line ~184)
- Added \`src/Support/HookAliases.php\` calling \`deprecateHook()\`
- Wired \`HookAliases::register()\` first thing in \`AnalyticsServiceProvider::boot()\`
- Added \`// TODO(#82 follow-up):\` comments to all 11 \`privacy.*\` subscriptions in \`src/Services/PrivacyIntegration.php\` — those should be updated to \`ap.privacy.*\` after privacy #64 lands (aliases keep them working in the interim)
- Added \`tests/Feature/SiteSelectorHookAliasTest.php\`
- Registered \`HooksServiceProvider\` in \`tests/TestCase.php\` (Testbench doesn't auto-discover)
- Updated CHANGELOG (1.4.0 entry)
- Bumped version \`1.3.0\` → \`1.4.0\`

## How Has This Been Tested?

**Tests Performed:**
1. \`./vendor/bin/pest\` — 594 passed, 2 skipped, 1334 assertions
2. Manual verification via \`/packages/hooks/wave-one-renames\` in the dev app

## Tests Added

- [x] Unit tests added/updated
- [x] All tests passing

## Documentation

- [x] CHANGELOG updated
- [x] README had no references to the old hook name