### PR TITLE
fix: stop PrivacyFilter discarding every batched beacon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Batched beacons are no longer silently discarded. `PrivacyFilter` resolved the excluded path with `$request->input( 'path', $request->path() )`; a batch payload carries its paths in `items[].data.path` and has no top-level `path`, so the check fell through to the ingest route's own URI (`api/analytics/batch`). That matches the `/api/*` pattern shipped in the default `excluded_paths`, so every batch was rejected with a 204 before reaching the controller — no error, no log, and the same status a successful beacon returns. Since the JS tracker batches whenever two or more items are queued within `batchInterval`, this dropped a large share of real traffic while single-item flushes kept working, which made it present as under-counting rather than as a broken endpoint. ([#85](https://github.com/ArtisanPack-UI/analytics/issues/85))
+
+### Changed
+
+- Excluded-path filtering moved from `PrivacyFilter` to `TrackingService`, so the decision is made once per tracked page view or event rather than once per HTTP request. A batch containing an excluded path now drops only that item instead of discarding the items alongside it. `PrivacyFilter` keeps the request-level checks it can actually evaluate (enabled flag, DNT/GPC, IP, user agent).
+- Exclusion matching now compares the path component only, so a tracked path arriving with a query string or fragment is matched on its path. A `null` or empty tracked path is treated as not excluded rather than being dropped.
+
+### Deprecated
+
+- `PrivacyFilter::isExcludedPath()` and `PrivacyFilter::pathMatches()` are deprecated in favour of `TrackingService::isExcludedPath()`. Both are retained and still called by the middleware, so subclasses that call or override them keep working; they are scheduled for removal in 2.0. `isExcludedPath()` no longer falls back to `$request->path()` — it returns `false` when the request carries no single top-level tracked path, deferring to the per-item filtering in `TrackingService`. One consequence worth knowing if you override it: the override governs only requests carrying a single tracked path, since batched items are filtered by `TrackingService` and are not routed through the middleware hook.
+
 ## [1.4.0] - 2026-07-21
 
 ### Changed

