### PR TITLE
feat: track SPA navigation via the History API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SPA navigation tracking.** The JS tracker now detects History API navigation (`pushState`, `replaceState`, `popstate`) — the mechanism Inertia, React Router, Vue Router and `wire:navigate` all navigate through — and records a page view whenever the path or query string changes. Previously page views were bound to the window `load` event and `hashchange` only, so in any SPA the tracker recorded the initial document load and nothing else; hash routing is not how current routers work. Controlled by the new `trackHistoryChanges` option, default `true`. ([#86](https://github.com/ArtisanPack-UI/analytics/issues/86))
+
 ### Fixed
 
+- Engagement metrics are now attributed to the page they were measured on and reset per navigation. `_sendEngagementData()` read `window.location.pathname` at flush time, which in an SPA is the *incoming* path — and the server matches the row to update by path, so the update landed on the wrong page view or none at all. Scroll depth, time on page, engaged time and scroll milestones also accumulated across the whole session rather than per page, so scroll depth could only ratchet upward and milestone events stopped firing after the first page.
 - Batched beacons are no longer silently discarded. `PrivacyFilter` resolved the excluded path with `$request->input( 'path', $request->path() )`; a batch payload carries its paths in `items[].data.path` and has no top-level `path`, so the check fell through to the ingest route's own URI (`api/analytics/batch`). That matches the `/api/*` pattern shipped in the default `excluded_paths`, so every batch was rejected with a 204 before reaching the controller — no error, no log, and the same status a successful beacon returns. Since the JS tracker batches whenever two or more items are queued within `batchInterval`, this dropped a large share of real traffic while single-item flushes kept working, which made it present as under-counting rather than as a broken endpoint. ([#85](https://github.com/ArtisanPack-UI/analytics/issues/85))
 
 ### Changed
 
 - Excluded-path filtering moved from `PrivacyFilter` to `TrackingService`, so the decision is made once per tracked page view or event rather than once per HTTP request. A batch containing an excluded path now drops only that item instead of discarding the items alongside it. `PrivacyFilter` keeps the request-level checks it can actually evaluate (enabled flag, DNT/GPC, IP, user agent).
 - Exclusion matching now compares the path component only, so a tracked path arriving with a query string or fragment is matched on its path. A `null` or empty tracked path is treated as not excluded rather than being dropped.
+- **SPA page-view counts will rise.** `trackHistoryChanges` defaults to `true`, so applications that were silently recording only the initial document load will start recording every navigation. That is the intent, but expect a step change in reported page views rather than a regression. Applications that already bridge their router's navigation events by hand must set `trackHistoryChanges: false` or they will count each page view twice.
 
 ### Deprecated
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -118,19 +118,29 @@ Check these common issues:
 
 ### How do I track single-page applications?
 
-Enable hash change tracking:
+Nothing to do — since 1.5.0 the tracker detects History API navigation on its
+own, which is how Inertia, React Router, Vue Router and `wire:navigate` all
+move between pages. `trackHistoryChanges` defaults to `true`.
 
-```php
-'tracker' => [
-    'track_hash_changes' => true,
-],
+Each navigation records a page view for the new path, and closes out the
+previous page's engagement metrics (time on page, scroll depth) against the
+path they were measured on.
+
+Only a change of path or query string counts. A `replaceState` that leaves the
+URL alone — routers do this constantly to sync state — records nothing, and
+hash-only changes are left to `trackHashChanges` so the two options cannot
+double count.
+
+If your app already bridges its router's navigation events by hand, turn the
+built-in detection off or you will count every page view twice:
+
+```js
+window.__ARTISANPACK_ANALYTICS_CONFIG__ = {
+    trackHistoryChanges: false,
+};
 ```
 
-Or manually track route changes:
-
-```javascript
-analytics.trackPageView(window.location.pathname, document.title);
-```
+`trackHashChanges` (default `false`) remains available for hash-based routers.
 
 ### Can I track logged-in users?
 

--- a/docs/usage/tracking-page-views.md
+++ b/docs/usage/tracking-page-views.md
@@ -48,17 +48,36 @@ The tracking script respects your configuration settings:
 
 ### SPA Support
 
-For single-page applications, enable hash change tracking:
+Single-page applications work out of the box. Since 1.5.0 the tracker watches
+`pushState`, `replaceState` and `popstate` — the History API that Inertia,
+React Router, Vue Router and `wire:navigate` all navigate through — and records
+a page view whenever the path or query string changes.
 
-```dotenv
-ANALYTICS_TRACK_HASH=true
+A navigation also closes out the previous page's engagement metrics, so time on
+page and scroll depth are attributed to the page they were measured on instead
+of accumulating across the session.
+
+Deliberately ignored, so numbers stay honest:
+
+- A `replaceState` that leaves the URL unchanged. Routers use it to sync state
+  without navigating.
+- Hash-only changes, which belong to `trackHashChanges` (default `false`) and
+  would otherwise be counted twice when both options are on.
+
+Turn it off if your app already bridges its router's navigation events itself,
+otherwise both will fire:
+
+```javascript
+window.__ARTISANPACK_ANALYTICS_CONFIG__ = {
+    trackHistoryChanges: false,
+};
 ```
 
-Or manually track navigation:
+You can still record a navigation by hand:
 
 ```javascript
 // After route change
-analytics.trackPageView(window.location.pathname, document.title);
+analytics.pageView();
 ```
 
 ## Manual Tracking

--- a/resources/js/tracker.js
+++ b/resources/js/tracker.js
@@ -30,6 +30,7 @@
         trackScrollDepth: true,
         trackEngagement: true,
         trackHashChanges: false,
+        trackHistoryChanges: true,
         trackOutboundLinks: true,
         trackFileDownloads: true,
         downloadExtensions: ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'zip', 'rar', 'gz', 'tar', 'exe', 'dmg'],
@@ -486,9 +487,15 @@
         _lastActiveTime: null,
         _isVisible: true,
         _engagementTimer: null,
+        // The path these metrics are being measured on. Held separately from
+        // window.location because an SPA navigation changes location before
+        // the outgoing page's engagement is flushed, and the server matches
+        // the row to update by path.
+        _path: null,
 
         init: function() {
             var self = this;
+            this._path = window.location.pathname;
             this._pageLoadTime = now();
             this._lastActiveTime = now();
             this._reachedMilestones = [];
@@ -613,12 +620,33 @@
             return this._scrollDepth;
         },
 
+        /**
+         * Flush the outgoing page's metrics and re-baseline for a new one.
+         *
+         * Called on SPA navigation. Without it every counter here would keep
+         * accumulating across pages: scroll depth would only ever ratchet up,
+         * time on page would measure the whole session, and the milestone
+         * list would suppress scroll events on every page after the first.
+         */
+        reset: function() {
+            // Flush before re-baselining, while _path still names the page
+            // the metrics were actually measured on.
+            this._sendEngagementData();
+
+            this._path = window.location.pathname;
+            this._pageLoadTime = now();
+            this._lastActiveTime = now();
+            this._engagedTime = 0;
+            this._scrollDepth = 0;
+            this._reachedMilestones = [];
+        },
+
         _sendEngagementData: function() {
             if (!Consent.check()) return;
 
             var data = {
                 session_id: Session.getId(),
-                path: window.location.pathname,
+                path: this._path || window.location.pathname,
                 time_on_page: this.getTimeOnPage(),
                 engaged_time: this.getEngagedTime(),
                 scroll_depth: this.getScrollDepth()
@@ -832,6 +860,9 @@
     var Analytics = {
         version: '1.0.0',
         _initialized: false,
+        // Path + query of the last page view sent, used to ignore history
+        // entries that do not represent a real navigation.
+        _lastTrackedUrl: null,
 
         init: function(userConfig) {
             if (this._initialized) {
@@ -875,8 +906,85 @@
                 });
             }
 
+            // Track History API navigation for SPAs
+            if (config.trackHistoryChanges) {
+                this._trackHistoryChanges();
+            }
+
             this._initialized = true;
             log('Initialized successfully');
+        },
+
+        /**
+         * Detect client-side navigation performed through the History API.
+         *
+         * Hash routing (above) is not how current SPA routers navigate —
+         * Inertia, React Router, Vue Router and wire:navigate all use
+         * pushState. Neither pushState nor replaceState emits an event, so
+         * the only way to observe them is to wrap them; popstate covers
+         * back/forward.
+         */
+        _trackHistoryChanges: function() {
+            var self = this;
+
+            this._lastTrackedUrl = this._currentUrl();
+
+            var onNavigate = function() {
+                // Routers set document.title after pushing the history entry,
+                // so defer a tick — reading it synchronously would attribute
+                // the outgoing page's title to the incoming path.
+                setTimeout(function() {
+                    self._handleHistoryChange();
+                }, 0);
+            };
+
+            if (typeof history.pushState === 'function') {
+                var originalPushState = history.pushState;
+                history.pushState = function() {
+                    var result = originalPushState.apply(this, arguments);
+                    onNavigate();
+                    return result;
+                };
+            }
+
+            if (typeof history.replaceState === 'function') {
+                var originalReplaceState = history.replaceState;
+                history.replaceState = function() {
+                    var result = originalReplaceState.apply(this, arguments);
+                    onNavigate();
+                    return result;
+                };
+            }
+
+            window.addEventListener('popstate', onNavigate);
+        },
+
+        _handleHistoryChange: function() {
+            var url = this._currentUrl();
+
+            // Routers call replaceState for state sync without a real
+            // navigation, and a single move can emit both replaceState and
+            // popstate. Only a changed path or query counts as a new page
+            // view, which collapses both cases to one send.
+            if (url === this._lastTrackedUrl) return;
+
+            this._lastTrackedUrl = url;
+
+            // Close out the previous page before the new page view, so its
+            // scroll depth and time on page do not leak forward.
+            Engagement.reset();
+
+            this.pageView();
+        },
+
+        /**
+         * Identity of the current page for navigation comparison. The hash is
+         * excluded deliberately: hash-only moves are the business of
+         * trackHashChanges, and including it here would double-count when
+         * both options are on.
+         */
+        _currentUrl: function() {
+            return window.location.pathname + window.location.search;
         },
 
         _trackInitialPageView: function() {

--- a/tests/Feature/TrackerSpaNavigationTest.php
+++ b/tests/Feature/TrackerSpaNavigationTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Behavioural coverage for the tracker's History API support.
+ *
+ * The tracker is a browser IIFE with no JS test runner in this package, and
+ * asserting on its source text cannot tell you whether the de-duplication or
+ * the engagement reset actually work. `tests/js/tracker-spa-harness.mjs` runs
+ * the real file inside a Node VM context with a stub DOM and reports the
+ * beacons it emits; these tests assert against that report.
+ *
+ * Skipped when Node is unavailable so the suite still runs on a PHP-only box.
+ */
+
+/**
+ * Run the SPA harness and return its decoded report.
+ *
+ * @param array<string, mixed> $configOverrides Tracker config overrides.
+ *
+ * @return array{initialPageViews: list<string>, steps: list<array{label: string, pageViewPaths: list<string>, engagementUpdates: list<array{path: string|null, scroll_depth: int|null}>}>}
+ */
+function runTrackerHarness( array $configOverrides = [] ): array
+{
+	$node = trim( (string) shell_exec( 'command -v node 2>/dev/null' ) );
+
+	if ( '' === $node ) {
+		test()->markTestSkipped( 'Node is not available; skipping tracker SPA harness.' );
+	}
+
+	$harness = realpath( __DIR__ . '/../js/tracker-spa-harness.mjs' );
+	$tracker = realpath( __DIR__ . '/../../resources/js/tracker.js' );
+
+	expect( $harness )->not->toBeFalse( 'tracker-spa-harness.mjs is missing' );
+	expect( $tracker )->not->toBeFalse( 'resources/js/tracker.js is missing' );
+
+	$command = sprintf(
+		'%s %s %s %s 2>&1',
+		escapeshellarg( $node ),
+		escapeshellarg( (string) $harness ),
+		escapeshellarg( (string) $tracker ),
+		[] === $configOverrides ? '' : escapeshellarg( (string) json_encode( $configOverrides ) ),
+	);
+
+	$output = (string) shell_exec( $command );
+	$report = json_decode( $output, true );
+
+	expect( $report )->toBeArray( "Harness did not return JSON. Output:\n" . $output );
+
+	return $report;
+}
+
+/**
+ * Collect the page view paths recorded for a labelled harness step.
+ *
+ * @param array<string, mixed> $report The harness report.
+ *
+ * @return list<string>
+ */
+function stepPageViews( array $report, string $label ): array
+{
+	foreach ( $report['steps'] as $step ) {
+		if ( $step['label'] === $label ) {
+			return $step['pageViewPaths'];
+		}
+	}
+
+	throw new RuntimeException( "No harness step labelled '{$label}'" );
+}
+
+/**
+ * Collect the engagement updates recorded for a labelled harness step.
+ *
+ * @param array<string, mixed> $report The harness report.
+ *
+ * @return list<array{path: string|null, scroll_depth: int|null}>
+ */
+function stepEngagement( array $report, string $label ): array
+{
+	foreach ( $report['steps'] as $step ) {
+		if ( $step['label'] === $label ) {
+			return $step['engagementUpdates'];
+		}
+	}
+
+	throw new RuntimeException( "No harness step labelled '{$label}'" );
+}
+
+test( 'a pushState navigation records a page view for the new path', function (): void {
+	$report = runTrackerHarness();
+
+	expect( $report['initialPageViews'] )->toBe( [ '/' ] )
+		->and( stepPageViews( $report, 'pushState -> /docs/one' ) )->toBe( [ '/docs/one' ] )
+		->and( stepPageViews( $report, 'pushState -> /docs/two' ) )->toBe( [ '/docs/two' ] );
+} );
+
+test( 'a popstate navigation records a page view', function (): void {
+	$report = runTrackerHarness();
+
+	expect( stepPageViews( $report, 'popstate back -> /docs/one' ) )->toBe( [ '/docs/one' ] );
+} );
+
+test( 'a replaceState that does not change the url records nothing', function (): void {
+	// Routers call replaceState routinely to sync state without navigating.
+	// Treating those as page views would inflate every SPA's numbers.
+	$report = runTrackerHarness();
+
+	expect( stepPageViews( $report, 'replaceState same url (router state sync)' ) )->toBe( [] );
+} );
+
+test( 'a hash-only change is left to trackHashChanges', function (): void {
+	// Otherwise a router that pushes a hash would double-count when both
+	// options are enabled.
+	$report = runTrackerHarness();
+
+	expect( stepPageViews( $report, 'hash-only change on same path' ) )->toBe( [] );
+} );
+
+test( 'a query string change counts as a new page view', function (): void {
+	$report = runTrackerHarness();
+
+	expect( stepPageViews( $report, 'query string change' ) )->toBe( [ '/docs/one' ] );
+} );
+
+test( 'engagement is flushed against the page it was measured on, not the incoming one', function (): void {
+	// location has already changed by the time the navigation handler runs, so
+	// the flush has to use the path Engagement recorded at reset. Getting this
+	// wrong would attribute the outgoing page's scroll depth and time on page
+	// to the incoming path — and the server matches the row to update by path,
+	// so the update would land on the wrong page view or none at all.
+	$report = runTrackerHarness();
+
+	expect( stepEngagement( $report, 'pushState -> /docs/one' ) )
+		->toBe( [ [ 'path' => '/', 'scroll_depth' => 0 ] ] );
+
+	expect( stepEngagement( $report, 'pushState -> /docs/two' ) )
+		->toBe( [ [ 'path' => '/docs/one', 'scroll_depth' => 0 ] ] );
+
+	expect( stepEngagement( $report, 'popstate back -> /docs/one' ) )
+		->toBe( [ [ 'path' => '/docs/two', 'scroll_depth' => 0 ] ] );
+} );
+
+test( 'setting trackHistoryChanges to false restores the previous behaviour', function (): void {
+	// The escape hatch for apps that already bridge their router's navigation
+	// events by hand; without it they would double count.
+	$report = runTrackerHarness( [ 'trackHistoryChanges' => false ] );
+
+	expect( $report['initialPageViews'] )->toBe( [ '/' ] );
+
+	foreach ( $report['steps'] as $step ) {
+		expect( $step['pageViewPaths'] )
+			->toBe( [], "Step '{$step['label']}' should record nothing when trackHistoryChanges is off" );
+	}
+} );

--- a/tests/js/tracker-spa-harness.mjs
+++ b/tests/js/tracker-spa-harness.mjs
@@ -1,0 +1,185 @@
+/**
+ * Drives resources/js/tracker.js inside a controlled VM context and reports
+ * the beacons it emits, so SPA navigation behaviour can be asserted for real
+ * rather than by grepping the source.
+ *
+ * Usage: node tracker-spa-harness.mjs /path/to/tracker.js ['{"trackHistoryChanges":false}']
+ * Emits a JSON report on stdout.
+ */
+import { readFileSync } from 'node:fs';
+import { createContext, runInContext } from 'node:vm';
+
+const trackerPath = process.argv[2];
+const configOverrides = process.argv[3] ? JSON.parse(process.argv[3]) : {};
+
+const beacons = [];
+const windowListeners = {};
+const documentListeners = {};
+
+const location = {
+    pathname: '/',
+    search: '',
+    hash: '',
+    hostname: 'example.test',
+    href: 'https://example.test/',
+    protocol: 'https:',
+};
+
+function applyUrl(url) {
+    if (typeof url !== 'string') return;
+    const [pathAndQuery, hash] = url.split('#');
+    const [pathname, search] = pathAndQuery.split('?');
+    location.pathname = pathname || location.pathname;
+    location.search = search ? '?' + search : '';
+    location.hash = hash ? '#' + hash : '';
+    location.href = 'https://example.test' + location.pathname + location.search + location.hash;
+}
+
+function listenerBag(bag) {
+    return {
+        addEventListener(type, fn) {
+            (bag[type] = bag[type] || []).push(fn);
+        },
+        removeEventListener(type, fn) {
+            bag[type] = (bag[type] || []).filter((f) => f !== fn);
+        },
+    };
+}
+
+const history = {
+    pushState(state, title, url) { applyUrl(url); },
+    replaceState(state, title, url) { applyUrl(url); },
+};
+
+const store = new Map();
+const storage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+};
+
+const stubElement = () => ({
+    style: {},
+    getContext: () => null,
+    setAttribute() {},
+    appendChild() {},
+    removeChild() {},
+    addEventListener() {},
+    getBoundingClientRect: () => ({ top: 0, left: 0, width: 0, height: 0 }),
+});
+
+const document = {
+    ...listenerBag(documentListeners),
+    readyState: 'complete',
+    title: 'Home',
+    referrer: '',
+    cookie: '',
+    hidden: false,
+    visibilityState: 'visible',
+    documentElement: { scrollTop: 0, scrollHeight: 1000, clientHeight: 800 },
+    body: { scrollTop: 0, scrollHeight: 1000, clientHeight: 800, offsetHeight: 1000 },
+    createElement: stubElement,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    getElementById: () => null,
+};
+
+const navigator = {
+    userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+    language: 'en-US',
+    languages: ['en-US'],
+    doNotTrack: null,
+    hardwareConcurrency: 8,
+    sendBeacon(url, data) {
+        let parsed = null;
+        const raw = typeof data === 'string' ? data : data && data.__body;
+        try { parsed = JSON.parse(raw || '{}'); } catch { /* not JSON */ }
+        beacons.push({ url: String(url), data: parsed });
+        return true;
+    },
+};
+
+const screen = { width: 2560, height: 1440, colorDepth: 24 };
+
+const window = {
+    ...listenerBag(windowListeners),
+    location,
+    history,
+    document,
+    navigator,
+    screen,
+    innerWidth: 1440,
+    innerHeight: 900,
+    localStorage: storage,
+    sessionStorage: storage,
+    performance: { now: () => Date.now(), timing: {}, getEntriesByType: () => [] },
+    __ARTISANPACK_ANALYTICS_CONFIG__: Object.assign({
+        endpoint: '/api/analytics',
+        consentRequired: false,
+        respectDNT: false,
+        batchInterval: 20,
+        debug: false,
+    }, configOverrides),
+};
+window.window = window;
+window.self = window;
+
+const context = createContext({
+    window, document, navigator, screen, location, history,
+    localStorage: storage,
+    sessionStorage: storage,
+    performance: window.performance,
+    setTimeout, clearTimeout, setInterval: () => 0, clearInterval: () => {},
+    console, JSON, Math, Date, Intl, URL, Object, Array, String, Number, Error,
+    encodeURIComponent, decodeURIComponent, isNaN, parseInt, parseFloat,
+    Blob: class { constructor(parts) { this.__body = parts.join(''); } },
+    XMLHttpRequest: class {
+        open(method, url) { this.__url = url; }
+        setRequestHeader() {}
+        send(body) {
+            let parsed = null;
+            try { parsed = JSON.parse(body || '{}'); } catch { /* not JSON */ }
+            beacons.push({ url: String(this.__url), data: parsed });
+        }
+    },
+});
+
+runInContext(readFileSync(trackerPath, 'utf8'), context);
+
+const wait = (ms) => new Promise((r) => setTimeout(r, ms));
+const fire = (bag, type) => (bag[type] || []).forEach((fn) => fn({}));
+
+const isPageView = (b) => /\/pageview$/.test(b.url) || /\/batch$/.test(b.url);
+const isUpdate = (b) => /pageview\/update$/.test(b.url);
+
+const pathsOf = (list) => list.flatMap((b) =>
+    b.data && Array.isArray(b.data.items)
+        ? b.data.items.map((i) => i.data && i.data.path)
+        : [b.data && b.data.path]
+).filter(Boolean);
+
+await wait(80);
+const report = { initialPageViews: pathsOf(beacons.filter(isPageView)), steps: [] };
+
+async function step(label, fn) {
+    beacons.length = 0;
+    fn();
+    await wait(80);
+    report.steps.push({
+        label,
+        pageViewPaths: pathsOf(beacons.filter(isPageView)),
+        engagementUpdates: beacons.filter(isUpdate).map((b) => ({
+            path: b.data && b.data.path,
+            scroll_depth: b.data && b.data.scroll_depth,
+        })),
+    });
+}
+
+await step('pushState -> /docs/one', () => history.pushState({}, '', '/docs/one'));
+await step('replaceState same url (router state sync)', () => history.replaceState({}, '', '/docs/one'));
+await step('pushState -> /docs/two', () => history.pushState({}, '', '/docs/two'));
+await step('hash-only change on same path', () => history.pushState({}, '', '/docs/two#section'));
+await step('popstate back -> /docs/one', () => { applyUrl('/docs/one'); fire(windowListeners, 'popstate'); });
+await step('query string change', () => history.pushState({}, '', '/docs/one?page=2'));
+
+console.log(JSON.stringify(report, null, 2));


### PR DESCRIPTION
## Description

The tracker bound page views to the window `load` event and, optionally, `hashchange`. Neither fires on a client-side route change, so in any SPA it recorded the initial document load and nothing else. The `hashchange` branch is commented "Track hash changes for SPAs", but hash routing is not how current routers navigate — Inertia, React Router, Vue Router and `wire:navigate` all use the History API, and there was no listener for it anywhere in the file.

The failure was invisible: analytics looked like it was working, just with implausibly low numbers. Consuming apps had to discover the gap and hand-roll a bridge, without anything in the tracker or its config hinting that one was needed.

**Closes:** #86

## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #86

## Motivation and Context

On a content site a visitor reads several pages per session, so recording only the first under-counts by roughly the average session depth and distorts every metric built on it — top pages, entry/exit paths, session duration, bounce rate.

### A second bug this surfaced

Adding History tracking on its own would have produced *wrong* data rather than missing data, so it is fixed here too.

`Engagement` initialised its state once at boot. Scroll depth, time on page, engaged time and the scroll-milestone list therefore accumulated across the entire session instead of per page: scroll depth could only ratchet upward, time on page measured the whole visit, and milestone events stopped firing after the first page.

Worse, `_sendEngagementData()` read `window.location.pathname` at flush time. On an SPA navigation the location has *already* changed, so the outgoing page's metrics would have been posted against the incoming path — and `TrackingService::updatePageView()` matches the row to update by `path`, so the update would have landed on the wrong page view or silently found none.

`Engagement` now records the path it is measuring and flushes against that path before re-baselining. As a side effect, intermediate SPA pages get engagement data at all, where previously only `beforeunload`/`pagehide` fired and only the last page's (polluted) numbers were ever sent.

## Changes Made

- New `trackHistoryChanges` config option, default `true`.
- Wraps `history.pushState` / `history.replaceState` and listens for `popstate` — none of them emit an observable event, so wrapping is the only way to see them.
- Only a change of path or query string counts as a navigation. This collapses two noisy cases to no-ops: routers calling `replaceState` to sync state without navigating, and a single move emitting both `replaceState` and `popstate`.
- Hash-only changes are ignored and left to `trackHashChanges`, so the two options cannot double count.
- The handler defers a tick before reading `document.title`, because routers set the title *after* pushing the history entry; reading synchronously would attribute the outgoing page's title to the incoming path.
- `Engagement` gains `_path` and `reset()`; `_sendEngagementData()` now attributes to `_path`.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 26 (Darwin 27.0.0)
- Browser (if applicable): N/A — driven headlessly through a Node VM context
- PHP Version: 8.4.13
- Project Version: 1.5.0-dev (branched from `release/1.5`)

**Tests Performed:**
1. `vendor/bin/pest tests/Feature/TrackerSpaNavigationTest.php` — 7 passed (38 assertions).
2. Full suite: **34 failed, 2 skipped, 579 passed**. Baseline on clean `release/1.5` is **34 failed, 2 skipped, 560 passed** — the same 34 pre-existing failures, from optional peers `artisanpack-ui/hooks` and `artisanpack-ui/ai` not being installed. This branch adds 19 passing tests (12 from #85, 7 here) and no new failures.
3. `php-cs-fixer` and `phpcs` clean; `node --check` clean.
4. Verified the opt-out: with `trackHistoryChanges: false` the harness records the initial page view and nothing for any of the six navigation steps.

### On the test approach

This package has no JS test runner, and the existing convention for JS assets is PHP assertions on file *contents*. That cannot tell you whether de-duplication or the engagement reset actually work — a `str_contains` check would pass against a broken implementation.

`tests/js/tracker-spa-harness.mjs` instead runs the real `tracker.js` inside a Node VM context with a stub DOM and a captured `sendBeacon`, then reports the beacons emitted for a scripted sequence of navigations. The PHP test asserts against that report and skips cleanly when Node is unavailable, so a PHP-only environment still runs the rest of the suite.

Scripted sequence and observed result:

| Step | Page view | Engagement flushed against |
|---|---|---|
| initial load | `/` | — |
| `pushState` → `/docs/one` | `/docs/one` | `/` |
| `replaceState` same URL | *none* | — |
| `pushState` → `/docs/two` | `/docs/two` | `/docs/one` |
| hash-only change | *none* | — |
| `popstate` back → `/docs/one` | `/docs/one` | `/docs/two` |
| query string change | `/docs/one` | `/docs/one` |

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — client-side tracking logic with no UI surface.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/TrackerSpaNavigationTest.php` (7 tests) plus the `tests/js/tracker-spa-harness.mjs` driver. Covers pushState, popstate, replaceState de-duplication, hash-only deferral, query-string changes, engagement attribution across three navigations, and the `trackHistoryChanges: false` opt-out.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** `CHANGELOG.md` under `[Unreleased]`. `docs/faq.md` and `docs/usage/tracking-page-views.md` both told readers to enable hash-change tracking for SPA support, which was never going to work for a History-API router — both rewritten. Both also referenced `analytics.trackPageView(path, title)`, a method that does not exist on the tracker; corrected to `analytics.pageView()`.

## Screenshots

N/A

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Note for consumers upgrading

`trackHistoryChanges` defaults to `true`, so SPA page-view counts will rise once this ships. That is the intent, but it is a step change in reported numbers rather than a regression, and it is flagged under Changed in the changelog.

Any app that already bridges its router's navigation events by hand **must** set `trackHistoryChanges: false` or it will count every page view twice. The ArtisanPack UI docs site is one such app — it bridges `inertia:navigate` in `resources/js/lib/analytics.ts` and will need updating when it takes this version.
