### PR TITLE
feat: render active providers' client-side tracker scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`@analyticsScripts` now emits the client-side snippets of active providers.** Providers whose tracking half runs in the browser can expose it through the new `ProvidesTrackerScript` contract, and the directive renders it alongside the package's own tracker. Previously nothing in this package ever called a provider's `trackerScript()`, so such a provider could be registered, listed in `active_providers`, and report success while contributing nothing in either direction — its server-side track methods are no-ops by design, and its snippet never reached the page. Providers exposing a `trackerScript()` method without implementing the contract are also honoured, so `artisanpack-ui/analytics-google` 1.0 works without a matching release. A provider that throws while producing its snippet is logged and skipped rather than taking down the page. ([#88](https://github.com/ArtisanPack-UI/analytics/issues/88))
+- `Analytics::trackerScripts()` returns the collected snippets for callers rendering their own markup.
 - **SPA navigation tracking.** The JS tracker now detects History API navigation (`pushState`, `replaceState`, `popstate`) — the mechanism Inertia, React Router, Vue Router and `wire:navigate` all navigate through — and records a page view whenever the path or query string changes. Previously page views were bound to the window `load` event and `hashchange` only, so in any SPA the tracker recorded the initial document load and nothing else; hash routing is not how current routers work. Controlled by the new `trackHistoryChanges` option, default `true`. ([#86](https://github.com/ArtisanPack-UI/analytics/issues/86))
 
 ### Fixed

--- a/docs/advanced/multiple-providers.md
+++ b/docs/advanced/multiple-providers.md
@@ -193,6 +193,52 @@ public function boot(): void
 ANALYTICS_ACTIVE_PROVIDERS=local,mixpanel
 ```
 
+### Providers That Track In The Browser
+
+Some providers cannot record anything server-side — their tracking half is a
+vendor snippet that has to reach the page, so `trackPageView()` and
+`trackEvent()` are necessarily no-ops. Those providers implement
+`ProvidesTrackerScript`, and `@analyticsScripts` emits what they return
+alongside the package's own tracker:
+
+```php
+use ArtisanPackUI\Analytics\Contracts\AnalyticsProviderInterface;
+use ArtisanPackUI\Analytics\Contracts\ProvidesTrackerScript;
+
+class VendorPixelProvider implements AnalyticsProviderInterface, ProvidesTrackerScript
+{
+    public function trackPageView( PageViewData $data ): void
+    {
+        // Nothing to do — the snippet below records page views in the browser.
+    }
+
+    public function trackerScript(): string
+    {
+        if ( ! $this->isEnabled() ) {
+            return '';
+        }
+
+        return '<script src="https://vendor.example/pixel.js" async></script>';
+    }
+
+    // ... the rest of AnalyticsProviderInterface
+}
+```
+
+Two things to know:
+
+- The return value is echoed **unescaped**, because it is script markup. Any
+  value interpolated into it — a measurement ID, a config option — must be
+  encoded by the provider.
+- Return an empty string when the provider is not configured. Empty snippets
+  are skipped, and a provider that throws is logged and skipped rather than
+  breaking the page it was rendering into.
+
+The snippets are only emitted where `@analyticsScripts` (or
+`<x-analytics::tracker-script />`) appears, and only for providers listed in
+`active_providers`. To render them yourself, call
+`Analytics::trackerScripts()`, which returns them as an array.
+
 ## Provider Methods
 
 ### Get a Specific Provider

--- a/resources/views/components/tracker-script.blade.php
+++ b/resources/views/components/tracker-script.blade.php
@@ -40,4 +40,15 @@
         </script>
     @endif
     <script src="{{ $scriptPath }}" {{ implode( ' ', $attributes ) }}></script>
+
+    {{--
+        Client-side snippets contributed by active providers (see
+        ProvidesTrackerScript). Emitted unescaped because they are script
+        markup; each provider is responsible for encoding anything it
+        interpolates. Without this, a provider whose tracking half runs in
+        the browser registers successfully and then contributes nothing.
+    --}}
+    @foreach ( \ArtisanPackUI\Analytics\Facades\Analytics::trackerScripts() as $providerScript )
+        {!! $providerScript !!}
+    @endforeach
 @endif

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -7,6 +7,7 @@ namespace ArtisanPackUI\Analytics;
 use ArtisanPackUI\Analytics\Contracts\AnalyticsProviderInterface;
 use ArtisanPackUI\Analytics\Contracts\AnalyticsQueryInterface;
 use ArtisanPackUI\Analytics\Contracts\AnalyticsServiceInterface;
+use ArtisanPackUI\Analytics\Contracts\ProvidesTrackerScript;
 use ArtisanPackUI\Analytics\Data\DateRange;
 use ArtisanPackUI\Analytics\Data\EventData;
 use ArtisanPackUI\Analytics\Data\PageViewData;
@@ -18,6 +19,7 @@ use ArtisanPackUI\Analytics\Models\Visitor;
 use ArtisanPackUI\Analytics\Providers\AbstractAnalyticsProvider;
 use BadMethodCallException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 /**
@@ -291,6 +293,57 @@ class Analytics implements AnalyticsQueryInterface, AnalyticsServiceInterface
         }
 
         return $providers;
+    }
+
+    /**
+     * Collect the client-side snippets of every active provider.
+     *
+     * Providers whose tracking half runs in the browser expose it through
+     * {@see ProvidesTrackerScript}. Without this, such a provider could be
+     * registered and listed in `active_providers` and still contribute
+     * nothing at all — its server-side track methods are no-ops by design,
+     * and nothing rendered its snippet, so it failed silently in both
+     * directions.
+     *
+     * Providers that expose a `trackerScript()` method without implementing
+     * the interface are also honoured. `artisanpack-ui/analytics-google` 1.0
+     * shipped before the contract existed, and requiring a matching release
+     * of every sibling package before any snippet renders would defeat the
+     * point of fixing this.
+     *
+     * A provider that throws is skipped rather than allowed to take down the
+     * page it was being rendered into.
+     *
+     * @return list<string> The non-empty snippets, in active-provider order.
+     *
+     * @since 1.5.0
+     */
+    public function trackerScripts(): array
+    {
+        $scripts = [];
+
+        foreach ( $this->getActiveProviders() as $provider ) {
+            if ( ! $provider instanceof ProvidesTrackerScript && ! method_exists( $provider, 'trackerScript' ) ) {
+                continue;
+            }
+
+            try {
+                $script = (string) $provider->trackerScript();
+            } catch ( Throwable $e ) {
+                Log::error( 'Analytics provider tracker script failed', [
+                    'provider' => $provider->getName(),
+                    'error'    => $e->getMessage(),
+                ] );
+
+                continue;
+            }
+
+            if ( '' !== trim( $script ) ) {
+                $scripts[] = $script;
+            }
+        }
+
+        return $scripts;
     }
 
     /**

--- a/src/Contracts/ProvidesTrackerScript.php
+++ b/src/Contracts/ProvidesTrackerScript.php
@@ -1,0 +1,38 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Contracts;
+
+/**
+ * Optional capability for providers whose tracking runs in the browser.
+ *
+ * A provider implementing {@see AnalyticsProviderInterface} is asked to record
+ * page views and events server-side. Some providers cannot: their tracking
+ * half is a vendor snippet that has to reach the page, and their server-side
+ * track methods are necessarily no-ops. Those providers implement this
+ * interface, and `@analyticsScripts` emits whatever they return alongside the
+ * package's own tracker.
+ *
+ * Implementations are responsible for the safety of the markup they return.
+ * The output is echoed unescaped, so anything interpolated into it — a
+ * measurement ID, a config value — must be encoded by the implementation.
+ *
+ * @since   1.5.0
+ *
+ * @package ArtisanPackUI\Analytics\Contracts
+ */
+interface ProvidesTrackerScript
+{
+	/**
+	 * The client-side snippet to emit for this provider.
+	 *
+	 * Return an empty string when the provider is not configured; callers
+	 * emit the result verbatim and do not filter it.
+	 *
+	 * @return string
+	 *
+	 * @since 1.5.0
+	 */
+	public function trackerScript(): string;
+}

--- a/src/Facades/Analytics.php
+++ b/src/Facades/Analytics.php
@@ -29,6 +29,7 @@ use Illuminate\Support\Facades\Facade;
  * @method static AnalyticsManager extend(string $name, callable $creator)
  * @method static AnalyticsProviderInterface provider(?string $name = null)
  * @method static Collection getActiveProviders()
+ * @method static list<string> trackerScripts()
  * @method static string getDefaultProvider()
  * @method static AnalyticsManager setDefaultProvider(string $name)
  * @method static array getProviderNames()

--- a/tests/Feature/ProviderTrackerScriptTest.php
+++ b/tests/Feature/ProviderTrackerScriptTest.php
@@ -1,0 +1,248 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\Contracts\AnalyticsProviderInterface;
+use ArtisanPackUI\Analytics\Contracts\ProvidesTrackerScript;
+use ArtisanPackUI\Analytics\Data\EventData;
+use ArtisanPackUI\Analytics\Data\PageViewData;
+use ArtisanPackUI\Analytics\Facades\Analytics;
+use Illuminate\Support\Facades\Blade;
+
+/**
+ * A provider whose tracking half runs in the browser, declared through the
+ * contract. Its server-side track methods are no-ops by design — which is
+ * exactly why nothing rendering its snippet meant it contributed nothing at
+ * all, in either direction, without failing.
+ */
+final class ContractedScriptProvider implements AnalyticsProviderInterface, ProvidesTrackerScript
+{
+	public function __construct( private string $name = 'contracted', private string $script = '<script>contracted()</script>' )
+	{
+	}
+
+	public function trackPageView( PageViewData $data ): void
+	{
+	}
+
+	public function trackEvent( EventData $data ): void
+	{
+	}
+
+	public function isEnabled(): bool
+	{
+		return true;
+	}
+
+	public function getName(): string
+	{
+		return $this->name;
+	}
+
+	/** @return array<string, mixed> */
+	public function getConfig(): array
+	{
+		return [];
+	}
+
+	public function trackerScript(): string
+	{
+		return $this->script;
+	}
+}
+
+/**
+ * A provider exposing trackerScript() without implementing the contract, as
+ * artisanpack-ui/analytics-google 1.0 does — it shipped before the interface
+ * existed.
+ */
+final class DuckTypedScriptProvider implements AnalyticsProviderInterface
+{
+	public function trackPageView( PageViewData $data ): void
+	{
+	}
+
+	public function trackEvent( EventData $data ): void
+	{
+	}
+
+	public function isEnabled(): bool
+	{
+		return true;
+	}
+
+	public function getName(): string
+	{
+		return 'duck-typed';
+	}
+
+	/** @return array<string, mixed> */
+	public function getConfig(): array
+	{
+		return [];
+	}
+
+	public function trackerScript(): string
+	{
+		return '<script>duckTyped()</script>';
+	}
+}
+
+/**
+ * A provider that offers no snippet at all — the ordinary server-side case.
+ */
+final class ServerOnlyProvider implements AnalyticsProviderInterface
+{
+	public function trackPageView( PageViewData $data ): void
+	{
+	}
+
+	public function trackEvent( EventData $data ): void
+	{
+	}
+
+	public function isEnabled(): bool
+	{
+		return true;
+	}
+
+	public function getName(): string
+	{
+		return 'server-only';
+	}
+
+	/** @return array<string, mixed> */
+	public function getConfig(): array
+	{
+		return [];
+	}
+}
+
+/**
+ * Register providers and mark them active.
+ *
+ * @param array<string, AnalyticsProviderInterface> $providers Keyed by name.
+ */
+function registerActiveProviders( array $providers ): void
+{
+	$analytics = app( ArtisanPackUI\Analytics\Analytics::class );
+
+	foreach ( $providers as $name => $provider ) {
+		$analytics->extend( $name, fn (): AnalyticsProviderInterface => $provider );
+	}
+
+	config()->set( 'artisanpack.analytics.active_providers', array_keys( $providers ) );
+}
+
+test( 'a provider implementing the contract has its snippet collected', function (): void {
+	registerActiveProviders( [ 'contracted' => new ContractedScriptProvider() ] );
+
+	expect( Analytics::trackerScripts() )->toBe( [ '<script>contracted()</script>' ] );
+} );
+
+test( 'a provider exposing trackerScript without the contract is still honoured', function (): void {
+	// analytics-google 1.0 predates the interface. Requiring a matching release
+	// of every sibling package before any snippet renders would defeat the
+	// point of fixing this.
+	registerActiveProviders( [ 'duck-typed' => new DuckTypedScriptProvider() ] );
+
+	expect( Analytics::trackerScripts() )->toBe( [ '<script>duckTyped()</script>' ] );
+} );
+
+test( 'providers without a snippet contribute nothing and do not error', function (): void {
+	registerActiveProviders( [ 'server-only' => new ServerOnlyProvider() ] );
+
+	expect( Analytics::trackerScripts() )->toBe( [] );
+} );
+
+test( 'snippets are collected from every active provider in order', function (): void {
+	registerActiveProviders( [
+		'contracted'  => new ContractedScriptProvider(),
+		'server-only' => new ServerOnlyProvider(),
+		'duck-typed'  => new DuckTypedScriptProvider(),
+	] );
+
+	expect( Analytics::trackerScripts() )->toBe( [
+		'<script>contracted()</script>',
+		'<script>duckTyped()</script>',
+	] );
+} );
+
+test( 'an unconfigured provider returning an empty snippet is skipped', function (): void {
+	registerActiveProviders( [
+		'blank'      => new ContractedScriptProvider( 'blank', '   ' ),
+		'contracted' => new ContractedScriptProvider(),
+	] );
+
+	expect( Analytics::trackerScripts() )->toBe( [ '<script>contracted()</script>' ] );
+} );
+
+test( 'a provider that is registered but not active contributes nothing', function (): void {
+	$analytics = app( ArtisanPackUI\Analytics\Analytics::class );
+	$analytics->extend( 'contracted', fn (): AnalyticsProviderInterface => new ContractedScriptProvider() );
+
+	config()->set( 'artisanpack.analytics.active_providers', [ 'local' ] );
+
+	expect( Analytics::trackerScripts() )->not->toContain( '<script>contracted()</script>' );
+} );
+
+test( 'a throwing provider is skipped rather than taking down the page', function (): void {
+	$exploding = new class implements AnalyticsProviderInterface, ProvidesTrackerScript {
+		public function trackPageView( PageViewData $data ): void
+		{
+		}
+
+		public function trackEvent( EventData $data ): void
+		{
+		}
+
+		public function isEnabled(): bool
+		{
+			return true;
+		}
+
+		public function getName(): string
+		{
+			return 'exploding';
+		}
+
+		/** @return array<string, mixed> */
+		public function getConfig(): array
+		{
+			return [];
+		}
+
+		public function trackerScript(): string
+		{
+			throw new RuntimeException( 'provider blew up' );
+		}
+	};
+
+	registerActiveProviders( [
+		'exploding'  => $exploding,
+		'contracted' => new ContractedScriptProvider(),
+	] );
+
+	expect( Analytics::trackerScripts() )->toBe( [ '<script>contracted()</script>' ] );
+} );
+
+test( 'the @analyticsScripts directive emits provider snippets alongside the package tracker', function (): void {
+	// The regression this fixes: the directive rendered only the package's own
+	// tracker and never asked providers for theirs, so the seam was dangling at
+	// both ends with nothing to indicate it.
+	registerActiveProviders( [ 'contracted' => new ContractedScriptProvider() ] );
+
+	$rendered = Blade::render( '@analyticsScripts' );
+
+	expect( $rendered )
+		->toContain( '<script>contracted()</script>' )
+		->toContain( 'analytics' );
+} );
+
+test( 'provider snippets are not emitted when analytics is disabled', function (): void {
+	registerActiveProviders( [ 'contracted' => new ContractedScriptProvider() ] );
+
+	config()->set( 'artisanpack.analytics.enabled', false );
+
+	expect( Blade::render( '@analyticsScripts' ) )->not->toContain( '<script>contracted()</script>' );
+} );


### PR DESCRIPTION
## Description

Providers whose tracking half runs in the browser could expose a `trackerScript()` method, and `artisanpack-ui/analytics-google` does — with a docblock pointing at *"the parent's `@analyticsScripts` output"*. Nothing in this package ever called it. `@analyticsScripts` rendered only the package's own tracker and never asked providers for theirs, so the seam was dangling at both ends; grepping this package for `trackerScript` returned no consumers at all.

The failure mode is silent and expensive to diagnose. Such a provider registers successfully, appears in `active_providers`, reports `isEnabled()` true — and contributes nothing in either direction, because its server-side track methods are no-ops by design and its snippet never reaches the page. From the consuming app it reads as a configuration problem, and it cost a real debugging session to establish that the measurement ID was set, the provider was registered, and there was simply no code path to put the snippet anywhere.

**Closes:** #88

## Type of Change

- [ ] Bug fix (fixes an issue)
- [x] New feature (adds new functionality)
- [x] Enhancement (improves existing functionality)
- [ ] Refactoring (code improvement, no behavior change)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Security fix
- [ ] Breaking change (breaks backward compatibility)

## Related Issue

**Issue:** #88

## Motivation and Context

A provider that registers and then does nothing, with no error and no warning, is the worst shape a failure can take — it looks like success everywhere you would think to check.

Beyond closing the gap, this makes the client-side route to GA4 actually work: with this merged, adding `google-ga4` to `active_providers` emits the gtag snippet through the parent's consent gate, which is what `analytics-google` was built expecting. That is complementary to the Measurement Protocol work in ArtisanPack-UI/analytics-google#15, not a replacement — client-side gtag carries referrer, geo, device and session attribution that the Measurement Protocol does not.

## Changes Made

- New `ProvidesTrackerScript` contract, so the capability is discoverable and type-checked rather than duck-typed.
- New `Analytics::trackerScripts(): list<string>`, collecting the snippets of every active provider.
- `@analyticsScripts` (and `<x-analytics::tracker-script />`) emits them after the package's own tracker.
- Providers exposing `trackerScript()` **without** implementing the contract are also honoured. `analytics-google` 1.0 shipped before the interface existed, and requiring a matching release of every sibling package before any snippet renders would defeat the point.
- Empty snippets are skipped, so an unconfigured provider emits nothing.
- A provider that throws while producing its snippet is logged and skipped, rather than taking down the page it was being rendered into.

### On escaping

Snippets are echoed unescaped, because they are `<script>` markup — there is no way to render them otherwise. The contract documents that implementations own the encoding of anything they interpolate into that markup, which is the same position the existing `Gtag` renderer in `analytics-google` already takes.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 26 (Darwin 27.0.0)
- Browser (if applicable): N/A — server-rendered output
- PHP Version: 8.4.13
- Project Version: 1.5.0-dev (branched from `release/1.5`)

**Tests Performed:**
1. `vendor/bin/pest tests/Feature/ProviderTrackerScriptTest.php` — 9 passed.
2. **Confirmed the tests are not vacuous.** Reverting `src/` and `resources/views/` makes 8 of the 9 fail; the one that still passes is the analytics-disabled case, which asserts an absence and would pass either way.
3. Full suite: **34 failed, 2 skipped, 588 passed**. Baseline on clean `release/1.5` is **34 failed, 2 skipped, 560 passed** — the same pre-existing failures from optional peers `artisanpack-ui/hooks` and `artisanpack-ui/ai` not being installed. This branch adds 28 passing tests across #85, #86 and #88, and no new failures.
4. `php-cs-fixer` and `phpcs` clean.

## Accessibility Tests Run

- [ ] Keyboard navigation tested
- [ ] Screen reader tested
- [ ] Color contrast verified
- [ ] ARIA labels checked

**Details:** Not applicable — emits script tags, no rendered UI.

## Tests Added

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** `tests/Feature/ProviderTrackerScriptTest.php` (9 tests) with three stub providers — one implementing the contract, one duck-typed like `analytics-google` 1.0, one server-only. Covers collection via the contract, via the bare method, ordering across several providers, providers with no snippet, unconfigured providers returning an empty string, a registered-but-inactive provider, a provider that throws, end-to-end rendering through `@analyticsScripts`, and suppression when analytics is disabled.

## Documentation

- [x] Inline code documentation added
- [ ] README updated
- [ ] Wiki updated
- [ ] API documentation updated

**Documentation details:** `CHANGELOG.md` under `[Unreleased]`. `docs/advanced/multiple-providers.md` gains a "Providers That Track In The Browser" section covering the contract, the escaping responsibility, the empty-string convention, and `Analytics::trackerScripts()` for callers rendering their own markup.

## Screenshots

N/A

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [ ] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated

## Note for consumers

Any app that already added a provider to `active_providers` **and** hand-rolled that provider's snippet into its own layout will start emitting it twice. Nothing renders a provider snippet today, so nothing can regress from the package's side — but the duplicate is worth checking for on upgrade.