--- a/docs/advanced/privacy-consent.md
+++ b/docs/advanced/privacy-consent.md
@@ -204,6 +204,15 @@ ANALYTICS_EXCLUDED_IPS=192.168.1.1,10.0.0.0/8
 ],
 ```
 
+Patterns are matched against the path of the **page being tracked**, never against
+the URI of the ingest endpoint the beacon was posted to. That distinction matters
+because the ingest routes themselves live under `/api`, which the default list
+excludes — matching on the ingest route would drop every beacon.
+
+Exclusion is evaluated once per tracked page view or event, so a batched beacon
+carrying several paths records the ones that are not excluded and drops only
+those that are. Query strings and fragments are ignored when matching.
+
 ## Data Retention
 
 Configure automatic data cleanup:

--- a/src/Http/Middleware/PrivacyFilter.php
+++ b/src/Http/Middleware/PrivacyFilter.php
@@ -53,6 +53,13 @@ class PrivacyFilter
 		}
 
 		// Check excluded paths
+		//
+		// TrackingService is the authority for this now: it applies the
+		// exclusion once per tracked item, which is the only way a batch
+		// beacon — many tracked paths in one HTTP request — can be filtered
+		// correctly. This call is kept so subclasses overriding
+		// isExcludedPath() continue to work, and it short-circuits only when
+		// the request carries a single unambiguous tracked path.
 		if ( $this->isExcludedPath( $request ) ) {
 			return $this->returnNoContent();
 		}
@@ -235,23 +242,43 @@ class PrivacyFilter
 	/**
 	 * Check if the request path matches an exclusion pattern.
 	 *
+	 * Only consults an explicit top-level `path` on the payload — the path of
+	 * the page being tracked. It no longer falls back to `$request->path()`,
+	 * which is the URI of the ingest endpoint itself: a batch beacon carries
+	 * its paths in `items[].data.path` and has no top-level `path`, so that
+	 * fallback matched `api/analytics/batch` against the `/api/*` pattern in
+	 * the default config and discarded every batch. Returning false for those
+	 * requests defers to the per-item filtering in TrackingService.
+	 *
 	 * @param Request $request The incoming request.
 	 *
 	 * @return bool
 	 *
-	 * @since 1.0.0
+	 * @since      1.0.0
+	 * @deprecated 1.5.0 Excluded-path filtering moved to
+	 *             {@see \ArtisanPackUI\Analytics\Services\TrackingService::isExcludedPath()},
+	 *             which evaluates one tracked path per item and so handles
+	 *             batched beacons correctly. Retained for backwards
+	 *             compatibility; scheduled for removal in 2.0. Note that
+	 *             overriding this method only affects requests carrying a
+	 *             single tracked path — batched items are filtered by
+	 *             TrackingService and are unaffected by the override.
 	 */
 	protected function isExcludedPath( Request $request ): bool
 	{
 		$excludedPaths = config( 'artisanpack.analytics.privacy.excluded_paths', [] );
-		$path          = $request->input( 'path', $request->path() );
+		$path          = $request->input( 'path' );
 
 		if ( empty( $excludedPaths ) ) {
 			return false;
 		}
 
+		if ( ! is_string( $path ) || '' === $path ) {
+			return false;
+		}
+
 		foreach ( $excludedPaths as $excludedPath ) {
-			if ( $this->pathMatches( $path, $excludedPath ) ) {
+			if ( $this->pathMatches( $path, (string) $excludedPath ) ) {
 				return true;
 			}
 		}
@@ -267,10 +294,18 @@ class PrivacyFilter
 	 *
 	 * @return bool
 	 *
-	 * @since 1.0.0
+	 * @since      1.0.0
+	 * @deprecated 1.5.0 Superseded by the matching in
+	 *             {@see \ArtisanPackUI\Analytics\Services\TrackingService}.
+	 *             Retained for backwards compatibility; scheduled for removal
+	 *             in 2.0.
 	 */
 	protected function pathMatches( string $path, string $pattern ): bool
 	{
+		// Compare path only — a tracked path may arrive with a query string
+		// or fragment attached, and neither should affect exclusion.
+		$path = (string) parse_url( $path, PHP_URL_PATH );
+
 		// Normalize paths
 		$path    = '/' . ltrim( $path, '/' );
 		$pattern = '/' . ltrim( $pattern, '/' );

--- a/src/Services/TrackingService.php
+++ b/src/Services/TrackingService.php
@@ -59,6 +59,14 @@ class TrackingService
 	public function trackPageView( PageViewData $data, Request $request, ?int $siteId = null ): void
 	{
 		try {
+			// Excluded-path filtering happens here rather than in PrivacyFilter
+			// so the decision is made once per tracked page view. A batch beacon
+			// carries many paths in one HTTP request, so the middleware has no
+			// single path it can evaluate on the request's behalf.
+			if ( $this->isExcludedPath( $data->path ) ) {
+				return;
+			}
+
 			// Enrich data with device info
 			$enrichedData = $this->enrichPageViewData( $data, $request );
 
@@ -186,6 +194,11 @@ class TrackingService
 	public function trackEvent( EventData $data, Request $request, ?int $siteId = null ): void
 	{
 		try {
+			// See trackPageView() — one exclusion decision per tracked item.
+			if ( $this->isExcludedPath( $data->path ) ) {
+				return;
+			}
+
 			// Resolve or create visitor from request
 			$visitorData = $this->createVisitorDataFromRequest( $request, $data->toArray() );
 			$visitor     = $this->visitorResolver->resolve( $visitorData, $siteId );
@@ -415,6 +428,82 @@ class TrackingService
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check whether a tracked path is excluded from tracking.
+	 *
+	 * Takes the path of the page being tracked — never the URI of the
+	 * ingest endpoint the beacon was posted to. Those are different
+	 * things, and conflating them is what made every batched beacon
+	 * match the `/api/*` exclusion that ships in the default config.
+	 *
+	 * A null or empty path is not treated as excluded; there is nothing
+	 * to match against, and silently dropping such an item would repeat
+	 * the same class of invisible data loss.
+	 *
+	 * @param string|null $path The path of the tracked page.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.5.0
+	 */
+	public function isExcludedPath( ?string $path ): bool
+	{
+		if ( null === $path || '' === $path ) {
+			return false;
+		}
+
+		$excludedPaths = config( 'artisanpack.analytics.privacy.excluded_paths', [] );
+
+		if ( empty( $excludedPaths ) ) {
+			return false;
+		}
+
+		foreach ( $excludedPaths as $excludedPath ) {
+			if ( $this->pathMatches( $path, (string) $excludedPath ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Check if a path matches an exclusion pattern (supports wildcards).
+	 *
+	 * @param string $path    The path to check.
+	 * @param string $pattern The exclusion pattern.
+	 *
+	 * @return bool
+	 *
+	 * @since 1.5.0
+	 */
+	protected function pathMatches( string $path, string $pattern ): bool
+	{
+		// Compare path only — a tracked path may arrive with a query string
+		// or fragment attached, and neither should affect exclusion.
+		$path = (string) parse_url( $path, PHP_URL_PATH );
+
+		// Normalize paths
+		$path    = '/' . ltrim( $path, '/' );
+		$pattern = '/' . ltrim( $pattern, '/' );
+
+		// Exact match
+		if ( $path === $pattern ) {
+			return true;
+		}
+
+		// Wildcard match
+		if ( str_contains( $pattern, '*' ) ) {
+			// Escape regex metacharacters first, then convert escaped wildcards to regex
+			$escaped = preg_quote( $pattern, '/' );
+			$regex   = '/^' . str_replace( '\\*', '.*', $escaped ) . '$/';
+
+			return 1 === preg_match( $regex, $path );
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/Feature/ExcludedPathFilteringTest.php
+++ b/tests/Feature/ExcludedPathFilteringTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Models\Event;
+use ArtisanPackUI\Analytics\Models\PageView;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses( RefreshDatabase::class );
+
+/**
+ * A real browser user agent. `canTrack()` runs bot detection on every
+ * ingest request, so an absent or synthetic agent would drop the beacon
+ * for a reason unrelated to what these tests are asserting.
+ */
+const EXCLUDED_PATH_TEST_AGENT = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15';
+
+beforeEach( function (): void {
+	config()->set( 'artisanpack.analytics.local.queue_processing', false );
+	config()->set( 'artisanpack.analytics.local.enabled', true );
+
+	// `/api/*` ships in the package's default excluded_paths, and the ingest
+	// endpoints all live under /api — which is precisely the collision this
+	// suite guards against.
+	config()->set( 'artisanpack.analytics.privacy.excluded_paths', [
+		'/admin/*',
+		'/api/*',
+	] );
+} );
+
+/**
+ * Post a payload to an ingest endpoint as a real browser would.
+ *
+ * @param string               $endpoint The ingest endpoint path.
+ * @param array<string, mixed> $payload  The beacon payload.
+ */
+function postBeacon( string $endpoint, array $payload ): Illuminate\Testing\TestResponse
+{
+	return test()
+		->withHeaders( [ 'User-Agent' => EXCLUDED_PATH_TEST_AGENT ] )
+		->postJson( $endpoint, $payload );
+}
+
+/**
+ * Build a single batch item wrapping a tracked page view.
+ *
+ * @param string $path The tracked path.
+ *
+ * @return array<string, mixed>
+ */
+function batchPageView( string $path ): array
+{
+	return [
+		'type' => 'pageview',
+		'data' => [
+			'visitor_id' => 'visitor-' . md5( $path ),
+			'session_id' => '11111111-2222-4333-8444-555555555555',
+			'path'       => $path,
+			'title'      => 'Page ' . $path,
+		],
+	];
+}
+
+test( 'batched page views are recorded even though the ingest route itself matches an exclusion', function (): void {
+	// Regression test for the bug where PrivacyFilter resolved the excluded
+	// path via `$request->input( 'path', $request->path() )`. A batch payload
+	// carries no top-level `path`, so it fell through to the request URI —
+	// `api/analytics/batch` — which matches `/api/*`, and the middleware
+	// discarded the entire batch with a 204 before the controller ever ran.
+	$response = postBeacon( '/api/analytics/batch', [
+		'items' => [
+			batchPageView( '/docs/getting-started' ),
+			batchPageView( '/docs/installation' ),
+		],
+	] );
+
+	$response->assertNoContent();
+
+	expect( PageView::query()->pluck( 'path' )->all() )
+		->toEqualCanonicalizing( [ '/docs/getting-started', '/docs/installation' ] );
+} );
+
+test( 'a batch drops only its excluded items and keeps the rest', function (): void {
+	// Rejecting the whole request because one item is excluded would be its
+	// own data-loss bug, so exclusion has to be decided per tracked item.
+	$response = postBeacon( '/api/analytics/batch', [
+		'items' => [
+			batchPageView( '/docs/getting-started' ),
+			batchPageView( '/admin/settings' ),
+			batchPageView( '/docs/configuration' ),
+		],
+	] );
+
+	$response->assertNoContent();
+
+	expect( PageView::query()->pluck( 'path' )->all() )
+		->toEqualCanonicalizing( [ '/docs/getting-started', '/docs/configuration' ] )
+		->not->toContain( '/admin/settings' );
+} );
+
+test( 'a batch of entirely excluded page views records nothing', function (): void {
+	$response = postBeacon( '/api/analytics/batch', [
+		'items' => [
+			batchPageView( '/admin/settings' ),
+			batchPageView( '/admin/users' ),
+		],
+	] );
+
+	$response->assertNoContent();
+
+	expect( PageView::query()->count() )->toBe( 0 );
+} );
+
+test( 'single page view beacons still honour excluded paths', function (): void {
+	// The exclusion moved from PrivacyFilter into TrackingService; this is the
+	// behaviour that move must not regress.
+	postBeacon( '/api/analytics/pageview', [
+		'visitor_id' => 'visitor-excluded',
+		'session_id' => '22222222-3333-4444-8555-666666666666',
+		'path'       => '/admin/settings',
+		'title'      => 'Settings',
+	] )->assertNoContent();
+
+	expect( PageView::query()->count() )->toBe( 0 );
+} );
+
+test( 'single page view beacons on a tracked path are recorded', function (): void {
+	postBeacon( '/api/analytics/pageview', [
+		'visitor_id' => 'visitor-tracked',
+		'session_id' => '33333333-4444-4555-8666-777777777777',
+		'path'       => '/docs/getting-started',
+		'title'      => 'Getting Started',
+	] )->assertNoContent();
+
+	expect( PageView::query()->pluck( 'path' )->all() )->toBe( [ '/docs/getting-started' ] );
+} );
+
+test( 'events are filtered by the path they were fired on, not the ingest route', function (): void {
+	postBeacon( '/api/analytics/event', [
+		'visitor_id' => 'visitor-event',
+		'session_id' => '44444444-5555-4666-8777-888888888888',
+		'name'       => 'docs_code_copy',
+		'path'       => '/docs/getting-started',
+	] )->assertNoContent();
+
+	postBeacon( '/api/analytics/event', [
+		'visitor_id' => 'visitor-event-admin',
+		'session_id' => '55555555-6666-4777-8888-999999999999',
+		'name'       => 'admin_action',
+		'path'       => '/admin/settings',
+	] )->assertNoContent();
+
+	expect( Event::query()->pluck( 'name' )->all() )->toBe( [ 'docs_code_copy' ] );
+} );
+
+test( 'a tracked path carrying a query string is matched on its path only', function (): void {
+	postBeacon( '/api/analytics/batch', [
+		'items' => [
+			batchPageView( '/admin/settings?tab=general' ),
+			batchPageView( '/docs/search?q=install' ),
+		],
+	] )->assertNoContent();
+
+	expect( PageView::query()->pluck( 'path' )->all() )
+		->toBe( [ '/docs/search?q=install' ] );
+} );
+
+test( 'an item with no path is kept rather than silently discarded', function (): void {
+	// Nothing to match against is not the same as "excluded". Dropping these
+	// would reintroduce invisible data loss through a different door.
+	postBeacon( '/api/analytics/event', [
+		'visitor_id' => 'visitor-pathless',
+		'session_id' => '66666666-7777-4888-8999-aaaaaaaaaaaa',
+		'name'       => 'pathless_event',
+	] )->assertNoContent();
+
+	expect( Event::query()->pluck( 'name' )->all() )->toBe( [ 'pathless_event' ] );
+} );
+
+test( 'the deprecated PrivacyFilter path hooks are still present and callable', function (): void {
+	// Both methods were protected, so removing them would break any subclass
+	// that calls or overrides them. 1.x cannot take that break, so they stay
+	// until 2.0 — this test is what stops them being dropped by accident.
+	$filter = new ReflectionClass( ArtisanPackUI\Analytics\Http\Middleware\PrivacyFilter::class );
+
+	expect( $filter->hasMethod( 'isExcludedPath' ) )->toBeTrue()
+		->and( $filter->hasMethod( 'pathMatches' ) )->toBeTrue();
+
+	foreach ( [ 'isExcludedPath', 'pathMatches' ] as $name ) {
+		expect( $filter->getMethod( $name )->isProtected() )
+			->toBeTrue( "PrivacyFilter::{$name}() must stay protected for subclasses" )
+			->and( $filter->getMethod( $name )->getDocComment() )
+			->toContain( '@deprecated 1.5.0' );
+	}
+} );
+
+test( 'a subclass overriding isExcludedPath still governs single beacons', function (): void {
+	// The BC guarantee that matters: handle() must keep calling the overridable
+	// hook, not just keep the method around as dead code.
+	$filter = new class extends ArtisanPackUI\Analytics\Http\Middleware\PrivacyFilter {
+		protected function isExcludedPath( Illuminate\Http\Request $request ): bool
+		{
+			return '/docs/blocked-by-subclass' === $request->input( 'path' );
+		}
+	};
+
+	$request = Illuminate\Http\Request::create( '/api/analytics/pageview', 'POST', [
+		'path' => '/docs/blocked-by-subclass',
+	] );
+
+	$response = $filter->handle( $request, fn (): Symfony\Component\HttpFoundation\Response => response( 'reached', 200 ) );
+
+	expect( $response->getStatusCode() )->toBe( 204 );
+
+	$allowed = Illuminate\Http\Request::create( '/api/analytics/pageview', 'POST', [
+		'path' => '/docs/getting-started',
+	] );
+
+	expect( $filter->handle( $allowed, fn (): Symfony\Component\HttpFoundation\Response => response( 'reached', 200 ) )->getStatusCode() )
+		->toBe( 200 );
+} );
+
+test( 'the deprecated middleware hook no longer matches the ingest route itself', function (): void {
+	// The exact regression: a batch request has no top-level `path`, so the
+	// hook must not fall back to `api/analytics/batch` and match `/api/*`.
+	$filter  = new ArtisanPackUI\Analytics\Http\Middleware\PrivacyFilter();
+	$request = Illuminate\Http\Request::create( '/api/analytics/batch', 'POST', [
+		'items' => [ batchPageView( '/docs/getting-started' ) ],
+	] );
+
+	$response = $filter->handle( $request, fn (): Symfony\Component\HttpFoundation\Response => response( 'reached', 200 ) );
+
+	expect( $response->getStatusCode() )->toBe( 200 );
+} );
+
+test( 'an empty exclusion list tracks everything', function (): void {
+	config()->set( 'artisanpack.analytics.privacy.excluded_paths', [] );
+
+	postBeacon( '/api/analytics/batch', [
+		'items' => [
+			batchPageView( '/admin/settings' ),
+			batchPageView( '/docs/getting-started' ),
+		],
+	] )->assertNoContent();
+
+	expect( PageView::query()->count() )->toBe( 2 );
+} );


### PR DESCRIPTION
## Description

`PrivacyFilter` resolved the excluded path with `$request->input( 'path', $request->path() )`. A batch payload carries its paths in `items[].data.path` and has no top-level `path`, so the check fell through to the ingest route's own URI — `api/analytics/batch` — which matches the `/api/*` pattern shipped in the package's own default `excluded_paths`. Every batch was rejected with a `204` before reaching the controller: no error, no log, and the same status a successfully ingested beacon returns.

Because the JS tracker batches whenever two or more items are queued inside `batchInterval` (`Transport._flush()` sends to `/batch` only when `items.length > 1`), this silently discarded a large share of real traffic while single-item flushes kept working. That is why it presented as "analytics is under-counting" rather than "an endpoint is broken", and why it survived unnoticed.

This affects any consumer on default config, not just one app — `/api/*` ships in the package's own `excluded_paths`.

**Closes:** #85

## Type of Change

- [x] Bug fix (fixes an issue)
- [ ] New feature (adds new functionality)
- [ ] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #85

## Motivation and Context

The exclusion decision was being made at the wrong layer. One HTTP request can carry many tracked paths, so a request-scoped middleware has no single path it can judge the request on — and the fallback it used, the ingest URI, is by definition never a page being tracked.

Rejecting a whole batch because one item is excluded would also be its own data-loss bug, so the fix moves the decision to where it can be made per tracked item.

## Changes Made

- Excluded-path filtering moved into `TrackingService`, applied once per tracked page view or event. Because `processItem()` delegates to `trackPageView()`/`trackEvent()`, per-item filtering covers batched and single beacons through one code path.
- A batch containing an excluded path now drops only that item and records the rest.
- `PrivacyFilter` keeps the request-level checks it can actually evaluate: enabled flag, DNT/GPC, IP, user agent.
- `PrivacyFilter::isExcludedPath()` and `::pathMatches()` are **kept and still called** by the middleware, marked `@deprecated 1.5.0` for removal in 2.0. Both were `protected`, and 1.x cannot take that break. `isExcludedPath()` no longer falls back to `$request->path()`; it returns `false` when there is no single top-level tracked path, deferring to `TrackingService`.
- Matching now compares the path component only, so a tracked path carrying a query string or fragment matches on its path.
- A `null` or empty tracked path is treated as **not** excluded rather than dropped — there is nothing to match against, and dropping it would reintroduce the same class of invisible loss through a different door.

### Deprecation note for reviewers

Overriding `PrivacyFilter::isExcludedPath()` now governs only requests carrying a single tracked path. Batched items are filtered by `TrackingService` and are unaffected by the override. This is inherent — the middleware cannot express a per-item decision — and it is documented in the `@deprecated` tag and the changelog rather than papered over.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 26 (Darwin 27.0.0)
- Browser (if applicable): N/A (server-side); original symptom observed in Safari
- PHP Version: 8.4.13
- Project Version: 1.5.0-dev (branched from `release/1.5`)

**Tests Performed:**
1. `vendor/bin/pest tests/Feature/ExcludedPathFilteringTest.php` — 12 passed (39 assertions).
2. **Confirmed the tests are not vacuous.** Reverting only `src/` makes 4 of them fail, including both core cases. The remaining 8 cover behaviour that already worked (single-beacon exclusion, event filtering, empty exclusion list, the deprecated hooks) and are there to prove the move does not regress it.
3. Full suite: **34 failed, 2 skipped, 572 passed**. Baseline on clean `release/1.5` is **34 failed, 2 skipped, 560 passed** — the same 34 pre-existing failures, caused by optional peers `artisanpack-ui/hooks` and `artisanpack-ui/ai` not being installed (`Call to undefined function addFilter()`, container binding errors). This branch adds 12 passing tests and no new failures.
4. `php-cs-fixer` and `phpcs` both clean.
5. **End-to-end against the original reproduction.** Synced the two changed files into the consuming docs app's vendor tree and posted a batch under that app's real, unmodified config: `/docs/getting-started` and `/docs/installation` persisted, `/dashboard/analytics` stayed correctly excluded. The vendor tree was restored afterwards.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — server-side ingest filtering with no UI surface.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/ExcludedPathFilteringTest.php` (12 tests). Covers the batch regression, mixed batches dropping only excluded items, fully-excluded batches, single page-view and event beacons, query-string handling, pathless items, an empty exclusion list, and three tests locking the deprecation contract — that both hooks remain `protected` and tagged, that a subclass override still governs single beacons, and that the hook no longer matches the ingest route.

Note that the exclusion config is first covered here; there were previously no tests referencing `excluded_paths` or `PrivacyFilter`.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** `CHANGELOG.md` updated under `[Unreleased]` with Fixed / Changed / Deprecated entries. `docs/advanced/privacy-consent.md` now states that patterns match the tracked page's path and never the ingest route, and that exclusion is evaluated per item.

## Screenshots

N/A

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded-path filtering now applies independently to each page view and event, including batched tracking.
  * Matching uses tracked page paths rather than ingest endpoint URLs.
  * Query strings and URL fragments are ignored during matching.
  * Items without a valid path are handled safely and are not incorrectly excluded.

* **Documentation**
  * Clarified excluded-path behavior, matching rules, and deprecated privacy-filter exclusion methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->