### PR TITLE
refactor: bind TenantManager against the core SiteResolver contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Site resolution now happens once for the whole ArtisanPack UI ecosystem, in `artisanpack-ui/core`.** `TenantManager` no longer owns a resolver chain: it reads `ArtisanPackUI\Core\MultiTenancy\SiteContext` and looks the `Site` model up from the identifier that contract hands back. Before this, every package that scoped data by site kept its own resolver shape and its own configuration — this package resolved a `Site` from a `Request`, `artisanpack-ui/bookings` resolved an `int` from a single configured class — so an application installing both configured tenancy twice, in shapes that could not share a source of truth, and one request could resolve to site 2 here while resolving to site 1 there, silently. A site pinned through `TenantManager` is now pinned for every package, and a site pinned by another package is seen here. ([#94](https://github.com/ArtisanPack-UI/analytics/issues/94))
+- Resolvers are configured at `artisanpack.core.multi_tenant.resolvers` and asked in the order they are listed. `priority()` no longer orders anything: a chain assembled from several packages' resolvers cannot be ordered by a number only one of those packages knows about.
+- `TenantManager::forSite()` accepts a bare site identifier as well as a `Site`, so a console command or job holding only an ID need not load the model to scope its work.
+- `TenantManager` is bound `scoped` rather than `singleton`, matching the context it wraps, so a site pinned by one queue job cannot scope the next job in the same worker.
+- The middleware, the `BelongsToSite` trait, and the `analyticsSite()` / `analyticsTenantId()` helpers all read the shared context. The trait's undocumented `artisanpack.analytics.multi_site.resolver` fallback is gone — it was a second resolver reachable only from that trait, able to disagree with the one every other query used.
+- Requires `artisanpack-ui/core` `^1.3`, which owns the shared contract.
+- **Resolvers now decide the site for every package, so their trust assumptions travel.** `HeaderResolver` believes whatever `X-Site-ID` the caller sends, and `ApiKeyResolver` with `allow_query_api_key` reads a credential from the query string; both previously only affected analytics. List them only where that is intended — authenticated ingest and API routes — and prefer resolvers keyed on something the caller cannot choose for routes serving site-scoped data. This applies to the deprecated analytics resolver list too, which the bridge carries onto the shared one.
+- Applying the `analytics.site` middleware matters more than it did. Scoped queries in a request that never runs it re-run the resolver chain per query, because resolvers are asked afresh by design; the middleware resolves once and pins the result. The upside of the same change: a request without that middleware is now scoped correctly rather than silently unscoped, which is what 1.4 did when nothing had called `resolve()`.
+
+### Fixed
+
+- `analyticsSite()` and `analyticsTenantId()` called `TenantManager::currentSite()` and `currentTenantId()`, neither of which has ever existed, so both helpers raised `BadMethodCallException` whenever multi-tenancy was enabled.
+- Site-scoped queries in a request that never ran the `analytics.site` middleware were not scoped at all: the global scope only applied when something had already called `TenantManager::resolve()`, so one site's dashboard could show another's rows. Scoping now follows the shared context whether or not the middleware ran.
+- A site identifier from another package that is not an analytics site ID (a slug, say) leaves analytics queries unscoped and logs once, rather than falling through to `default_site_id` and filing the work under the wrong site.
+- The site-scoping global scope no longer issues a `sites` lookup per query. `TenantManager` caches the loaded `Site` against the identifier it was loaded for, so the cache invalidates itself the moment the context's answer changes.
+- `multi_tenant.default_site_id` no longer stands in for an explicitly requested "no site": `withoutSite()`, `allSites()`, and `setCurrent( null )` mean no scoping, and a report meant to run across every site can no longer be quietly confined to one.
+
+### Deprecated
+
+- `artisanpack.analytics.multi_tenant.enabled` and `.resolvers`, in favour of `artisanpack.core.multi_tenant.enabled` and `.resolvers`. Both are still honoured: while the analytics flag is on, it switches the shared flag on and its resolver list is prepended to the shared one at boot, so an upgrade keeps resolving the site it always did rather than silently pooling every site's visits into one dashboard. A notice is logged when this happens. Removed in 2.0.
+- `Contracts\SiteResolverInterface`, which now extends `ArtisanPackUI\Core\Contracts\SiteResolver`, along with its `resolve( Request ): ?Site` and `priority()` methods. Extend the new `Resolvers\AbstractSiteResolver` to keep a request-shaped resolver working — it implements `currentSiteId()` in terms of `resolve()`. Removed in 2.0.
+- `Contracts\TenantResolverInterface` and `artisanpack.analytics.multi_tenant.resolver`. Kept because a tenant is not always a site — the interface carries its own column name — but it is consulted only by the `TenantResolver` middleware, and only when nothing has put a site in the shared context, so it cannot decide what queries are scoped to. Where a tenant is a site, implement core's `SiteResolver`.
+- `TenantManager::resolve( Request )`, now an alias for `current()` that ignores its argument. Resolvers read the request from the container themselves, because a resolver that requires one is unusable from the console commands and queue workers where per-site iteration happens.
+
+### Removed
+
+- `TenantManager::registerResolver()` and `registerResolversFromConfig()`. Registering a resolver only this package could see is what the shared context exists to prevent; list resolvers under `artisanpack.core.multi_tenant.resolvers` instead. `getResolvers()` remains and now reports the shared chain.
+
 ### Added
 
 - **Anonymous mode: page views from visitors who have not granted consent.** Off by default; enable with `privacy.anonymous_mode` (`ANALYTICS_ANONYMOUS_MODE`) plus `anonymousMode: true` in the client config. Previously a visitor who ignored the consent banner produced nothing at all, so on a site where most visitors ignore it most traffic was invisible. Anonymous hits are written to a new `analytics_anonymous_page_views` table holding path, title, referring host, device class and timestamp — and no visitor ID, session ID, fingerprint, IP or user agent. The table has no column able to hold an identifier, so two rows cannot be correlated to one person even by mistake. In the browser nothing is written either: the visitor, session and fingerprint setup is never called, so no cookie or `localStorage` key is created before consent. Granting consent mid-visit upgrades to normal tracking; rows already recorded stay anonymous and are never back-filled. An explicit `DNT: 1` / `Sec-GPC: 1` opt-out still suppresses everything, anonymous mode included. ([#87](https://github.com/ArtisanPack-UI/analytics/issues/87))

--- a/README.md
+++ b/README.md
@@ -252,10 +252,11 @@ return [
         'aggregate_before_delete' => true,
     ],
 
-    // Multi-tenant settings
+    // Multi-tenant settings. Since 1.5.0, 'enabled' and the resolver list
+    // live under artisanpack.core.multi_tenant, shared with every other
+    // ArtisanPack UI package; the keys here are deprecated but still honoured.
     'multi_tenant' => [
         'enabled' => false,
-        'resolver' => 'domain', // domain, subdomain, api_key, header
     ],
 
     // Dashboard settings
@@ -413,27 +414,41 @@ Analytics::extend('mixpanel', function ($app) {
 
 ### Custom Site Resolvers (Multi-Tenant)
 
-Create custom resolvers by implementing `SiteResolverInterface`:
+Which site a request is for is decided once for the whole ArtisanPack UI
+ecosystem, by `artisanpack-ui/core`. Implement its contract, which is keyed on
+the site identifier so packages need not share models:
 
 ```php
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
+use ArtisanPackUI\Core\Contracts\SiteResolver;
 use Illuminate\Http\Request;
 
-class TeamResolver implements SiteResolverInterface
+class TeamResolver implements SiteResolver
 {
-    public function resolve(Request $request): ?Site
+    public function __construct(private Request $request)
     {
-        $teamId = $request->user()?->current_team_id;
-        return Site::where('team_id', $teamId)->first();
+    }
+
+    public function currentSiteId(): int|string|null
+    {
+        $teamId = $this->request->user()?->current_team_id;
+
+        return Site::where('team_id', $teamId)->value('id');
     }
 }
 
-// Register in config
-'multi_tenant' => [
-    'enabled' => true,
-    'resolver' => App\Analytics\TeamResolver::class,
+// Register in config/artisanpack.php
+'core' => [
+    'multi_tenant' => [
+        'enabled' => true,
+        'resolvers' => [
+            App\Analytics\TeamResolver::class,
+        ],
+    ],
 ],
 ```
+
+See [Multi-Tenancy](docs/advanced/multi-tenancy.md) for migrating a resolver
+written against the deprecated `SiteResolverInterface`.
 
 ### Filter Hooks
 

--- a/README.md
+++ b/README.md
@@ -252,9 +252,21 @@ return [
         'aggregate_before_delete' => true,
     ],
 
-    // Multi-tenant settings. Since 1.5.0, 'enabled' and the resolver list
-    // live under artisanpack.core.multi_tenant, shared with every other
-    // ArtisanPack UI package; the keys here are deprecated but still honoured.
+    // Multi-tenant settings. Since 1.5.0, whether site scoping is on and
+    // which resolvers decide the site are configured once for every
+    // ArtisanPack UI package, in config/artisanpack.php:
+    //
+    //     'core' => [
+    //         'multi_tenant' => [
+    //             'enabled'   => env('ARTISANPACK_MULTI_TENANT_ENABLED', false),
+    //             'resolvers' => [
+    //                 ArtisanPackUI\Analytics\Resolvers\DomainResolver::class,
+    //             ],
+    //         ],
+    //     ],
+    //
+    // The keys below are deprecated compatibility settings, still honoured
+    // and carried onto the shared configuration at boot.
     'multi_tenant' => [
         'enabled' => false,
     ],
@@ -419,6 +431,7 @@ ecosystem, by `artisanpack-ui/core`. Implement its contract, which is keyed on
 the site identifier so packages need not share models:
 
 ```php
+use ArtisanPackUI\Analytics\Models\Site;
 use ArtisanPackUI\Core\Contracts\SiteResolver;
 use Illuminate\Http\Request;
 
@@ -431,6 +444,12 @@ class TeamResolver implements SiteResolver
     public function currentSiteId(): int|string|null
     {
         $teamId = $this->request->user()?->current_team_id;
+
+        // Return before querying. A null $teamId would become
+        // where team_id is null, which matches unassigned sites.
+        if ($teamId === null) {
+            return null;
+        }
 
         return Site::where('team_id', $teamId)->value('id');
     }

--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
   "require": {
     "php": "^8.2",
     "artisanpack-ui/ai": "^1.0",
+    "artisanpack-ui/core": "^1.3",
     "artisanpack-ui/hooks": "^1.3",
     "doctrine/dbal": "^4.0",
     "illuminate/cache": "^11.0|^12.0|^13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b6be0e62a7262da2a3e63eef6c25d51b",
+    "content-hash": "ff845afa396944fdf4064a2aa469ed24",
     "packages": [
         {
             "name": "artisanpack-ui/ai",
@@ -80,21 +80,21 @@
         },
         {
             "name": "artisanpack-ui/core",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ArtisanPack-UI/core.git",
-                "reference": "bb7055c4b250612d987398f990b5537fbc28865b"
+                "reference": "2e18d700745aa331683fa5c6afb7864fe355798b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/bb7055c4b250612d987398f990b5537fbc28865b",
-                "reference": "bb7055c4b250612d987398f990b5537fbc28865b",
+                "url": "https://api.github.com/repos/ArtisanPack-UI/core/zipball/2e18d700745aa331683fa5c6afb7864fe355798b",
+                "reference": "2e18d700745aa331683fa5c6afb7864fe355798b",
                 "shasum": ""
             },
             "require": {
                 "composer/semver": "^3.0",
-                "illuminate/support": "^11.0|^12.0|^13.0",
+                "illuminate/support": "^12.0|^13.0",
                 "laravel/prompts": "^0.3",
                 "php": "^8.2"
             },
@@ -104,10 +104,13 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "friendsofphp/php-cs-fixer": "^3.75",
                 "laravel/pint": "^1.27",
-                "orchestra/testbench": "^9.0|^10.0|^11.0",
+                "orchestra/testbench": "^10.0|^11.0",
                 "pestphp/pest": "^3.8|^4.0",
                 "pestphp/pest-plugin-laravel": "^3.1|^4.0",
                 "squizlabs/php_codesniffer": "3.11.3"
+            },
+            "suggest": {
+                "artisanpack-ui/hooks": "Required for HookSiteResolver to resolve the current site through the ap.cmsFramework.currentSite.resolve filter."
             },
             "type": "library",
             "extra": {
@@ -115,6 +118,7 @@
                     "aliases": {
                         "Core": "ArtisanPackUI\\Core\\Facades\\Core",
                         "ArtisanPackLog": "ArtisanPackUI\\Core\\Facades\\ArtisanPackLog",
+                        "ArtisanPackSite": "ArtisanPackUI\\Core\\Facades\\ArtisanPackSite",
                         "ArtisanPackConfig": "ArtisanPackUI\\Core\\Facades\\ArtisanPackConfig"
                     },
                     "providers": [
@@ -143,9 +147,9 @@
             "description": "Supplies the core functionality for ArtisanPack UI that needs to be shared across all packages.",
             "support": {
                 "issues": "https://github.com/ArtisanPack-UI/core/issues",
-                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.2.0"
+                "source": "https://github.com/ArtisanPack-UI/core/tree/v1.3.0"
             },
-            "time": "2026-05-24T02:53:50+00:00"
+            "time": "2026-08-08T17:13:56+00:00"
         },
         {
             "name": "artisanpack-ui/hooks",

--- a/config/analytics.php
+++ b/config/analytics.php
@@ -754,6 +754,11 @@ return [
         |
         | Enable multi-tenant support for analytics data isolation.
         |
+        | Deprecated since 1.5.0 in favour of
+        | artisanpack.core.multi_tenant.enabled, which switches site scoping on
+        | for every ArtisanPack UI package at once. Either flag enables it here;
+        | switching this one on also switches the shared one on.
+        |
         */
         'enabled' => env( 'ANALYTICS_MULTI_TENANT', false ),
 
@@ -775,7 +780,12 @@ return [
         | Class responsible for resolving the current tenant. Must implement
         | ArtisanPackUI\Analytics\Contracts\TenantResolverInterface.
         |
-        | Note: Consider using the 'resolvers' array below for more flexibility.
+        | Deprecated since 1.5.0. It is consulted only by the TenantResolver
+        | middleware, and only when nothing has put a site in the shared
+        | context — so it cannot decide what queries are scoped to. Unless your
+        | tenants are genuinely not sites, implement
+        | ArtisanPackUI\Core\Contracts\SiteResolver and list it under
+        | artisanpack.core.multi_tenant.resolvers instead.
         |
         */
         'resolver' => env( 'ANALYTICS_TENANT_RESOLVER' ),
@@ -785,14 +795,22 @@ return [
         | Site Resolvers
         |----------------------------------------------------------------------
         |
-        | Array of resolver classes to use for site resolution. Resolvers
-        | are tried in priority order (lower numbers first).
+        | Deprecated since 1.5.0. Site resolution is shared across every
+        | ArtisanPack UI package and configured at
+        | artisanpack.core.multi_tenant.resolvers; move this list there, where
+        | resolvers are asked in the order they are listed. Two packages
+        | keeping separate resolver lists is how one request came to be site 2
+        | for analytics and site 1 for another package.
         |
-        | Available resolvers:
-        | - ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver (priority: 10)
-        | - ArtisanPackUI\Analytics\Resolvers\HeaderResolver (priority: 50)
-        | - ArtisanPackUI\Analytics\Resolvers\SubdomainResolver (priority: 90)
-        | - ArtisanPackUI\Analytics\Resolvers\DomainResolver (priority: 100)
+        | While 'enabled' above is on, this list is still honoured: it is
+        | prepended to the shared list at boot so upgrades keep resolving the
+        | site they always did. Empty it once you have migrated.
+        |
+        | Available resolvers, in their conventional order:
+        | - ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver
+        | - ArtisanPackUI\Analytics\Resolvers\HeaderResolver
+        | - ArtisanPackUI\Analytics\Resolvers\SubdomainResolver
+        | - ArtisanPackUI\Analytics\Resolvers\DomainResolver
         |
         */
         'resolvers' => [
@@ -840,7 +858,10 @@ return [
         | Default Site ID
         |----------------------------------------------------------------------
         |
-        | Default site ID to use when no site can be resolved.
+        | Default site ID to use when no site can be resolved. Applies only when
+        | no resolver puts a site in context; code that asks explicitly for no
+        | site — withoutSite(), allSites() — still gets none. Ignored when the
+        | site does not exist or is not active.
         |
         */
         'default_site_id' => env( 'ANALYTICS_DEFAULT_SITE_ID' ),

--- a/docs/advanced/multi-tenancy.md
+++ b/docs/advanced/multi-tenancy.md
@@ -6,46 +6,109 @@ title: Multi-Tenancy
 
 ArtisanPack UI Analytics provides comprehensive multi-tenant support for SaaS and multi-site applications.
 
+Since 1.5.0, *which site a request is for* is decided once for the whole
+ArtisanPack UI ecosystem, by `artisanpack-ui/core`. Analytics reads that answer
+rather than resolving its own. Before this, each package that scoped data by
+site kept its own resolver and its own configuration, so an application
+installing two of them could resolve to site 2 in one and site 1 in the other,
+in the same request, with nothing to signal it.
+
 ## Enabling Multi-Tenancy
 
 ```php
 // .env
-ANALYTICS_MULTI_TENANT=true
+ARTISANPACK_MULTI_TENANT_ENABLED=true
 ```
 
 ```php
-// config/artisanpack/analytics.php
-'multi_tenant' => [
-    'enabled' => env('ANALYTICS_MULTI_TENANT', false),
+// config/artisanpack.php
+'core' => [
+    'multi_tenant' => [
+        'enabled' => env('ARTISANPACK_MULTI_TENANT_ENABLED', false),
+    ],
 ],
 ```
 
+The pre-1.5 switch, `ANALYTICS_MULTI_TENANT` / `artisanpack.analytics.multi_tenant.enabled`,
+still works: it enables analytics scoping and switches the shared flag on too,
+so an upgrade does not silently pool every site's visits into one dashboard.
+It is deprecated and will be removed in 2.0.
+
 ## Site Resolution
 
-Sites are resolved from incoming requests using configurable resolvers.
+Sites are resolved from incoming requests using configurable resolvers, listed
+under the shared configuration key. Resolvers are asked in the order they are
+listed, and the first non-null answer wins — a chain assembled from several
+packages' resolvers cannot be ordered by a priority number only one of those
+packages knows about.
 
 ### Available Resolvers
 
-| Resolver | Priority | Method |
-|----------|----------|--------|
-| `ApiKeyResolver` | 10 | API key in header/query |
-| `HeaderResolver` | 50 | X-Site-ID header |
-| `SubdomainResolver` | 90 | Subdomain extraction |
-| `DomainResolver` | 100 | Full domain match |
+| Resolver | Method |
+|----------|--------|
+| `ApiKeyResolver` | API key in header/query |
+| `HeaderResolver` | X-Site-ID header |
+| `SubdomainResolver` | Subdomain extraction |
+| `DomainResolver` | Full domain match |
+
+The resolvers this package ships answer from the request, so they resolve to
+`null` in console commands and queue workers. Pin a site explicitly there — see
+[Working across sites](#working-across-sites).
+
+### Trust boundaries
+
+The resolver list is now ecosystem-wide, so a resolver's trust assumptions apply
+to every package that scopes data by site, not only to analytics. Two of the
+shipped resolvers take the site from client-controlled input:
+
+- `HeaderResolver` believes whatever `X-Site-ID` the caller sends.
+- `ApiKeyResolver` is authenticated, but `allow_query_api_key` moves the
+  credential into the query string, where it lands in access logs.
+
+Both were only ever as trusted as the routes they ran on. Now they decide the
+site for every package, so list them only where that is what you want — typically
+on authenticated ingest and API routes — and prefer resolvers keyed on something
+the caller cannot choose (the domain, the authenticated user) for routes serving
+site-scoped data.
+
+### Pinning per request
+
+Resolvers are asked afresh on every call, by design: a worker looping over sites
+changes the answer within one process, and a cached answer would scope the later
+iterations to the wrong site. That means an unpinned request re-runs the chain
+for every scoped query.
+
+Apply the `analytics.site` middleware to route groups that query analytics data.
+It resolves once and pins the result for the rest of the request:
+
+```php
+Route::middleware(['web', 'auth', 'analytics.site'])->group(function () {
+    // ...
+});
+```
 
 ### Configure Resolvers
 
 ```php
-// config/artisanpack/analytics.php
-'multi_tenant' => [
-    'resolvers' => [
-        \ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver::class,
-        \ArtisanPackUI\Analytics\Resolvers\HeaderResolver::class,
-        \ArtisanPackUI\Analytics\Resolvers\SubdomainResolver::class,
-        \ArtisanPackUI\Analytics\Resolvers\DomainResolver::class,
+// config/artisanpack.php
+'core' => [
+    'multi_tenant' => [
+        'resolvers' => [
+            \ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver::class,
+            \ArtisanPackUI\Analytics\Resolvers\HeaderResolver::class,
+            \ArtisanPackUI\Analytics\Resolvers\SubdomainResolver::class,
+            \ArtisanPackUI\Analytics\Resolvers\DomainResolver::class,
+            // Answers from artisanpack-ui/cms-framework, when installed.
+            \ArtisanPackUI\Core\MultiTenancy\HookSiteResolver::class,
+        ],
     ],
 ],
 ```
+
+A list still configured under `artisanpack.analytics.multi_tenant.resolvers` is
+prepended to the shared list at boot while the deprecated analytics flag is on,
+so resolution order survives the upgrade. Move the list to the core key and
+empty the analytics one once you have migrated.
 
 ## Resolution Strategies
 
@@ -186,7 +249,7 @@ class DashboardController extends Controller
 {
     public function index(TenantManager $tenantManager)
     {
-        $site = $tenantManager->currentSite();
+        $site = $tenantManager->current();
 
         if (!$site) {
             abort(404, 'Site not found');
@@ -255,45 +318,104 @@ $allStats = $reporting->getAllSitesStats($dateRange);
 $tenantStats = $reporting->getTenantStats($tenantId, $dateRange);
 ```
 
-## Custom Site Resolver
+## Working across sites
 
-Create a custom resolver for your specific needs:
+A console command or queue worker has no request to resolve from, so pin the
+site you want. The pin is shared, so every package scopes to it, not just
+analytics:
 
 ```php
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
 use ArtisanPackUI\Analytics\Models\Site;
-use Illuminate\Http\Request;
+use ArtisanPackUI\Analytics\Services\TenantManager;
 
-class TeamBasedResolver implements SiteResolverInterface
+$tenantManager = app(TenantManager::class);
+
+foreach (Site::all() as $site) {
+    $tenantManager->forSite($site, function () use ($site) {
+        // Everything in here — analytics and any other ArtisanPack UI
+        // package — is scoped to $site. The previous context is restored
+        // afterwards, including if this throws.
+    });
+}
+
+// Run something against every site's data at once:
+$tenantManager->withoutSite(fn () => PageView::count());
+```
+
+`forSite()` also accepts a bare identifier, so a job that only carries a site ID
+does not have to load the model first.
+
+## Custom Site Resolver
+
+Implement the ecosystem's shared contract. It is keyed on the site identifier
+rather than a `Site` model, because core cannot depend on this package's models
+— analytics looks the model up from the identifier you return:
+
+```php
+use ArtisanPackUI\Core\Contracts\SiteResolver;
+use ArtisanPackUI\Analytics\Models\Site;
+
+class TeamBasedResolver implements SiteResolver
 {
-    public function resolve(Request $request): ?Site
+    public function __construct(private \Illuminate\Http\Request $request)
     {
-        $user = $request->user();
+    }
+
+    public function currentSiteId(): int|string|null
+    {
+        $user = $this->request->user();
 
         if (!$user || !$user->currentTeam) {
             return null;
         }
 
-        return Site::where('team_id', $user->currentTeam->id)->first();
-    }
-
-    public function getPriority(): int
-    {
-        return 25;
+        return Site::where('team_id', $user->currentTeam->id)->value('id');
     }
 }
 ```
 
+Note the resolver asks for the request in its constructor rather than taking one
+as a parameter: a resolver that *requires* a request is unusable from the
+console commands and queue workers where per-site iteration happens.
+
 Register in config:
 
 ```php
-'multi_tenant' => [
-    'resolvers' => [
-        \App\Analytics\TeamBasedResolver::class,
-        // ... other resolvers
+'core' => [
+    'multi_tenant' => [
+        'resolvers' => [
+            \App\Analytics\TeamBasedResolver::class,
+            // ... other resolvers
+        ],
     ],
 ],
 ```
+
+A class listed here that does not exist, or does not implement `SiteResolver`,
+raises `ArtisanPackUI\Core\Exceptions\SiteResolutionException` when the chain
+is built. Dropping it quietly would leave an application that reads as
+multi-site running with every query unscoped.
+
+### Migrating a pre-1.5 resolver
+
+A resolver implementing `SiteResolverInterface` keeps working if you extend
+`ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver`, which implements
+`currentSiteId()` in terms of your existing `resolve(Request): ?Site`:
+
+```php
+use ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver;
+
+class TeamBasedResolver extends AbstractSiteResolver
+{
+    public function resolve(Request $request): ?Site
+    {
+        // unchanged
+    }
+}
+```
+
+`SiteResolverInterface` and its `priority()` method are deprecated and will be
+removed in 2.0.
 
 ## Middleware
 

--- a/docs/advanced/multi-tenancy.md
+++ b/docs/advanced/multi-tenancy.md
@@ -352,12 +352,13 @@ rather than a `Site` model, because core cannot depend on this package's models
 — analytics looks the model up from the identifier you return:
 
 ```php
-use ArtisanPackUI\Core\Contracts\SiteResolver;
 use ArtisanPackUI\Analytics\Models\Site;
+use ArtisanPackUI\Core\Contracts\SiteResolver;
+use Illuminate\Http\Request;
 
 class TeamBasedResolver implements SiteResolver
 {
-    public function __construct(private \Illuminate\Http\Request $request)
+    public function __construct(private Request $request)
     {
     }
 
@@ -403,7 +404,9 @@ A resolver implementing `SiteResolverInterface` keeps working if you extend
 `currentSiteId()` in terms of your existing `resolve(Request): ?Site`:
 
 ```php
+use ArtisanPackUI\Analytics\Models\Site;
 use ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver;
+use Illuminate\Http\Request;
 
 class TeamBasedResolver extends AbstractSiteResolver
 {
@@ -413,6 +416,9 @@ class TeamBasedResolver extends AbstractSiteResolver
     }
 }
 ```
+
+`AbstractSiteResolver::currentSiteId()` is what core calls; it reads the request
+from the container and hands it to your `resolve()`, returning the site's ID.
 
 `SiteResolverInterface` and its `priority()` method are deprecated and will be
 removed in 2.0.

--- a/docs/api.md
+++ b/docs/api.md
@@ -91,8 +91,8 @@ ArtisanPackUI\Analytics\
 ├── AnalyticsServiceProvider     # Service provider
 ├── Contracts\                   # Interfaces
 │   ├── AnalyticsProviderInterface
-│   ├── SiteResolverInterface
-│   └── TenantResolverInterface
+│   ├── SiteResolverInterface    # Deprecated; extends core's SiteResolver
+│   └── TenantResolverInterface  # Deprecated
 ├── Data\                        # DTOs
 │   ├── DateRange
 │   ├── DeviceInfo
@@ -213,21 +213,17 @@ class CustomProvider implements AnalyticsProviderInterface
 
 ### Custom Site Resolver
 
+Site resolution is shared across every ArtisanPack UI package; implement core's
+contract and list the class under `artisanpack.core.multi_tenant.resolvers`.
+
 ```php
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
-use ArtisanPackUI\Analytics\Models\Site;
-use Illuminate\Http\Request;
+use ArtisanPackUI\Core\Contracts\SiteResolver;
 
-class CustomResolver implements SiteResolverInterface
+class CustomResolver implements SiteResolver
 {
-    public function resolve(Request $request): ?Site
+    public function currentSiteId(): int|string|null
     {
-        // Custom resolution logic
-    }
-
-    public function getPriority(): int
-    {
-        return 50;
+        // Custom resolution logic, returning a site identifier or null
     }
 }
 ```

--- a/docs/api/contracts.md
+++ b/docs/api/contracts.md
@@ -105,78 +105,88 @@ Then enable in config:
 
 ---
 
-## SiteResolverInterface
+## SiteResolver (core)
 
-Interface for resolving the current site in multi-tenant setups.
+Since 1.5.0 site resolution is a single ecosystem-wide contract owned by
+`artisanpack-ui/core`, so analytics and every sibling package resolve one site
+from one configuration.
 
 ### Definition
 
 ```php
-namespace ArtisanPackUI\Analytics\Contracts;
+namespace ArtisanPackUI\Core\Contracts;
 
-use ArtisanPackUI\Analytics\Models\Site;
-use Illuminate\Http\Request;
-
-interface SiteResolverInterface
+interface SiteResolver
 {
     /**
-     * Resolve the site from the request.
+     * The identifier of the site currently in context, or null for none.
      */
-    public function resolve(Request $request): ?Site;
-
-    /**
-     * Get the resolver priority (lower runs first).
-     */
-    public function getPriority(): int;
+    public function currentSiteId(): int|string|null;
 }
 ```
 
+It is keyed on the identifier rather than a model, because core cannot depend on
+any package's `Site`; and it takes no `Request`, because a resolver that
+requires one is unusable from the console commands and queue workers where
+per-site iteration happens. A resolver that wants the request injects it.
+
 ### Built-in Resolvers
 
-| Resolver | Priority | Resolution Method |
-|----------|----------|-------------------|
-| `ApiKeyResolver` | 10 | API key in header or query |
-| `HeaderResolver` | 50 | Custom header (X-Site-ID) |
-| `SubdomainResolver` | 90 | Subdomain extraction |
-| `DomainResolver` | 100 | Full domain matching |
+Asked in the order they are listed in configuration; the first non-null answer
+wins.
+
+| Resolver | Resolution Method |
+|----------|-------------------|
+| `ApiKeyResolver` | API key in header or query |
+| `HeaderResolver` | Custom header (X-Site-ID) |
+| `SubdomainResolver` | Subdomain extraction |
+| `DomainResolver` | Full domain matching |
 
 ### Implementation Example
 
 ```php
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
+use ArtisanPackUI\Core\Contracts\SiteResolver;
 use ArtisanPackUI\Analytics\Models\Site;
 use Illuminate\Http\Request;
 
-class TenantIdResolver implements SiteResolverInterface
+class TenantIdResolver implements SiteResolver
 {
-    public function resolve(Request $request): ?Site
+    public function __construct(private Request $request)
     {
-        // Get tenant from authenticated user
-        $user = $request->user();
+    }
+
+    public function currentSiteId(): int|string|null
+    {
+        $user = $this->request->user();
 
         if (!$user || !$user->tenant_id) {
             return null;
         }
 
-        return Site::where('tenant_id', $user->tenant_id)->first();
-    }
-
-    public function getPriority(): int
-    {
-        return 20; // Run early, after API key
+        return Site::where('tenant_id', $user->tenant_id)->value('id');
     }
 }
 ```
 
+### SiteResolverInterface (deprecated)
+
+`ArtisanPackUI\Analytics\Contracts\SiteResolverInterface` now extends the core
+contract and keeps its `resolve(Request): ?Site` and `priority()` methods for
+existing implementations. Neither is consulted during resolution. Extend
+`ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver` to keep a
+request-shaped resolver working; both are removed in 2.0.
+
 ### Registering Custom Resolvers
 
 ```php
-// config/artisanpack/analytics.php
-'multi_tenant' => [
-    'resolvers' => [
-        \ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver::class,
-        \App\Analytics\TenantIdResolver::class, // Your custom resolver
-        \ArtisanPackUI\Analytics\Resolvers\DomainResolver::class,
+// config/artisanpack.php
+'core' => [
+    'multi_tenant' => [
+        'resolvers' => [
+            \ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver::class,
+            \App\Analytics\TenantIdResolver::class, // Your custom resolver
+            \ArtisanPackUI\Analytics\Resolvers\DomainResolver::class,
+        ],
     ],
 ],
 ```
@@ -185,7 +195,13 @@ class TenantIdResolver implements SiteResolverInterface
 
 ## TenantResolverInterface
 
-Legacy interface for tenant resolution.
+Legacy interface for tenant resolution. **Deprecated in 1.5.0.** It describes a
+*tenant*, which is not always a site — it carries its own column name — so it
+survived the move to the shared contract rather than being folded into it. It is
+consulted only by the `TenantResolver` middleware, and only when nothing has put
+a site in the shared context, so it cannot decide what queries are scoped to.
+Where a tenant is a site, implement `ArtisanPackUI\Core\Contracts\SiteResolver`
+instead.
 
 ### Definition
 
@@ -297,7 +313,7 @@ class MyService
 {
     public function __construct(
         private AnalyticsProviderInterface $provider,
-        private SiteResolverInterface $resolver,
+        private SiteContext $siteContext,
     ) {}
 
     public function doSomething(): void

--- a/docs/api/contracts.md
+++ b/docs/api/contracts.md
@@ -172,9 +172,11 @@ class TenantIdResolver implements SiteResolver
 
 `ArtisanPackUI\Analytics\Contracts\SiteResolverInterface` now extends the core
 contract and keeps its `resolve(Request): ?Site` and `priority()` methods for
-existing implementations. Neither is consulted during resolution. Extend
-`ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver` to keep a
-request-shaped resolver working; both are removed in 2.0.
+existing implementations. Core calls only `currentSiteId()`; `resolve()` is
+called by the compatibility adapter,
+`ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver`, whose
+`currentSiteId()` delegates to it — extend that class to keep a request-shaped
+resolver working. `priority()` is called by nothing. Both are removed in 2.0.
 
 ### Registering Custom Resolvers
 

--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -354,7 +354,11 @@ $status = $consentService->getConsentStatus($fingerprint);
 
 ## TenantManager
 
-Manages multi-tenant site resolution.
+The analytics view onto the ecosystem's shared site context. Since 1.5.0 it
+resolves nothing itself: `ArtisanPackUI\Core\MultiTenancy\SiteContext` decides
+which site is in context, from one configuration every ArtisanPack UI package
+reads, and this class looks the `Site` model up from the identifier it returns.
+A site pinned here is pinned for every package, and vice versa.
 
 ### Usage
 
@@ -366,37 +370,84 @@ $tenantManager = app(TenantManager::class);
 
 ### Methods
 
-#### currentSite()
+#### current()
 
-Get the current site:
-
-```php
-$site = $tenantManager->currentSite();
-```
-
-#### currentTenantId()
-
-Get current tenant ID:
+Get the current site, or `null` when none is in context:
 
 ```php
-$tenantId = $tenantManager->currentTenantId();
+$site = $tenantManager->current();
 ```
 
-#### setSite()
+#### currentId()
 
-Set the current site:
+Get the current site ID, falling back to
+`artisanpack.analytics.multi_tenant.default_site_id` when nothing resolves:
 
 ```php
-$tenantManager->setSite($site);
+$siteId = $tenantManager->currentId();
 ```
 
-#### resolveSite()
+#### hasCurrent()
 
-Resolve site from request:
+Whether any site is in context:
 
 ```php
-$site = $tenantManager->resolveSite($request);
+if ($tenantManager->hasCurrent()) {
+    // ...
+}
 ```
+
+#### setCurrent()
+
+Pin a site for the rest of the process, for every package:
+
+```php
+$tenantManager->setCurrent($site);
+```
+
+#### forSite()
+
+Run a callback with a site in context, restoring whatever was there before —
+including when the callback throws. Accepts a `Site` or a bare identifier:
+
+```php
+$tenantManager->forSite($site, fn () => PageView::count());
+$tenantManager->forSite(42, fn () => PageView::count());
+```
+
+#### withoutSite()
+
+Run a callback with no site in context, so nothing is scoped:
+
+```php
+$total = $tenantManager->withoutSite(fn () => PageView::count());
+```
+
+The configured default site does not fill in here: asking for no site is an
+instruction, not an absence of one.
+
+#### forget() / flush()
+
+Release the pinned site. Register `flush()` against Octane's
+`RequestTerminated` event so a pinned site cannot leak between requests:
+
+```php
+$tenantManager->forget();
+```
+
+#### context()
+
+The shared `SiteContext` this manager delegates to, for code that wants the
+identifier without the model:
+
+```php
+$siteId = $tenantManager->context()->currentSiteId();
+```
+
+#### resolve()
+
+**Deprecated in 1.5.0.** An alias for `current()`; the `$request` argument is
+ignored, because resolvers now read the request from the container themselves.
 
 ---
 

--- a/docs/api/services.md
+++ b/docs/api/services.md
@@ -372,7 +372,10 @@ $tenantManager = app(TenantManager::class);
 
 #### current()
 
-Get the current site, or `null` when none is in context:
+Get the site in context. When the shared context has no answer, this returns the
+site configured as `artisanpack.analytics.multi_tenant.default_site_id` — unless
+that site is missing, inactive or deleted, or unless no site was asked for
+explicitly through `withoutSite()` or `setCurrent( null )`. `null` otherwise:
 
 ```php
 $site = $tenantManager->current();

--- a/docs/installation/configuration.md
+++ b/docs/installation/configuration.md
@@ -286,11 +286,36 @@ Runtime whitelist entries can also be managed with the [`analytics:whitelist`](A
 
 ## Multi-Tenant Configuration
 
+Since 1.5.0, whether site scoping is on and which resolvers decide the site are
+configured once for every ArtisanPack UI package, under `artisanpack.core`:
+
+```php
+// config/artisanpack.php
+'core' => [
+    'multi_tenant' => [
+        'enabled' => env('ARTISANPACK_MULTI_TENANT_ENABLED', false),
+        'resolvers' => [
+            ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver::class,
+            ArtisanPackUI\Analytics\Resolvers\HeaderResolver::class,
+            ArtisanPackUI\Analytics\Resolvers\SubdomainResolver::class,
+            ArtisanPackUI\Analytics\Resolvers\DomainResolver::class,
+        ],
+    ],
+],
+```
+
+The analytics block keeps the settings those resolvers read, plus the deprecated
+keys, which still work: `enabled` and `resolvers` are carried onto the shared
+configuration at boot so upgrades keep resolving the site they always did.
+
 ```php
 'multi_tenant' => [
+    // Deprecated 1.5.0 — use artisanpack.core.multi_tenant.enabled
     'enabled' => env('ANALYTICS_MULTI_TENANT', false),
     'tenant_column' => env('ANALYTICS_TENANT_COLUMN', 'tenant_id'),
+    // Deprecated 1.5.0 — only the TenantResolver middleware reads this
     'resolver' => env('ANALYTICS_TENANT_RESOLVER'),
+    // Deprecated 1.5.0 — use artisanpack.core.multi_tenant.resolvers
     'resolvers' => [
         ArtisanPackUI\Analytics\Resolvers\ApiKeyResolver::class,
         ArtisanPackUI\Analytics\Resolvers\HeaderResolver::class,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -288,18 +288,30 @@ Schedule::command('analytics:cleanup')->daily();
 
 ```php
 use ArtisanPackUI\Analytics\Services\TenantManager;
+use ArtisanPackUI\Core\MultiTenancy\SiteContext;
 
 $manager = app(TenantManager::class);
-$site = $manager->resolveSite(request());
-dd($site);
+
+// What the shared context says, what analytics makes of it, and which
+// resolvers were asked.
+dd(
+    app(SiteContext::class)->currentSiteId(),
+    $manager->current(),
+    $manager->getResolvers(),
+);
 ```
 
 **Check:**
 
-1. Is multi-tenant enabled?
+1. Is multi-tenant enabled? Since 1.5.0 this lives under the shared key:
 ```php
-'multi_tenant' => ['enabled' => true],
+// config/artisanpack.php
+'core' => ['multi_tenant' => ['enabled' => true]],
 ```
+
+If only the deprecated `artisanpack.analytics.multi_tenant.enabled` is set, it
+is carried onto the shared key at boot — check the logs for the deprecation
+notice naming the bridge.
 
 2. Does the site exist?
 ```php

--- a/src/AnalyticsServiceProvider.php
+++ b/src/AnalyticsServiceProvider.php
@@ -44,10 +44,12 @@ use ArtisanPackUI\Analytics\Services\IpAnonymizer;
 use ArtisanPackUI\Analytics\Services\PrivacyIntegration;
 use ArtisanPackUI\Analytics\Services\SiteSettingsService;
 use ArtisanPackUI\Analytics\Services\TenantManager;
+use ArtisanPackUI\Core\MultiTenancy\SiteContext;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
@@ -157,18 +159,16 @@ class AnalyticsServiceProvider extends ServiceProvider
             );
         } );
 
-        // Register TenantManager as singleton
-        $this->app->singleton( TenantManager::class, function () {
-            $manager = new TenantManager;
-
-            // Register resolvers from config
-            $resolvers = config( 'artisanpack.analytics.multi_tenant.resolvers', [] );
-
-            if ( ! empty( $resolvers ) ) {
-                $manager->registerResolversFromConfig( $resolvers );
-            }
-
-            return $manager;
+        // Register TenantManager over the ecosystem's shared site context.
+        //
+        // Scoped rather than singleton, to match the context it wraps: Laravel
+        // forgets scoped instances between Octane requests and between queue
+        // jobs, so a site pinned by one job cannot scope the next job's data,
+        // and neither can the Site model this manager caches.
+        $this->app->scoped( TenantManager::class, function ( $app ) {
+            return new TenantManager(
+                $app->make( SiteContext::class ),
+            );
         } );
 
         // Register SiteSettingsService
@@ -204,6 +204,7 @@ class AnalyticsServiceProvider extends ServiceProvider
         Support\HookAliases::register();
 
         $this->mergeConfiguration();
+        $this->bridgeLegacyMultiTenantConfig();
         $this->publishConfiguration();
         $this->publishMigrations();
         $this->publishViews();
@@ -293,6 +294,71 @@ class AnalyticsServiceProvider extends ServiceProvider
             SiteSettingsService::class,
             CrossTenantReporting::class,
         ];
+    }
+
+    /**
+     * Carry a pre-1.5 multi-tenant configuration onto the shared one.
+     *
+     * Site resolution moved to `artisanpack-ui/core` in 1.5.0 so that every
+     * package in an installation resolves one site from one configuration.
+     * Applications configured before that switched tenancy on with
+     * `artisanpack.analytics.multi_tenant.enabled` and listed their resolvers
+     * under the same block, and core's own switch defaults to off — so without
+     * this bridge an upgrade would silently stop scoping analytics by site,
+     * pooling every site's visits into one dashboard with nothing in the logs
+     * to explain it.
+     *
+     * The legacy resolvers go in front of whatever the shared list already
+     * holds, which preserves the order they resolved in before: an API key or
+     * `X-Site-ID` header identifies the site a tracking request is *for*,
+     * which is not always the site the request is *served from*.
+     *
+     * Applications that have migrated set the core keys and either switch the
+     * analytics flag off or empty its resolver list; nothing is bridged then.
+     *
+     * @return void
+     *
+     * @since 1.5.0
+     */
+    protected function bridgeLegacyMultiTenantConfig(): void
+    {
+        if ( ! config( 'artisanpack.analytics.multi_tenant.enabled', false ) ) {
+            return;
+        }
+
+        $config = $this->app->make( 'config' );
+
+        if ( ! $config->get( 'artisanpack.core.multi_tenant.enabled', false ) ) {
+            $config->set( 'artisanpack.core.multi_tenant.enabled', true );
+        }
+
+        $legacyResolvers = $config->get( 'artisanpack.analytics.multi_tenant.resolvers', [] );
+        $sharedResolvers = $config->get( 'artisanpack.core.multi_tenant.resolvers', [] );
+
+        // A shared list that is not a list is a configuration fault, and core
+        // reports it as one when the resolver is built. Merging into it here
+        // would turn that report into a confusing one about analytics.
+        if ( ! is_array( $legacyResolvers ) || [] === $legacyResolvers || ! is_array( $sharedResolvers ) ) {
+            return;
+        }
+
+        $merged = array_values( array_unique( array_merge(
+            array_values( $legacyResolvers ),
+            array_values( $sharedResolvers ),
+        ) ) );
+
+        if ( $merged === array_values( $sharedResolvers ) ) {
+            return;
+        }
+
+        $config->set( 'artisanpack.core.multi_tenant.resolvers', $merged );
+
+        Log::notice( __(
+            '[Analytics] Bridging the deprecated "artisanpack.analytics.multi_tenant" settings onto'
+                . ' "artisanpack.core.multi_tenant", which every ArtisanPack UI package now resolves sites from.'
+                . ' Move your resolvers to the core key and switch tenancy on there; support for the analytics'
+                . ' key will be removed in 2.0.',
+        ) );
     }
 
     /**

--- a/src/Contracts/SiteResolverInterface.php
+++ b/src/Contracts/SiteResolverInterface.php
@@ -5,19 +5,38 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Analytics\Contracts;
 
 use ArtisanPackUI\Analytics\Models\Site;
+use ArtisanPackUI\Core\Contracts\SiteResolver;
 use Illuminate\Http\Request;
 
 /**
  * Interface for resolving the current site in multi-site deployments.
  *
- * Implement this interface to provide custom site resolution logic
- * for your multi-tenant application.
+ * This now extends the ecosystem's shared contract,
+ * {@see SiteResolver}, so a resolver written for
+ * analytics answers the same question every other ArtisanPack UI package asks.
+ * Before that, this package resolved a `Site` model from a `Request` while
+ * sibling packages resolved an identifier from nothing at all, and an
+ * application installing both could resolve to a different site in each.
  *
+ * Implement `currentSiteId()` — that is the method the shared resolver chain
+ * calls. `resolve()` and `priority()` are retained for existing resolvers and
+ * are no longer consulted during resolution: ordering now comes from the order
+ * of `artisanpack.core.multi_tenant.resolvers`, because a chain assembled from
+ * several packages' resolvers cannot be ordered by a priority number only one
+ * of those packages knows about.
+ *
+ * Extending {@see \ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver} is
+ * the shortest migration for a resolver that already returns a `Site` from a
+ * `Request`: it implements `currentSiteId()` in terms of `resolve()`.
+ *
+ * @deprecated 1.5.0 Implement {@see SiteResolver}
+ *                   directly. This interface is kept so existing resolvers
+ *                   keep type-checking and will be removed in 2.0.
  * @since   1.0.0
  *
  * @package ArtisanPackUI\Analytics\Contracts
  */
-interface SiteResolverInterface
+interface SiteResolverInterface extends SiteResolver
 {
 	/**
 	 * Resolve the current site from the request.
@@ -26,6 +45,10 @@ interface SiteResolverInterface
 	 *
 	 * @return Site|null The resolved site, or null if not found.
 	 *
+	 * @deprecated 1.5.0 Resolution goes through `currentSiteId()`. A resolver
+	 *                   that needs the request reads it from the container, so
+	 *                   it stays usable from console commands and queue
+	 *                   workers.
 	 * @since 1.0.0
 	 */
 	public function resolve( Request $request ): ?Site;
@@ -37,6 +60,8 @@ interface SiteResolverInterface
 	 *
 	 * @return int
 	 *
+	 * @deprecated 1.5.0 Ordering comes from the order of the
+	 *                   `artisanpack.core.multi_tenant.resolvers` list.
 	 * @since 1.0.0
 	 */
 	public function priority(): int;

--- a/src/Contracts/SiteResolverInterface.php
+++ b/src/Contracts/SiteResolverInterface.php
@@ -18,10 +18,13 @@ use Illuminate\Http\Request;
  * sibling packages resolved an identifier from nothing at all, and an
  * application installing both could resolve to a different site in each.
  *
- * Implement `currentSiteId()` — that is the method the shared resolver chain
- * calls. `resolve()` and `priority()` are retained for existing resolvers and
- * are no longer consulted during resolution: ordering now comes from the order
- * of `artisanpack.core.multi_tenant.resolvers`, because a chain assembled from
+ * `currentSiteId()` is the only method the shared resolver chain calls.
+ * `resolve()` is never called by core — it is called by
+ * {@see \ArtisanPackUI\Analytics\Resolvers\AbstractSiteResolver}, whose
+ * `currentSiteId()` delegates to it, so a resolver already written against the
+ * request keeps working through that adapter. `priority()` is called by nothing
+ * at all: ordering comes from the order of
+ * `artisanpack.core.multi_tenant.resolvers`, because a chain assembled from
  * several packages' resolvers cannot be ordered by a priority number only one
  * of those packages knows about.
  *

--- a/src/Contracts/TenantResolverInterface.php
+++ b/src/Contracts/TenantResolverInterface.php
@@ -7,9 +7,21 @@ namespace ArtisanPackUI\Analytics\Contracts;
 /**
  * Interface for resolving the current tenant in multi-tenant deployments.
  *
- * Implement this interface to provide custom tenant resolution logic
- * for your multi-tenant application.
+ * This describes a *tenant*, not a site: it carries its own column name, so an
+ * application whose tenants are something other than analytics sites — an
+ * account, an organisation — can still identify one. That is why it survived
+ * the move to the ecosystem's shared site contract rather than being folded
+ * into it.
  *
+ * Where a tenant and a site are the same thing, which is the usual case,
+ * implement {@see \ArtisanPackUI\Core\Contracts\SiteResolver} and list it in
+ * `artisanpack.core.multi_tenant.resolvers` instead. Only that contract feeds
+ * the site context every package scopes its queries by; a resolver reachable
+ * only from here answers for the tenant middleware and nothing else, which is
+ * exactly the split-brain the shared contract exists to remove.
+ *
+ * @deprecated 1.5.0 Prefer {@see \ArtisanPackUI\Core\Contracts\SiteResolver}
+ *                   unless a tenant genuinely is not a site.
  * @since   1.0.0
  *
  * @package ArtisanPackUI\Analytics\Contracts

--- a/src/Http/Middleware/ResolveSite.php
+++ b/src/Http/Middleware/ResolveSite.php
@@ -13,9 +13,10 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Middleware to resolve the current site using TenantManager.
  *
- * Uses the registered site resolvers to determine the current site
- * and sets it in the TenantManager for downstream processing.
- * Also shares the current site with all views.
+ * Resolution itself happens in `artisanpack-ui/core`'s shared site context,
+ * from one ecosystem-wide configuration. What this middleware adds is putting
+ * the resolved `Site` where the rest of a request expects it: on the request
+ * attributes and shared with every view.
  *
  * @since   1.0.0
  *
@@ -51,14 +52,22 @@ class ResolveSite
 	public function handle( Request $request, Closure $next ): Response
 	{
 		// Check if multi-tenant is enabled
-		if ( ! config( 'artisanpack.analytics.multi_tenant.enabled', false ) ) {
+		if ( ! analyticsMultiTenancyEnabled() ) {
 			return $next( $request );
 		}
 
-		// Resolve the current site
-		$site = $this->tenantManager->resolve( $request );
+		// Ask the shared site context every ArtisanPack UI package reads from,
+		// so this request cannot be site 2 here and site 1 somewhere else.
+		$site = $this->tenantManager->current();
 
 		if ( null !== $site ) {
+			// Pin it for the rest of the request. The site a request is for
+			// cannot change mid-request, and resolvers are asked afresh on
+			// every call by design — without pinning, each scoped query would
+			// re-run the whole chain, putting a domain or API-key lookup in
+			// front of it.
+			$this->tenantManager->setCurrent( $site );
+
 			// Add site to request attributes
 			$request->attributes->set( 'site', $site );
 			$request->attributes->set( 'site_id', $site->id );

--- a/src/Http/Middleware/ResolveSite.php
+++ b/src/Http/Middleware/ResolveSite.php
@@ -58,15 +58,23 @@ class ResolveSite
 
 		// Ask the shared site context every ArtisanPack UI package reads from,
 		// so this request cannot be site 2 here and site 1 somewhere else.
-		$site = $this->tenantManager->current();
+		$resolvedSiteId = $this->tenantManager->context()->currentSiteId();
+		$site           = $this->tenantManager->current();
 
 		if ( null !== $site ) {
-			// Pin it for the rest of the request. The site a request is for
-			// cannot change mid-request, and resolvers are asked afresh on
-			// every call by design — without pinning, each scoped query would
-			// re-run the whole chain, putting a domain or API-key lookup in
-			// front of it.
-			$this->tenantManager->setCurrent( $site );
+			// Pin it for the rest of the request, but only when a shared
+			// resolver actually named it. The site a request is for cannot
+			// change mid-request, and resolvers are asked afresh on every call
+			// by design — without pinning, each scoped query would re-run the
+			// whole chain, putting a domain or API-key lookup in front of it.
+			//
+			// A site that came from `multi_tenant.default_site_id` is not
+			// pinned: that key is this package's own fallback, and writing it
+			// into the shared context would scope every other package to a
+			// default it never opted into.
+			if ( null !== $resolvedSiteId ) {
+				$this->tenantManager->setCurrent( $site );
+			}
 
 			// Add site to request attributes
 			$request->attributes->set( 'site', $site );

--- a/src/Http/Middleware/TenantResolver.php
+++ b/src/Http/Middleware/TenantResolver.php
@@ -50,7 +50,9 @@ class TenantResolver
 		}
 
 		// The shared context is authoritative; the legacy resolver only fills
-		// in when nothing has put a site in context.
+		// in when nothing has put a site in context. No bound() guard: core is
+		// a hard requirement of this package, so its provider is always
+		// registered and SiteContext always resolvable.
 		$tenantId = app( SiteContext::class )->currentSiteId();
 
 		if ( null === $tenantId ) {

--- a/src/Http/Middleware/TenantResolver.php
+++ b/src/Http/Middleware/TenantResolver.php
@@ -5,6 +5,7 @@ declare( strict_types=1 );
 namespace ArtisanPackUI\Analytics\Http\Middleware;
 
 use ArtisanPackUI\Analytics\Contracts\TenantResolverInterface;
+use ArtisanPackUI\Core\MultiTenancy\SiteContext;
 use Closure;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -13,8 +14,17 @@ use Throwable;
 /**
  * Tenant resolver middleware for multi-tenant analytics.
  *
- * Resolves the current tenant for multi-tenant deployments and
- * adds the tenant ID to the request for downstream processing.
+ * Adds the current tenant identifier to the request for downstream
+ * processing. The identifier comes from the ecosystem's shared site context
+ * first, so this middleware agrees with every query scope, dashboard, and
+ * sibling package in the same request.
+ *
+ * A `TenantResolverInterface` configured under
+ * `artisanpack.analytics.multi_tenant.resolver` is still consulted when the
+ * shared context has no answer. That interface describes a tenant, which is
+ * not always a site — it carries its own column name — so it is kept as a
+ * fallback rather than folded into site resolution, and is deprecated for the
+ * common case where the two are the same thing.
  *
  * @since   1.0.0
  *
@@ -35,18 +45,17 @@ class TenantResolver
 	public function handle( Request $request, Closure $next ): Response
 	{
 		// Check if multi-tenant is enabled
-		if ( ! config( 'artisanpack.analytics.multi_tenant.enabled', false ) ) {
+		if ( ! analyticsMultiTenancyEnabled() ) {
 			return $next( $request );
 		}
 
-		$resolver = $this->getResolver();
+		// The shared context is authoritative; the legacy resolver only fills
+		// in when nothing has put a site in context.
+		$tenantId = app( SiteContext::class )->currentSiteId();
 
-		if ( null === $resolver ) {
-			return $next( $request );
+		if ( null === $tenantId ) {
+			$tenantId = $this->getResolver()?->resolve();
 		}
-
-		// Resolve the tenant
-		$tenantId = $resolver->resolve();
 
 		if ( null !== $tenantId ) {
 			// Add tenant ID to request for downstream processing
@@ -57,10 +66,12 @@ class TenantResolver
 	}
 
 	/**
-	 * Get the tenant resolver instance.
+	 * Get the legacy tenant resolver instance, if one is configured.
 	 *
 	 * @return TenantResolverInterface|null
 	 *
+	 * @deprecated 1.5.0 Configure a `ArtisanPackUI\Core\Contracts\SiteResolver`
+	 *                   under `artisanpack.core.multi_tenant.resolvers` instead.
 	 * @since 1.0.0
 	 */
 	protected function getResolver(): ?TenantResolverInterface

--- a/src/Resolvers/AbstractSiteResolver.php
+++ b/src/Resolvers/AbstractSiteResolver.php
@@ -1,0 +1,95 @@
+<?php
+
+declare( strict_types=1 );
+
+namespace ArtisanPackUI\Analytics\Resolvers;
+
+use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
+use Illuminate\Http\Request;
+
+/**
+ * Base class for request-driven analytics site resolvers.
+ *
+ * The ecosystem's shared contract asks for an identifier and takes no
+ * `Request`, because a resolver that requires one is unusable from a console
+ * command or queue worker — which is exactly where per-site iteration happens.
+ * Every resolver this package ships, though, genuinely answers from the
+ * request: a domain, a header, an API key. This class reconciles the two by
+ * reading the request out of the container and returning null when there is no
+ * request to read, so the subclasses stay written against `Request` and are
+ * simply inert outside an HTTP context.
+ *
+ * @since   1.5.0
+ *
+ * @package ArtisanPackUI\Analytics\Resolvers
+ */
+abstract class AbstractSiteResolver implements SiteResolverInterface
+{
+	/**
+	 * Get the identifier of the site currently in context.
+	 *
+	 * @return int|string|null The current site identifier, or null when no site
+	 *                         is in context.
+	 *
+	 * @since 1.5.0
+	 */
+	public function currentSiteId(): int|string|null
+	{
+		$request = $this->currentRequest();
+
+		if ( null === $request ) {
+			return null;
+		}
+
+		return $this->resolve( $request )?->id;
+	}
+
+	/**
+	 * Get the priority of this resolver.
+	 *
+	 * @return int
+	 *
+	 * @deprecated 1.5.0 Ordering comes from the order of the
+	 *                   `artisanpack.core.multi_tenant.resolvers` list.
+	 * @since 1.5.0
+	 */
+	public function priority(): int
+	{
+		return 100;
+	}
+
+	/**
+	 * Get the request being handled, if there is one.
+	 *
+	 * Laravel binds a `Request` in console too — one synthesised from the
+	 * command's argv, carrying whatever host the machine reports and none of
+	 * the headers a real request would. Resolving from that would let a
+	 * scheduled command attach its work to whichever site happens to match
+	 * `localhost`, so console contexts resolve to null and leave a site pinned
+	 * with `SiteContext::forSite()` as the only answer there.
+	 *
+	 * Tests are the exception: they run in console while exercising requests,
+	 * and a resolver that always returns null under test is a resolver nothing
+	 * can prove works.
+	 *
+	 * @return Request|null The current request, or null outside an HTTP context.
+	 *
+	 * @since 1.5.0
+	 */
+	protected function currentRequest(): ?Request
+	{
+		$app = app();
+
+		if ( $app->runningInConsole() && ! $app->runningUnitTests() ) {
+			return null;
+		}
+
+		if ( ! $app->bound( 'request' ) ) {
+			return null;
+		}
+
+		$request = $app->make( 'request' );
+
+		return $request instanceof Request ? $request : null;
+	}
+}

--- a/src/Resolvers/ApiKeyResolver.php
+++ b/src/Resolvers/ApiKeyResolver.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Analytics\Resolvers;
 
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
 use ArtisanPackUI\Analytics\Models\Site;
 use Illuminate\Http\Request;
 
@@ -20,7 +19,7 @@ use Illuminate\Http\Request;
  *
  * @package ArtisanPackUI\Analytics\Resolvers
  */
-class ApiKeyResolver implements SiteResolverInterface
+class ApiKeyResolver extends AbstractSiteResolver
 {
 	/**
 	 * Resolve the current site from the API key.

--- a/src/Resolvers/DomainResolver.php
+++ b/src/Resolvers/DomainResolver.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Analytics\Resolvers;
 
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
 use ArtisanPackUI\Analytics\Models\Site;
 use Illuminate\Http\Request;
 
@@ -18,7 +17,7 @@ use Illuminate\Http\Request;
  *
  * @package ArtisanPackUI\Analytics\Resolvers
  */
-class DomainResolver implements SiteResolverInterface
+class DomainResolver extends AbstractSiteResolver
 {
 	/**
 	 * Resolve the current site from the request domain.

--- a/src/Resolvers/HeaderResolver.php
+++ b/src/Resolvers/HeaderResolver.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Analytics\Resolvers;
 
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
 use ArtisanPackUI\Analytics\Models\Site;
 use Illuminate\Http\Request;
 
@@ -18,7 +17,7 @@ use Illuminate\Http\Request;
  *
  * @package ArtisanPackUI\Analytics\Resolvers
  */
-class HeaderResolver implements SiteResolverInterface
+class HeaderResolver extends AbstractSiteResolver
 {
 	/**
 	 * The header name to read the site ID from.

--- a/src/Resolvers/SubdomainResolver.php
+++ b/src/Resolvers/SubdomainResolver.php
@@ -4,7 +4,6 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Analytics\Resolvers;
 
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
 use ArtisanPackUI\Analytics\Models\Site;
 use Illuminate\Http\Request;
 
@@ -18,7 +17,7 @@ use Illuminate\Http\Request;
  *
  * @package ArtisanPackUI\Analytics\Resolvers
  */
-class SubdomainResolver implements SiteResolverInterface
+class SubdomainResolver extends AbstractSiteResolver
 {
 	/**
 	 * The base domain to extract subdomain from.

--- a/src/Services/TenantManager.php
+++ b/src/Services/TenantManager.php
@@ -4,18 +4,27 @@ declare( strict_types=1 );
 
 namespace ArtisanPackUI\Analytics\Services;
 
-use ArtisanPackUI\Analytics\Contracts\SiteResolverInterface;
 use ArtisanPackUI\Analytics\Models\Site;
+use ArtisanPackUI\Core\Contracts\SiteResolver;
+use ArtisanPackUI\Core\MultiTenancy\ChainSiteResolver;
+use ArtisanPackUI\Core\MultiTenancy\SiteContext;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
-use Throwable;
 
 /**
  * Manages multi-tenant site resolution and context.
  *
- * Provides a centralized service for resolving the current site
- * from incoming requests using a chain of resolvers.
+ * Since 1.5.0 this is a thin analytics-shaped view over
+ * {@see SiteContext}, the ecosystem's single
+ * site context. It owns no resolver chain of its own: resolution happens once,
+ * in core, from one configuration, so a request cannot resolve to site 2 for
+ * analytics while resolving to site 1 for another package. What this class
+ * still adds is the `Site` model — core's contract is keyed on the identifier
+ * because it cannot depend on this package's model, so the lookup lives here.
+ *
+ * A site pinned here is pinned for every package, and a site pinned by another
+ * package is visible here.
  *
  * For Laravel Octane compatibility, call flush() after each request
  * to prevent state leakage between requests.
@@ -27,121 +36,96 @@ use Throwable;
 class TenantManager
 {
 	/**
-	 * Registered site resolvers.
+	 * The shared site context.
 	 *
-	 * @var array<SiteResolverInterface>
+	 * @var SiteContext
 	 */
-	protected array $resolvers = [];
+	protected SiteContext $context;
 
 	/**
-	 * The currently resolved site.
+	 * The most recently loaded site, cached against its identifier.
+	 *
+	 * The context is deliberately not memoised — it re-resolves on every call
+	 * so a worker looping over sites gets the right answer each time. Without
+	 * this cache, every global scope on every query would re-query the sites
+	 * table for the same record. The identifier is stored alongside the model
+	 * so the cache invalidates itself the moment the context's answer changes.
 	 *
 	 * @var Site|null
 	 */
-	protected ?Site $currentSite = null;
+	protected ?Site $cachedSite = null;
 
 	/**
-	 * Whether resolvers have been sorted.
+	 * The identifier the cached site was loaded for.
+	 *
+	 * @var int|string|null
+	 */
+	protected int|string|null $cachedSiteId = null;
+
+	/**
+	 * Whether an explicit "no site" is in force.
+	 *
+	 * Pinning "no site" is an instruction, not an absence of one, so the
+	 * configured default site must not quietly fill the gap — a report asked to
+	 * run across every site would otherwise silently run against one.
 	 *
 	 * @var bool
 	 */
-	protected bool $resolversSorted = false;
+	protected bool $defaultSuppressed = false;
 
 	/**
-	 * Register a site resolver.
+	 * How many nested `withoutSite()` calls are currently open.
 	 *
-	 * @param SiteResolverInterface $resolver The resolver to register.
-	 *
-	 * @return static
-	 *
-	 * @since 1.0.0
+	 * @var int
 	 */
-	public function registerResolver( SiteResolverInterface $resolver ): static
-	{
-		$this->resolvers[]     = $resolver;
-		$this->resolversSorted = false;
+	protected int $withoutSiteDepth = 0;
 
-		return $this;
+	/**
+	 * Whether an unusable site identifier has already been reported.
+	 *
+	 * @var bool
+	 */
+	protected bool $warnedAboutSiteId = false;
+
+	/**
+	 * The default site identifier the usability check was last run for.
+	 *
+	 * @var int|null
+	 */
+	protected ?int $checkedDefaultSiteId = null;
+
+	/**
+	 * Whether the checked default site exists and is active.
+	 *
+	 * @var bool
+	 */
+	protected bool $defaultSiteUsable = false;
+
+	/**
+	 * Create a new tenant manager.
+	 *
+	 * @param SiteContext $context The shared site context.
+	 */
+	public function __construct( SiteContext $context )
+	{
+		$this->context = $context;
 	}
 
 	/**
-	 * Register multiple resolvers from configuration.
+	 * Resolve the current site.
 	 *
-	 * @param array<class-string<SiteResolverInterface>> $resolverClasses Array of resolver class names.
-	 *
-	 * @return static
-	 *
-	 * @since 1.0.0
-	 */
-	public function registerResolversFromConfig( array $resolverClasses ): static
-	{
-		foreach ( $resolverClasses as $resolverClass ) {
-			if ( class_exists( $resolverClass ) ) {
-				$resolver = app( $resolverClass );
-
-				if ( $resolver instanceof SiteResolverInterface ) {
-					$this->registerResolver( $resolver );
-				}
-			}
-		}
-
-		return $this;
-	}
-
-	/**
-	 * Resolve the current site from the request.
-	 *
-	 * Iterates through registered resolvers in priority order
-	 * until one successfully resolves a site.
-	 *
-	 * @param Request $request The incoming HTTP request.
+	 * @param Request|null $request Unused. Retained so existing callers keep
+	 *                              working; resolvers read the request from the
+	 *                              container themselves.
 	 *
 	 * @return Site|null The resolved site, or null if not found.
 	 *
+	 * @deprecated 1.5.0 Call `current()`. Resolution no longer takes a request.
 	 * @since 1.0.0
 	 */
-	public function resolve( Request $request ): ?Site
+	public function resolve( ?Request $request = null ): ?Site
 	{
-		$this->sortResolvers();
-
-		foreach ( $this->resolvers as $resolver ) {
-			try {
-				$site = $resolver->resolve( $request );
-
-				if ( null !== $site ) {
-					$this->currentSite = $site;
-
-					Log::debug( __( '[Analytics] Site resolved via :resolver', [
-						'resolver' => get_class( $resolver ),
-					] ) );
-
-					return $site;
-				}
-			} catch ( Throwable $e ) {
-				Log::warning( __( '[Analytics] Resolver :resolver failed: :message', [
-					'resolver' => get_class( $resolver ),
-					'message'  => $e->getMessage(),
-				] ) );
-			}
-		}
-
-		// Fall back to default site if configured
-		$defaultSiteId = config( 'artisanpack.analytics.multi_tenant.default_site_id' );
-
-		if ( null !== $defaultSiteId ) {
-			// Only use default site if it exists and is active
-			$defaultSite = Site::where( 'id', $defaultSiteId )
-				->where( 'is_active', true )
-				->first();
-
-			if ( null !== $defaultSite ) {
-				$this->currentSite = $defaultSite;
-
-				return $this->currentSite;
-			}
-		}
-
-		return null;
+		return $this->current();
 	}
 
 	/**
@@ -153,11 +137,36 @@ class TenantManager
 	 */
 	public function current(): ?Site
 	{
-		return $this->currentSite;
+		$siteId = $this->currentId();
+
+		if ( null === $siteId ) {
+			$this->cachedSite   = null;
+			$this->cachedSiteId = null;
+
+			return null;
+		}
+
+		if ( $this->cachedSiteId === $siteId && null !== $this->cachedSite ) {
+			return $this->cachedSite;
+		}
+
+		// Deliberately not withoutGlobalScopes(): Site carries the soft-delete
+		// scope, and a deleted site must not come back as the current one.
+		$site = Site::query()
+			->where( 'id', $siteId )
+			->first();
+
+		$this->cachedSite   = $site;
+		$this->cachedSiteId = null !== $site ? $siteId : null;
+
+		return $site;
 	}
 
 	/**
 	 * Set the current site.
+	 *
+	 * Pins the site in the shared context, so every package that scopes by
+	 * site sees it, not just this one.
 	 *
 	 * @param Site|null $site The site to set as current.
 	 *
@@ -167,7 +176,11 @@ class TenantManager
 	 */
 	public function setCurrent( ?Site $site ): static
 	{
-		$this->currentSite = $site;
+		$this->context->setSiteId( $site?->id );
+
+		$this->defaultSuppressed = null === $site;
+		$this->cachedSite        = $site;
+		$this->cachedSiteId      = $site?->id;
 
 		return $this;
 	}
@@ -175,13 +188,37 @@ class TenantManager
 	/**
 	 * Get the current site ID.
 	 *
+	 * Answers from the shared context, falling back to the configured default
+	 * site when nothing puts a site in context.
+	 *
 	 * @return int|null The current site ID, or null if not set.
 	 *
 	 * @since 1.0.0
 	 */
 	public function currentId(): ?int
 	{
-		return $this->currentSite?->id;
+		$siteId = $this->context->currentSiteId();
+
+		if ( null !== $siteId ) {
+			if ( is_numeric( $siteId ) ) {
+				return (int) $siteId;
+			}
+
+			// Another package's resolver named a site this package cannot have
+			// a record for — analytics site IDs are integers. Leave queries
+			// unscoped, and do not reach for the default site: a site *is* in
+			// context, so attributing this work to a different one would file
+			// it under the wrong site rather than under none.
+			$this->warnAboutUnusableSiteId( $siteId );
+
+			return null;
+		}
+
+		if ( $this->defaultSuppressed || $this->withoutSiteDepth > 0 ) {
+			return null;
+		}
+
+		return $this->defaultSiteId();
 	}
 
 	/**
@@ -193,31 +230,47 @@ class TenantManager
 	 */
 	public function hasCurrent(): bool
 	{
-		return null !== $this->currentSite;
+		return null !== $this->currentId();
 	}
 
 	/**
 	 * Execute a callback in the context of a specific site.
 	 *
-	 * The site context is restored after the callback completes.
+	 * The site context is restored after the callback completes, including
+	 * when the callback throws, and the pinned site is visible to every
+	 * package for the duration.
 	 *
-	 * @param Site    $site     The site to use as context.
-	 * @param Closure $callback The callback to execute.
+	 * @param int|Site|string $site     The site, or site identifier, to use as context.
+	 * @param Closure         $callback The callback to execute.
 	 *
 	 * @return mixed The callback return value.
 	 *
 	 * @since 1.0.0
 	 */
-	public function forSite( Site $site, Closure $callback ): mixed
+	public function forSite( Site|int|string $site, Closure $callback ): mixed
 	{
-		$previousSite = $this->currentSite;
+		$siteId = $site instanceof Site ? $site->id : $site;
 
-		$this->currentSite = $site;
+		$previousSite         = $this->cachedSite;
+		$previousSiteId       = $this->cachedSiteId;
+		$previouslySuppressed = $this->defaultSuppressed;
+
+		$this->defaultSuppressed = false;
+
+		if ( $site instanceof Site ) {
+			$this->cachedSite   = $site;
+			$this->cachedSiteId = $site->id;
+		} else {
+			$this->cachedSite   = null;
+			$this->cachedSiteId = null;
+		}
 
 		try {
-			return $callback( $site );
+			return $this->context->forSite( $siteId, fn () => $callback( $site ) );
 		} finally {
-			$this->currentSite = $previousSite;
+			$this->cachedSite        = $previousSite;
+			$this->cachedSiteId      = $previousSiteId;
+			$this->defaultSuppressed = $previouslySuppressed;
 		}
 	}
 
@@ -234,19 +287,27 @@ class TenantManager
 	 */
 	public function withoutSite( Closure $callback ): mixed
 	{
-		$previousSite = $this->currentSite;
+		$previousSite   = $this->cachedSite;
+		$previousSiteId = $this->cachedSiteId;
 
-		$this->currentSite = null;
+		$this->cachedSite   = null;
+		$this->cachedSiteId = null;
+		++$this->withoutSiteDepth;
 
 		try {
-			return $callback();
+			return $this->context->withoutSite( fn () => $callback() );
 		} finally {
-			$this->currentSite = $previousSite;
+			--$this->withoutSiteDepth;
+			$this->cachedSite   = $previousSite;
+			$this->cachedSiteId = $previousSiteId;
 		}
 	}
 
 	/**
 	 * Clear the current site context.
+	 *
+	 * Releases the pinned site for every package, handing resolution back to
+	 * the configured resolvers.
 	 *
 	 * @return static
 	 *
@@ -254,7 +315,9 @@ class TenantManager
 	 */
 	public function forget(): static
 	{
-		$this->currentSite = null;
+		$this->context->forget();
+
+		$this->resetCaches();
 
 		return $this;
 	}
@@ -272,40 +335,130 @@ class TenantManager
 	 */
 	public function flush(): static
 	{
-		$this->currentSite = null;
+		$this->context->flush();
+
+		$this->resetCaches();
 
 		return $this;
 	}
 
 	/**
-	 * Get all registered resolvers.
+	 * Get the shared site context this manager delegates to.
 	 *
-	 * @return array<SiteResolverInterface>
+	 * @return SiteContext The shared context.
+	 *
+	 * @since 1.5.0
+	 */
+	public function context(): SiteContext
+	{
+		return $this->context;
+	}
+
+	/**
+	 * Get the resolvers backing site resolution.
+	 *
+	 * These come from `artisanpack.core.multi_tenant.resolvers` and are shared
+	 * with every other package, so the list may contain resolvers this package
+	 * knows nothing about.
+	 *
+	 * @return array<int, SiteResolver> The resolvers, in the order they are asked.
 	 *
 	 * @since 1.0.0
 	 */
 	public function getResolvers(): array
 	{
-		$this->sortResolvers();
+		$resolver = $this->context->resolver();
 
-		return $this->resolvers;
+		return $resolver instanceof ChainSiteResolver ? $resolver->resolvers() : [ $resolver ];
 	}
 
 	/**
-	 * Sort resolvers by priority.
+	 * Log a site identifier this package cannot use, once per instance.
+	 *
+	 * Once, because this is reached from every scoped query: logging each time
+	 * would bury the fault it is reporting.
+	 *
+	 * @param int|string $siteId The identifier the shared context returned.
 	 *
 	 * @return void
 	 *
-	 * @since 1.0.0
+	 * @since 1.5.0
 	 */
-	protected function sortResolvers(): void
+	protected function warnAboutUnusableSiteId( int|string $siteId ): void
 	{
-		if ( $this->resolversSorted ) {
+		if ( $this->warnedAboutSiteId ) {
 			return;
 		}
 
-		usort( $this->resolvers, fn ( $a, $b ) => $a->priority() <=> $b->priority() );
+		$this->warnedAboutSiteId = true;
 
-		$this->resolversSorted = true;
+		// The identifier goes in the context array rather than the message: it
+		// can originate in a request header, and a value carrying newlines
+		// interpolated into a log line can forge log entries.
+		Log::warning(
+			__(
+				'[Analytics] The shared site context resolved to an identifier that is not an analytics site ID,'
+					. ' so analytics queries are not being scoped by site. Analytics sites are identified by'
+					. ' integer IDs; check the resolvers in "artisanpack.core.multi_tenant.resolvers".',
+			),
+			[ 'site_id' => $siteId ],
+		);
+	}
+
+	/**
+	 * Clear the locally cached site and default-site lookups.
+	 *
+	 * @return void
+	 *
+	 * @since 1.5.0
+	 */
+	protected function resetCaches(): void
+	{
+		$this->cachedSite           = null;
+		$this->cachedSiteId         = null;
+		$this->defaultSuppressed    = false;
+		$this->checkedDefaultSiteId = null;
+		$this->defaultSiteUsable    = false;
+	}
+
+	/**
+	 * Get the configured default site ID.
+	 *
+	 * Kept from before the move to the shared context: an application that
+	 * names a default site expects its analytics to land there when nothing
+	 * else identifies one. The site still has to exist and be active, so a
+	 * stale identifier leaves the context empty rather than silently attaching
+	 * every visit to a deleted site.
+	 *
+	 * @return int|null The default site ID, or null when none is usable.
+	 *
+	 * @since 1.5.0
+	 */
+	protected function defaultSiteId(): ?int
+	{
+		$defaultSiteId = config( 'artisanpack.analytics.multi_tenant.default_site_id' );
+
+		if ( null === $defaultSiteId || '' === $defaultSiteId || ! is_numeric( $defaultSiteId ) ) {
+			return null;
+		}
+
+		$defaultSiteId = (int) $defaultSiteId;
+
+		// The existence check is memoised because this runs from every model's
+		// global scope, on every query. Left unmemoised it would put a second
+		// query in front of each one. `forget()` and `flush()` clear it, which
+		// covers the case of the default site being created or deactivated
+		// within a single process.
+		if ( $this->checkedDefaultSiteId === $defaultSiteId ) {
+			return $this->defaultSiteUsable ? $defaultSiteId : null;
+		}
+
+		$this->checkedDefaultSiteId = $defaultSiteId;
+		$this->defaultSiteUsable    = Site::query()
+			->where( 'id', $defaultSiteId )
+			->where( 'is_active', true )
+			->exists();
+
+		return $this->defaultSiteUsable ? $defaultSiteId : null;
 	}
 }

--- a/src/Services/TenantManager.php
+++ b/src/Services/TenantManager.php
@@ -200,7 +200,11 @@ class TenantManager
 		$siteId = $this->context->currentSiteId();
 
 		if ( null !== $siteId ) {
-			if ( is_numeric( $siteId ) ) {
+			// Deliberately stricter than is_numeric(), which accepts "12.5",
+			// "1e3", " 12" and "-3" — each of which casts to an int that is
+			// either a different site or no site at all. "12.5" becoming site
+			// 12 would attribute this work to a real, wrong site.
+			if ( is_int( $siteId ) || ( is_string( $siteId ) && 1 === preg_match( '/^\d+$/', $siteId ) ) ) {
 				return (int) $siteId;
 			}
 
@@ -287,8 +291,9 @@ class TenantManager
 	 */
 	public function withoutSite( Closure $callback ): mixed
 	{
-		$previousSite   = $this->cachedSite;
-		$previousSiteId = $this->cachedSiteId;
+		$previousSite         = $this->cachedSite;
+		$previousSiteId       = $this->cachedSiteId;
+		$previouslySuppressed = $this->defaultSuppressed;
 
 		$this->cachedSite   = null;
 		$this->cachedSiteId = null;
@@ -300,6 +305,11 @@ class TenantManager
 			--$this->withoutSiteDepth;
 			$this->cachedSite   = $previousSite;
 			$this->cachedSiteId = $previousSiteId;
+
+			// Restored like the rest: a `setCurrent( null )` inside the
+			// callback would otherwise outlive the scope and suppress the
+			// default site for every later query in the request.
+			$this->defaultSuppressed = $previouslySuppressed;
 		}
 	}
 

--- a/src/Traits/BelongsToSite.php
+++ b/src/Traits/BelongsToSite.php
@@ -67,7 +67,8 @@ trait BelongsToSite
 	/**
 	 * Scope a query to filter by current site.
 	 *
-	 * Uses the TenantManager to determine the current site.
+	 * The site comes from the shared site context, so this scopes to the same
+	 * site every other ArtisanPack UI package is scoping to.
 	 *
 	 * @param Builder $query The query builder.
 	 *
@@ -164,7 +165,7 @@ trait BelongsToSite
 	public static function withoutSiteScopeCallback( callable $callback ): mixed
 	{
 		if ( app()->bound( TenantManager::class ) ) {
-			return app( TenantManager::class )->withoutSite( $callback );
+			return app( TenantManager::class )->withoutSite( fn () => $callback() );
 		}
 
 		return $callback();
@@ -178,7 +179,7 @@ trait BelongsToSite
 	protected static function bootBelongsToSite(): void
 	{
 		// Add global scope for automatic site filtering when multi-tenant is enabled
-		if ( config( 'artisanpack.analytics.multi_tenant.enabled', false ) ) {
+		if ( analyticsMultiTenancyEnabled() ) {
 			static::addGlobalScope( 'site', new class implements Scope {
 				/**
 				 * Apply the scope to a given Eloquent query builder.
@@ -190,10 +191,10 @@ trait BelongsToSite
 				 */
 				public function apply( Builder $builder, Model $model ): void
 				{
-					$tenantManager = app( TenantManager::class );
+					$siteId = app( TenantManager::class )->currentId();
 
-					if ( $tenantManager->hasCurrent() ) {
-						$builder->where( $model->getTable() . '.site_id', $tenantManager->currentId() );
+					if ( null !== $siteId ) {
+						$builder->where( $model->getTable() . '.site_id', $siteId );
 					}
 				}
 			} );
@@ -210,8 +211,12 @@ trait BelongsToSite
 	/**
 	 * Get the current site ID.
 	 *
-	 * Uses the TenantManager to determine the current site.
-	 * Falls back to configuration if no TenantManager context.
+	 * Reads the ecosystem's shared site context through the TenantManager,
+	 * which also applies the configured default site. The old
+	 * `artisanpack.analytics.multi_site.resolver` fallback is gone: a second
+	 * resolver reachable only from this trait could disagree with the one
+	 * every other query used, which is the divergence the shared context
+	 * exists to remove.
 	 *
 	 * @return int|null
 	 *
@@ -219,38 +224,10 @@ trait BelongsToSite
 	 */
 	protected static function getCurrentSiteId(): ?int
 	{
-		// First, check TenantManager
-		if ( app()->bound( TenantManager::class ) ) {
-			$tenantManager = app( TenantManager::class );
-
-			if ( $tenantManager->hasCurrent() ) {
-				return $tenantManager->currentId();
-			}
+		if ( ! app()->bound( TenantManager::class ) ) {
+			return null;
 		}
 
-		// Fall back to legacy resolver configuration
-		$resolver = config( 'artisanpack.analytics.multi_site.resolver' );
-
-		if ( null === $resolver ) {
-			$defaultSiteId = config( 'artisanpack.analytics.multi_site.default_site_id' );
-
-			return is_int( $defaultSiteId ) ? $defaultSiteId : null;
-		}
-
-		$result = null;
-
-		if ( is_callable( $resolver ) ) {
-			$result = $resolver();
-		} elseif ( is_string( $resolver ) && class_exists( $resolver ) ) {
-			$instance = app( $resolver );
-
-			if ( method_exists( $instance, 'resolve' ) ) {
-				$result = $instance->resolve();
-			} elseif ( method_exists( $instance, '__invoke' ) ) {
-				$result = $instance();
-			}
-		}
-
-		return is_int( $result ) ? $result : null;
+		return app( TenantManager::class )->currentId();
 	}
 }

--- a/src/Traits/BelongsToSite.php
+++ b/src/Traits/BelongsToSite.php
@@ -178,27 +178,34 @@ trait BelongsToSite
 	 */
 	protected static function bootBelongsToSite(): void
 	{
-		// Add global scope for automatic site filtering when multi-tenant is enabled
-		if ( analyticsMultiTenancyEnabled() ) {
-			static::addGlobalScope( 'site', new class implements Scope {
-				/**
-				 * Apply the scope to a given Eloquent query builder.
-				 *
-				 * @param Builder $builder The query builder.
-				 * @param Model   $model   The model.
-				 *
-				 * @return void
-				 */
-				public function apply( Builder $builder, Model $model ): void
-				{
-					$siteId = app( TenantManager::class )->currentId();
-
-					if ( null !== $siteId ) {
-						$builder->where( $model->getTable() . '.site_id', $siteId );
-					}
+		// The scope is registered unconditionally and decides at query time
+		// whether to apply. Booting a model happens once per class per
+		// process, and whether tenancy is on is only settled once every
+		// provider has booted — a model that booted first would otherwise
+		// carry no scope for the life of the process, and run unscoped in an
+		// installation whose configuration says it is multi-site.
+		static::addGlobalScope( 'site', new class implements Scope {
+			/**
+			 * Apply the scope to a given Eloquent query builder.
+			 *
+			 * @param Builder $builder The query builder.
+			 * @param Model   $model   The model.
+			 *
+			 * @return void
+			 */
+			public function apply( Builder $builder, Model $model ): void
+			{
+				if ( ! analyticsMultiTenancyEnabled() ) {
+					return;
 				}
-			} );
-		}
+
+				$siteId = app( TenantManager::class )->currentId();
+
+				if ( null !== $siteId ) {
+					$builder->where( $model->getTable() . '.site_id', $siteId );
+				}
+			}
+		} );
 
 		// Automatically set site_id when creating new records
 		static::creating( function ( $model ): void {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -374,6 +374,32 @@ if ( ! function_exists( 'analyticsRealtime' ) ) {
 |--------------------------------------------------------------------------
 */
 
+if ( ! function_exists( 'analyticsMultiTenancyEnabled' ) ) {
+	/**
+	 * Determine whether analytics should scope its data by site.
+	 *
+	 * True when either switch is on: `artisanpack.core.multi_tenant.enabled`,
+	 * the ecosystem-wide flag every package reads, or this package's own
+	 * `artisanpack.analytics.multi_tenant.enabled`, which predates it. The
+	 * legacy flag is still honoured because an application that switched
+	 * analytics tenancy on before 1.5.0 would otherwise silently stop scoping
+	 * — every site's visits pooling into one dashboard, with nothing in the
+	 * logs to say why.
+	 *
+	 * @return bool True when a site should be resolved and queries scoped.
+	 *
+	 * @since 1.5.0
+	 */
+	function analyticsMultiTenancyEnabled(): bool
+	{
+		if ( (bool) config( 'artisanpack.analytics.multi_tenant.enabled', false ) ) {
+			return true;
+		}
+
+		return (bool) config( 'artisanpack.core.multi_tenant.enabled', false );
+	}
+}
+
 if ( ! function_exists( 'analyticsSite' ) ) {
 	/**
 	 * Get the current analytics site from the TenantManager.
@@ -384,11 +410,11 @@ if ( ! function_exists( 'analyticsSite' ) ) {
 	 */
 	function analyticsSite(): ?Site
 	{
-		if ( ! config( 'artisanpack.analytics.multi_tenant.enabled', false ) ) {
+		if ( ! analyticsMultiTenancyEnabled() ) {
 			return null;
 		}
 
-		return app( TenantManager::class )->currentSite();
+		return app( TenantManager::class )->current();
 	}
 }
 
@@ -402,11 +428,11 @@ if ( ! function_exists( 'analyticsTenantId' ) ) {
 	 */
 	function analyticsTenantId(): int|string|null
 	{
-		if ( ! config( 'artisanpack.analytics.multi_tenant.enabled', false ) ) {
+		if ( ! analyticsMultiTenancyEnabled() ) {
 			return null;
 		}
 
-		return app( TenantManager::class )->currentTenantId();
+		return app( TenantManager::class )->currentId();
 	}
 }
 

--- a/tests/Feature/SharedSiteResolutionTest.php
+++ b/tests/Feature/SharedSiteResolutionTest.php
@@ -406,3 +406,81 @@ it( 'leaves queries unscoped when the shared site is not an analytics site ID', 
 	expect( $analytics->currentId() )->toBeNull()
 		->and( $analytics->current() )->toBeNull();
 } );
+
+it( 'restores the default-site suppression after withoutSite()', function (): void {
+	$default = sharedResolutionSite( 'Default' );
+
+	useSharedResolvers( [] );
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', $default->id );
+
+	$analytics = app( TenantManager::class );
+
+	// A callback that pins "no site" must not leave that suppression behind
+	// for the rest of the request.
+	$analytics->withoutSite( function () use ( $analytics ): void {
+		$analytics->setCurrent( null );
+	} );
+
+	expect( $analytics->currentId() )->toBe( $default->id );
+} );
+
+it( 'rejects identifiers that only look numeric', function ( int|string $siteId ): void {
+	useSharedResolvers( [] );
+
+	app( SiteContext::class )->setSiteId( $siteId );
+
+	expect( app( TenantManager::class )->currentId() )->toBeNull();
+} )->with( [
+	'decimal'     => '12.5',
+	'exponent'    => '1e3',
+	'padded'      => ' 12',
+	'negative'    => '-3',
+	'hexadecimal' => '0x1A',
+] );
+
+it( 'accepts an integer-shaped identifier from another package', function (): void {
+	$site = sharedResolutionSite( 'Stringly typed' );
+
+	useSharedResolvers( [] );
+
+	app( SiteContext::class )->setSiteId( (string) $site->id );
+
+	expect( app( TenantManager::class )->currentId() )->toBe( $site->id );
+} );
+
+it( 'scopes models when tenancy is switched on after the model booted', function (): void {
+	$site = sharedResolutionSite( 'Late' );
+
+	// Boot the model while tenancy is off, the way a model touched by another
+	// provider during boot would be.
+	config()->set( 'artisanpack.analytics.multi_tenant.enabled', false );
+	config()->set( 'artisanpack.core.multi_tenant.enabled', false );
+	Goal::query()->count();
+
+	sharedResolutionGoal( 'Scoped late', $site->id );
+	sharedResolutionGoal( 'Other site', $site->id + 100 );
+
+	useSharedResolvers( [] );
+	app( SiteContext::class )->setSiteId( $site->id );
+
+	expect( Goal::query()->pluck( 'name' )->all() )->toBe( [ 'Scoped late' ] );
+} );
+
+it( 'does not publish the analytics default site into the shared context', function (): void {
+	$default = sharedResolutionSite( 'Default' );
+
+	useSharedResolvers( [ HeaderResolver::class ] );
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', $default->id );
+
+	$request = Request::create( '/', 'GET' );
+	app()->instance( 'request', $request );
+
+	app( ResolveSite::class )->handle( $request, fn () => new Response );
+
+	// Analytics still falls back to its own default...
+	expect( app( TenantManager::class )->currentId() )->toBe( $default->id )
+		->and( $request->attributes->get( 'site_id' ) )->toBe( $default->id )
+		// ...but a sibling package must not be scoped to a default it never
+		// configured.
+		->and( app( SiteContext::class )->currentSiteId() )->toBeNull();
+} );

--- a/tests/Feature/SharedSiteResolutionTest.php
+++ b/tests/Feature/SharedSiteResolutionTest.php
@@ -1,0 +1,408 @@
+<?php
+
+declare( strict_types=1 );
+
+use ArtisanPackUI\Analytics\AnalyticsServiceProvider;
+use ArtisanPackUI\Analytics\Http\Middleware\ResolveSite;
+use ArtisanPackUI\Analytics\Models\Goal;
+use ArtisanPackUI\Analytics\Models\Site;
+use ArtisanPackUI\Analytics\Resolvers\HeaderResolver;
+use ArtisanPackUI\Analytics\Services\TenantManager;
+use ArtisanPackUI\Core\Contracts\SiteResolver;
+use ArtisanPackUI\Core\MultiTenancy\ChainSiteResolver;
+use ArtisanPackUI\Core\MultiTenancy\HookSiteResolver;
+use ArtisanPackUI\Core\MultiTenancy\SiteContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\View;
+
+uses( RefreshDatabase::class );
+
+/**
+ * Stands in for a sibling package that scopes its own data by site.
+ *
+ * It knows nothing about analytics: it reads the shared context and nothing
+ * else, exactly as artisanpack-ui/bookings does. Any test where this and the
+ * TenantManager disagree is the bug this refactor exists to prevent.
+ */
+final class SiblingPackageSiteConsumer
+{
+	public function __construct( private SiteContext $context )
+	{
+	}
+
+	public function currentSiteId(): int|string|null
+	{
+		return $this->context->currentSiteId();
+	}
+}
+
+/**
+ * Create an active site.
+ */
+function sharedResolutionSite( string $name, ?string $domain = null ): Site
+{
+	return Site::create( [
+		'name'      => $name,
+		'domain'    => $domain,
+		'is_active' => true,
+	] );
+}
+
+/**
+ * Create a goal belonging to the given site.
+ */
+function sharedResolutionGoal( string $name, int $siteId ): Goal
+{
+	return Goal::withoutSiteScopeCallback( fn () => Goal::create( [
+		'name'       => $name,
+		'site_id'    => $siteId,
+		'type'       => 'page_view',
+		'conditions' => [ 'path' => '/' ],
+	] ) );
+}
+
+/**
+ * Switch site resolution on with the given shared resolver list.
+ *
+ * @param array<int, class-string<SiteResolver>> $resolvers
+ */
+function useSharedResolvers( array $resolvers ): void
+{
+	config()->set( 'artisanpack.core.multi_tenant.enabled', true );
+	config()->set( 'artisanpack.core.multi_tenant.resolvers', $resolvers );
+
+	// The chain and the context are scoped bindings built from configuration,
+	// so they have to be rebuilt once the configuration changes.
+	app()->forgetInstance( SiteResolver::class );
+	app()->forgetInstance( SiteContext::class );
+	app()->forgetInstance( TenantManager::class );
+}
+
+/**
+ * Run the legacy-configuration bridge the service provider runs at boot.
+ */
+function bridgeLegacyAnalyticsTenancy(): void
+{
+	$provider = new class( app() ) extends AnalyticsServiceProvider {
+		public function bridge(): void
+		{
+			$this->bridgeLegacyMultiTenantConfig();
+		}
+	};
+
+	$provider->bridge();
+}
+
+it( 'resolves the same site for analytics and a sibling package from one configuration', function (): void {
+	$siteOne = sharedResolutionSite( 'Site One' );
+	$siteTwo = sharedResolutionSite( 'Site Two' );
+
+	useSharedResolvers( [ HeaderResolver::class ] );
+
+	app()->instance( 'request', Request::create( '/', 'GET', [], [], [], [
+		'HTTP_X_SITE_ID' => (string) $siteTwo->id,
+	] ) );
+
+	$analytics = app( TenantManager::class );
+	$sibling   = new SiblingPackageSiteConsumer( app( SiteContext::class ) );
+
+	expect( $analytics->currentId() )->toBe( $siteTwo->id )
+		->and( $analytics->current()?->id )->toBe( $siteTwo->id )
+		->and( $sibling->currentSiteId() )->toBe( $siteTwo->id )
+		->and( $sibling->currentSiteId() )->not->toBe( $siteOne->id );
+} );
+
+it( 'shows a site pinned through analytics to a sibling package, and the reverse', function (): void {
+	$site = sharedResolutionSite( 'Pinned' );
+
+	useSharedResolvers( [] );
+
+	$analytics = app( TenantManager::class );
+	$sibling   = new SiblingPackageSiteConsumer( app( SiteContext::class ) );
+
+	$analytics->setCurrent( $site );
+
+	expect( $sibling->currentSiteId() )->toBe( $site->id );
+
+	$analytics->forget();
+
+	expect( $sibling->currentSiteId() )->toBeNull()
+		->and( $analytics->hasCurrent() )->toBeFalse();
+
+	app( SiteContext::class )->setSiteId( $site->id );
+
+	expect( $analytics->currentId() )->toBe( $site->id )
+		->and( $analytics->current()?->id )->toBe( $site->id );
+} );
+
+it( 'restores the surrounding context after forSite() and withoutSite()', function (): void {
+	$outer = sharedResolutionSite( 'Outer' );
+	$inner = sharedResolutionSite( 'Inner' );
+
+	useSharedResolvers( [] );
+
+	$analytics = app( TenantManager::class );
+	$sibling   = new SiblingPackageSiteConsumer( app( SiteContext::class ) );
+
+	$analytics->setCurrent( $outer );
+
+	$seen = $analytics->forSite( $inner, fn () => $sibling->currentSiteId() );
+
+	expect( $seen )->toBe( $inner->id )
+		->and( $sibling->currentSiteId() )->toBe( $outer->id );
+
+	$seen = $analytics->withoutSite( fn () => $sibling->currentSiteId() );
+
+	expect( $seen )->toBeNull()
+		->and( $sibling->currentSiteId() )->toBe( $outer->id );
+} );
+
+it( 'accepts a bare identifier for forSite() so console work needs no model', function (): void {
+	$site = sharedResolutionSite( 'By identifier' );
+
+	useSharedResolvers( [] );
+
+	$analytics = app( TenantManager::class );
+
+	$seen = $analytics->forSite( $site->id, fn () => $analytics->current()?->id );
+
+	expect( $seen )->toBe( $site->id );
+} );
+
+it( 'releases the shared context on flush() for Octane', function (): void {
+	$site = sharedResolutionSite( 'Octane' );
+
+	useSharedResolvers( [] );
+
+	$analytics = app( TenantManager::class );
+	$analytics->setCurrent( $site );
+
+	$analytics->flush();
+
+	expect( app( SiteContext::class )->currentSiteId() )->toBeNull()
+		->and( $analytics->current() )->toBeNull();
+} );
+
+it( 'exposes the shared resolver chain rather than a private one', function (): void {
+	useSharedResolvers( [ HeaderResolver::class ] );
+
+	$resolvers = app( TenantManager::class )->getResolvers();
+
+	expect( app( SiteContext::class )->resolver() )->toBeInstanceOf( ChainSiteResolver::class )
+		->and( $resolvers )->toHaveCount( 1 )
+		->and( $resolvers[0] )->toBeInstanceOf( HeaderResolver::class );
+} );
+
+it( 'scopes models on the shared context', function (): void {
+	$siteOne = sharedResolutionSite( 'Scoped One' );
+	$siteTwo = sharedResolutionSite( 'Scoped Two' );
+
+	useSharedResolvers( [] );
+
+	$analytics = app( TenantManager::class );
+
+	sharedResolutionGoal( 'Goal One', $siteOne->id );
+	sharedResolutionGoal( 'Goal Two', $siteTwo->id );
+
+	// The site the scope reads is the shared one, so pinning it from outside
+	// this package still scopes analytics queries.
+	app( SiteContext::class )->setSiteId( $siteOne->id );
+
+	expect( Goal::forCurrentSite()->pluck( 'name' )->all() )->toBe( [ 'Goal One' ] )
+		->and( Goal::allSites()->count() )->toBe( 2 )
+		->and( Goal::withoutSiteScope()->count() )->toBe( 2 )
+		->and( Goal::query()->pluck( 'name' )->all() )->toBe( [ 'Goal One' ] );
+} );
+
+it( 'assigns the shared context site to new records', function (): void {
+	$site = sharedResolutionSite( 'Creating' );
+
+	useSharedResolvers( [] );
+
+	app( SiteContext::class )->setSiteId( $site->id );
+
+	$goal = Goal::create( [
+		'name'       => 'Assigned',
+		'type'       => 'page_view',
+		'conditions' => [ 'path' => '/assigned' ],
+	] );
+
+	expect( $goal->site_id )->toBe( $site->id );
+} );
+
+it( 'falls back to the configured default site when nothing resolves', function (): void {
+	$site = sharedResolutionSite( 'Default' );
+
+	useSharedResolvers( [] );
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', $site->id );
+
+	$analytics = app( TenantManager::class );
+
+	expect( $analytics->currentId() )->toBe( $site->id )
+		->and( $analytics->current()?->id )->toBe( $site->id );
+} );
+
+it( 'ignores a default site that is missing or inactive', function (): void {
+	$inactive = Site::create( [
+		'name'      => 'Inactive',
+		'is_active' => false,
+	] );
+
+	useSharedResolvers( [] );
+
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', $inactive->id );
+	expect( app( TenantManager::class )->currentId() )->toBeNull();
+
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', 9999 );
+	app()->forgetInstance( TenantManager::class );
+
+	expect( app( TenantManager::class )->currentId() )->toBeNull();
+} );
+
+it( 'does not let the default site stand in for an explicit no-site', function (): void {
+	$site = sharedResolutionSite( 'Default' );
+
+	useSharedResolvers( [] );
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', $site->id );
+
+	$analytics = app( TenantManager::class );
+
+	expect( $analytics->withoutSite( fn () => $analytics->currentId() ) )->toBeNull()
+		->and( $analytics->currentId() )->toBe( $site->id );
+
+	$analytics->setCurrent( null );
+
+	expect( $analytics->currentId() )->toBeNull();
+} );
+
+it( 'bridges a pre-1.5 analytics tenancy configuration onto the shared one', function (): void {
+	// The configuration an installation upgrading from 1.4 arrives with:
+	// tenancy switched on and resolvers listed under the analytics key, with
+	// the shared switch still at its default of off.
+	config()->set( 'artisanpack.analytics.multi_tenant.enabled', true );
+	config()->set( 'artisanpack.analytics.multi_tenant.resolvers', [ HeaderResolver::class ] );
+	config()->set( 'artisanpack.core.multi_tenant.enabled', false );
+	config()->set( 'artisanpack.core.multi_tenant.resolvers', [ HookSiteResolver::class ] );
+
+	bridgeLegacyAnalyticsTenancy();
+
+	expect( config( 'artisanpack.core.multi_tenant.enabled' ) )->toBeTrue()
+		// The legacy list goes first, so a request that resolved by header
+		// before the upgrade still resolves by header after it.
+		->and( config( 'artisanpack.core.multi_tenant.resolvers' ) )
+		->toBe( [ HeaderResolver::class, HookSiteResolver::class ] );
+} );
+
+it( 'leaves a migrated configuration alone', function (): void {
+	config()->set( 'artisanpack.analytics.multi_tenant.enabled', false );
+	config()->set( 'artisanpack.analytics.multi_tenant.resolvers', [ HeaderResolver::class ] );
+	config()->set( 'artisanpack.core.multi_tenant.enabled', true );
+	config()->set( 'artisanpack.core.multi_tenant.resolvers', [ HookSiteResolver::class ] );
+
+	bridgeLegacyAnalyticsTenancy();
+
+	expect( config( 'artisanpack.core.multi_tenant.resolvers' ) )->toBe( [ HookSiteResolver::class ] );
+} );
+
+it( 'bridges nothing twice when the legacy resolvers are already shared', function (): void {
+	config()->set( 'artisanpack.analytics.multi_tenant.enabled', true );
+	config()->set( 'artisanpack.analytics.multi_tenant.resolvers', [ HeaderResolver::class ] );
+	config()->set( 'artisanpack.core.multi_tenant.resolvers', [ HeaderResolver::class ] );
+
+	bridgeLegacyAnalyticsTenancy();
+	bridgeLegacyAnalyticsTenancy();
+
+	expect( config( 'artisanpack.core.multi_tenant.resolvers' ) )->toBe( [ HeaderResolver::class ] );
+} );
+
+it( 'shares the context-resolved site through the ResolveSite middleware', function (): void {
+	$site = sharedResolutionSite( 'Middleware', 'middleware.test' );
+
+	useSharedResolvers( [ HeaderResolver::class ] );
+
+	$request = Request::create( '/', 'GET', [], [], [], [
+		'HTTP_X_SITE_ID' => (string) $site->id,
+	] );
+
+	app()->instance( 'request', $request );
+
+	$response = app( ResolveSite::class )->handle( $request, fn () => new Response );
+
+	expect( $response->getStatusCode() )->toBe( 200 )
+		->and( $request->attributes->get( 'site_id' ) )->toBe( $site->id )
+		->and( $request->attributes->get( 'site' )?->id )->toBe( $site->id )
+		->and( View::shared( 'currentSiteId' ) )->toBe( $site->id );
+} );
+
+it( 'leaves the request alone when tenancy is switched off everywhere', function (): void {
+	sharedResolutionSite( 'Unused', 'unused.test' );
+
+	config()->set( 'artisanpack.analytics.multi_tenant.enabled', false );
+	config()->set( 'artisanpack.core.multi_tenant.enabled', false );
+
+	$request  = Request::create( '/', 'GET' );
+	$response = app( ResolveSite::class )->handle( $request, fn () => new Response );
+
+	expect( $response->getStatusCode() )->toBe( 200 )
+		->and( $request->attributes->has( 'site_id' ) )->toBeFalse();
+} );
+
+it( 'does not resurrect a soft-deleted site as the current one', function (): void {
+	$site = sharedResolutionSite( 'Deleted' );
+
+	useSharedResolvers( [] );
+
+	app( SiteContext::class )->setSiteId( $site->id );
+	$site->delete();
+
+	expect( app( TenantManager::class )->current() )->toBeNull();
+} );
+
+it( 'ignores a soft-deleted default site', function (): void {
+	$site = sharedResolutionSite( 'Deleted default' );
+	$site->delete();
+
+	useSharedResolvers( [] );
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', $site->id );
+
+	expect( app( TenantManager::class )->currentId() )->toBeNull();
+} );
+
+it( 'pins the resolved site for the rest of the request', function (): void {
+	$site = sharedResolutionSite( 'Pinned by middleware' );
+
+	useSharedResolvers( [ HeaderResolver::class ] );
+
+	$request = Request::create( '/', 'GET', [], [], [], [
+		'HTTP_X_SITE_ID' => (string) $site->id,
+	] );
+
+	app()->instance( 'request', $request );
+	app( ResolveSite::class )->handle( $request, fn () => new Response );
+
+	// Nothing left for a resolver to answer from, so a site still in context
+	// can only have come from the pin the middleware set.
+	app()->instance( 'request', Request::create( '/', 'GET' ) );
+
+	expect( app( SiteContext::class )->currentSiteId() )->toBe( $site->id );
+} );
+
+it( 'leaves queries unscoped when the shared site is not an analytics site ID', function (): void {
+	$default = sharedResolutionSite( 'Default' );
+
+	useSharedResolvers( [] );
+	config()->set( 'artisanpack.analytics.multi_tenant.default_site_id', $default->id );
+
+	// A sibling package's resolver can legitimately name a site by slug.
+	app( SiteContext::class )->setSiteId( 'acme' );
+
+	$analytics = app( TenantManager::class );
+
+	// Not the default site: a site is in context, it is simply not one this
+	// package has a record for, and filing the work under a different site
+	// would be worse than not scoping it.
+	expect( $analytics->currentId() )->toBeNull()
+		->and( $analytics->current() )->toBeNull();
+} );

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -59,6 +59,10 @@ abstract class TestCase extends BaseTestCase
 			LivewireServiceProvider::class,
 		];
 
+		if ( class_exists( \ArtisanPackUI\Core\CoreServiceProvider::class ) ) {
+			$providers[] = \ArtisanPackUI\Core\CoreServiceProvider::class;
+		}
+
 		if ( class_exists( \ArtisanPackUI\Hooks\Providers\HooksServiceProvider::class ) ) {
 			$providers[] = \ArtisanPackUI\Hooks\Providers\HooksServiceProvider::class;
 		}


### PR DESCRIPTION
## Description

Site resolution now happens once for the whole ArtisanPack UI ecosystem, in `artisanpack-ui/core`. `TenantManager` no longer owns a resolver chain: it reads `ArtisanPackUI\Core\MultiTenancy\SiteContext` and looks the `Site` model up from the identifier that contract returns. A site pinned through analytics is pinned for every package, and a site pinned by another package is seen here.

**Closes:** #94

## Type of Change

- [x] Refactoring (code improvement, no behavior change)
- [x] Bug fix (fixes an issue)
- [x] Documentation update

## Related Issue

**Issue:** #94

Related: ArtisanPack-UI/core#39 (the contract this binds against), ArtisanPack-UI/bookings#56 (same migration on the bookings side), ArtisanPack-UI/bookings#55 (where this surfaced).

## Motivation and Context

Two packages shipped mutually incompatible answers to "which site is this request for" — this package's `resolve(Request): ?Site` against a resolver chain, and bookings' `currentSiteId(): ?int` against a single configured FQCN. An application installing both configured tenancy twice, in shapes that could not share a source of truth, so a single request could resolve to site 2 for analytics while resolving to site 1 for bookings, silently.

## Changes Made

- `TenantManager` rewritten over `SiteContext`. `forSite()` / `withoutSite()` / `setCurrent()` / `forget()` / `flush()` all delegate, so a site pinned by any package is seen by all of them. It caches the loaded `Site` against the identifier it was loaded for, so the global scope no longer issues a `sites` lookup per query. Bound `scoped` rather than `singleton`, matching the context it wraps.
- `Contracts\SiteResolverInterface` now extends `ArtisanPackUI\Core\Contracts\SiteResolver`; `resolve()` and `priority()` are kept and deprecated. New `Resolvers\AbstractSiteResolver` implements `currentSiteId()` in terms of an existing `resolve(Request): ?Site`, so a third-party resolver migrates by changing one line. The four shipped resolvers extend it.
- `Contracts\TenantResolverInterface` kept and deprecated, documented as serving a different purpose: it describes a *tenant*, which is not always a site — it carries its own column name. It is consulted only by the `TenantResolver` middleware, and only when nothing has put a site in the shared context.
- `ResolveSite` and `TenantResolver` go through the shared context. `ResolveSite` pins the resolved site for the rest of the request, since resolvers are asked afresh on every call by design.
- `Traits\BelongsToSite` scopes on the shared context. Its undocumented `artisanpack.analytics.multi_site.resolver` fallback is gone — a second resolver reachable only from that trait could disagree with the one every other query used.
- **Config migration with a fallback.** `artisanpack.analytics.multi_tenant.enabled` and `.resolvers` are deprecated in favour of the `artisanpack.core.multi_tenant` keys, and both are still honoured: while the analytics flag is on, it switches the shared flag on and its resolver list is prepended to the shared one at boot, preserving resolution order. A notice is logged. Without this an upgrade would silently stop scoping analytics by site.
- **`multi_tenant.default_site_id` preserved**, with one deliberate narrowing: it no longer stands in for an explicitly requested "no site". `withoutSite()`, `allSites()` and `setCurrent(null)` mean no scoping, so a report meant to run across every site can no longer be quietly confined to one.
- Requires `artisanpack-ui/core` `^1.3`.

### Fixed along the way

- `analyticsSite()` and `analyticsTenantId()` called `TenantManager::currentSite()` and `currentTenantId()`, neither of which has ever existed — both helpers raised `BadMethodCallException` whenever multi-tenancy was enabled.
- Site-scoped queries in a request that never ran the `analytics.site` middleware were not scoped at all, because the global scope only applied once something had called `resolve()`. One site's dashboard could show another's rows.
- An identifier from another package that is not an analytics site ID (a slug, say) leaves analytics queries unscoped and logs once, rather than falling through to `default_site_id` and filing the work under the wrong site.
- A soft-deleted site can no longer come back as the current one.

### On the failure-handling question in the issue

Adopted core's behaviour deliberately: a resolver that throws aborts the chain rather than being skipped and logged. Skipping hands the next resolver's answer — or null — to a caller about to scope a query, which turns a configuration fault into cross-site exposure.

## How Has This Been Tested?

**Testing Environment:**
- Operating System: macOS 27.0
- PHP Version: 8.4 / 8.5
- Project Version: 1.5.0-dev (branched from `release/1.5`)

**Tests Performed:**
1. `composer test` — 661 passed, 2 skipped, 1546 assertions.
2. `composer lint` — php-cs-fixer and phpcs both clean.
3. Manual verification in the ArtisanPack UI dev app: single-tenant unchanged; the legacy `ANALYTICS_MULTI_TENANT` path still resolving by API key / `X-Site-ID` / domain with the deprecation notice logged; the migrated `artisanpack.core.multi_tenant` path scoping the dashboard, site selector and tracking; cross-package agreement with cms-framework's `HookSiteResolver` in the list.

## Accessibility Tests Run

- [x] Keyboard navigation tested
- [x] Screen reader tested
- [x] Color contrast verified
- [x] ARIA labels checked

**Details:** No user-facing markup changed — this is service, middleware and configuration wiring, so the existing dashboard and site-selector UI is untouched. Verified in the dev app that the site selector and dashboard still render and operate identically.

## Tests Added

- [x] Integration tests added/updated
- [x] All tests passing

**Test details:** New `tests/Feature/SharedSiteResolutionTest.php` (20 tests). The one the issue asks for is *"resolves the same site for analytics and a sibling package from one configuration"*: a `SiblingPackageSiteConsumer` that knows nothing about analytics and reads only `SiteContext`, asserted to agree with `TenantManager` from a single resolver list. Also covers pinning in both directions, `forSite()` / `withoutSite()` restoration, `flush()` for Octane, model scoping and `site_id` assignment, the `default_site_id` fallback and its limits (missing, inactive, soft-deleted, explicit no-site, non-analytics identifier), the legacy config bridge in all three states, and the `ResolveSite` middleware including its per-request pin.

## Documentation

- [x] Inline code documentation added
- [x] README updated
- [x] Wiki updated
- [x] API documentation updated

**Documentation details:** `docs/advanced/multi-tenancy.md` rewritten around the shared contract, with new sections on trust boundaries, per-request pinning, working across sites, and migrating a pre-1.5 resolver. `docs/api/contracts.md`, `docs/api/services.md`, `docs/api.md`, `docs/installation/configuration.md`, `docs/troubleshooting.md` and the README updated — several of those documented methods (`currentSite()`, `setSite()`, `resolveSite()`, `getPriority()`) never existed and now match the code. `CHANGELOG.md` has Changed / Fixed / Deprecated / Removed entries.

## Notes for review

Three things worth a deliberate look:

1. **Trust boundaries now travel.** The resolver list is ecosystem-wide, so `HeaderResolver` (believes any `X-Site-ID`) and `ApiKeyResolver` with `allow_query_api_key` decide the site for *every* package, not just analytics. Documented under "Trust boundaries", and the bridge carries a legacy list onto the shared one — worth confirming that is the intent for installs upgrading with `HeaderResolver` configured.
2. **`ApiKeyGuard`** can now authenticate an API request as `default_site_id` without `ResolveSite` having run, because `hasCurrent()` reflects the default fallback. Reachable before too when the middleware ran; slightly broader now. Say the word and I will narrow it.
3. **Out of scope, flagged:** `TrackingService::getTenantId()` still reads only the legacy `multi_tenant.resolver`, so a recorded row's `tenant_id` can come from a different source than the request's. Routing it through the shared context would change recorded data for existing installs, so I left it — happy to open a follow-up issue.

## Pre-Submission Checklist

- [x] Followed contributing guidelines
- [x] Checked for other open PRs for same update
- [x] Code passes all tests
- [x] Code has been linted
- [x] Accessibility tests completed
- [x] Code follows project style guide
- [x] Self-review completed
- [x] Comments added for complex code
- [x] No new warnings generated


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added shared site resolution across packages, including identifier-based site selection and consistent site context.
  - Added scoped site operations for commands, workers, and requests, with support for explicit no-site contexts.
  - Improved site and record scoping, default-site handling, and resolver ordering.

- **Bug Fixes**
  - Fixed invalid identifier handling, repeated site lookups, missing query scoping, and helper failures.

- **Documentation**
  - Updated configuration and migration guidance for shared multi-tenancy.
  - Documented deprecated analytics-specific settings and compatibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->